### PR TITLE
Removed single PR axioms referring to an obsolete GO:0043234

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -26494,10 +26494,6 @@ SubClassOf(<http://purl.obolibrary.org/obo/PATO_0002097> <http://purl.obolibrary
 
 SubClassOf(<http://purl.obolibrary.org/obo/PR_000002981> <http://purl.obolibrary.org/obo/PR_000000001>)
 
-# Class: <http://purl.obolibrary.org/obo/PR_000025402> (T cell receptor co-receptor CD8)
-
-SubClassOf(<http://purl.obolibrary.org/obo/PR_000025402> <http://purl.obolibrary.org/obo/GO_0043234>)
-
 
 EquivalentClasses(ObjectComplementOf(ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/GO_0005634>)) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000053> <http://purl.obolibrary.org/obo/PATO_0001405>))
 EquivalentClasses(ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> <http://purl.obolibrary.org/obo/GO_0005634>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000053> <http://purl.obolibrary.org/obo/PATO_0002505>))


### PR DESCRIPTION
In order for our QC to pass community wide, we need to remove references to obsolete entities in our ontologies. Ususally, we would replace occurrences with their recommended replacements; in this case how ever, the offending axiom does not all belong into cell ontology (it should be maintained by PR!).