### PR TITLE
Fix newline in Xref causing literal `\n` to be written in `cl.obo`

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -21086,7 +21086,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true"^^xsd:string) obo:CL_0005022 ob
 # Class: obo:CL_0005023 (branchiomotor neuron)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "ZFIN:CVS") obo:IAO_0000115 obo:CL_0005023 "Cranial motor neuron which innervates muscles derived from the branchial (pharyngeal) arches.")
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0005023 "PMID:14699587 ")
+AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0005023 "PMID:14699587")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0005023 "branchi  motor neuron ")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0005023 "special visceral motor neuron")
 AnnotationAssertion(rdfs:label obo:CL_0005023 "branchiomotor neuron"@en)
@@ -22021,10 +22021,8 @@ SubClassOf(obo:CL_0013000 obo:CL_0000681)
 
 # Class: obo:CL_0015000 (cranial motor neuron)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "ZFIN:CVS
-") obo:IAO_0000115 obo:CL_0015000 "Motor neuron that innervate muscles that control eye, jaw, and facial movements of the vertebrate head and parasympathetic neurons that innervate certain glands and organs. ")
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0015000 "PMID:14699587 
-")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "ZFIN:CVS") obo:IAO_0000115 obo:CL_0015000 "Motor neuron that innervate muscles that control eye, jaw, and facial movements of the vertebrate head and parasympathetic neurons that innervate certain glands and organs. ")
+AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0015000 "PMID:14699587 ")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0015000 "cranial motoneuron")
 AnnotationAssertion(rdfs:label obo:CL_0015000 "cranial motor neuron")
 SubClassOf(obo:CL_0015000 obo:CL_0000100)


### PR DESCRIPTION
Hi !

This PR removes the newline from the annotation of `CL:0015000` that was causing a literal `\n` to be present in line 24750 of `cl.obo`, and resulting in a syntax error.

Other than that, `cl.obo` is compatible with OBO format version 1.4 (with the exceptions of quoted property values that should be resolved when `robot` and `owlapi` are updated).

cc @cmungall 