### PR TITLE
change subclassOf assertion for 'germ line cell'

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -3005,7 +3005,7 @@ AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000039 "cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:inSubset obo:CL_0000039 <http://purl.obolibrary.org/obo/ubprop#_upper_level>)
 AnnotationAssertion(rdfs:comment obo:CL_0000039 "Originally this term had some plant germ line cell children."^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000039 "germ line cell"^^xsd:string)
-SubClassOf(obo:CL_0000039 obo:CL_0000548)
+SubClassOf(obo:CL_0000039 obo:CL_0000003)
 SubClassOf(obo:CL_0000039 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0022414))
 DisjointClasses(obo:CL_0000039 obo:CL_0002371)
 


### PR DESCRIPTION
Per #587
@cmungall asked to remove the linkage between GLC and animal cell. I changed the superclass for 'germ line cell' to 'native cell'.

Addresses #587