### PR TITLE
remove logical definition from CL_0000019 sperm

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -2787,7 +2787,6 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000019 "spermatozoid"^^xsd:
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000019 "spermatozoon"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000019 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000019 "sperm"^^xsd:string)
-EquivalentClasses(obo:CL_0000019 ObjectIntersectionOf(obo:CL_0000408 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0030317) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0048240)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true"^^xsd:string) obo:CL_0000019 obo:CL_0000408)
 SubClassOf(obo:CL_0000019 ObjectSomeValuesFrom(obo:BFO_0000051 obo:GO_0005929))
 SubClassOf(obo:CL_0000019 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000018))

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -1872,6 +1872,10 @@ Declaration(Class(obo:CL_0011009))
 Declaration(Class(obo:CL_0011010))
 Declaration(Class(obo:CL_0011011))
 Declaration(Class(obo:CL_0011012))
+Declaration(Class(obo:CL_0011013))
+Declaration(Class(obo:CL_0011014))
+Declaration(Class(obo:CL_0011015))
+Declaration(Class(obo:CL_0011016))
 Declaration(Class(obo:CL_0011100))
 Declaration(Class(obo:CL_0011101))
 Declaration(Class(obo:CL_0011102))
@@ -21858,6 +21862,36 @@ AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0011012 "cell")
 AnnotationAssertion(rdfs:label obo:CL_0011012 "neural crest cell")
 SubClassOf(obo:CL_0011012 obo:CL_0000048)
 SubClassOf(obo:CL_0011012 obo:CL_0002321)
+
+# Class: obo:CL_0011013 (motile sperm cell)
+
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30612620") obo:IAO_0000115 obo:CL_0011013 "A sperm cell that is cabaple of motion (motility).")
+AnnotationAssertion(oboInOwl:created_by obo:CL_0011013 <http://orcid.org/0000-0001-5208-3432>)
+AnnotationAssertion(rdfs:label obo:CL_0011013 "motile sperm cell")
+EquivalentClasses(obo:CL_0011013 ObjectIntersectionOf(obo:CL_0000019 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0097722)))
+SubClassOf(obo:CL_0011013 obo:CL_0000019)
+
+# Class: obo:CL_0011014 (non-motile sperm cell)
+
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30612620") obo:IAO_0000115 obo:CL_0011014 "A sperm cell that is not cabaple of motion (motility).")
+AnnotationAssertion(oboInOwl:created_by obo:CL_0011014 <http://orcid.org/0000-0001-5208-3432>)
+AnnotationAssertion(rdfs:label obo:CL_0011014 "non-motile sperm cell")
+SubClassOf(obo:CL_0011014 obo:CL_0000019)
+
+# Class: obo:CL_0011015 (amoeboid sperm cell)
+
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:17708982") obo:IAO_0000115 obo:CL_0011015 "A motile sperm cell that contain no F-actin, and their motility is powered by a dynamic filament system.")
+AnnotationAssertion(oboInOwl:created_by obo:CL_0011015 <http://orcid.org/0000-0001-5208-3432>)
+AnnotationAssertion(rdfs:label obo:CL_0011015 "amoeboid sperm cell")
+SubClassOf(obo:CL_0011015 obo:CL_0011013)
+
+# Class: obo:CL_0011016 (flagellated sperm cell)
+
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30612620") Annotation(oboInOwl:hasDbXref "https://www.lexico.com/en/definition/flagellum") obo:IAO_0000115 obo:CL_0011016 "A motile sperm cell that contains a slender threadlike microscopic appendage that enables motion.")
+AnnotationAssertion(oboInOwl:created_by obo:CL_0011016 <http://orcid.org/0000-0001-5208-3432>)
+AnnotationAssertion(rdfs:label obo:CL_0011016 "flagellated sperm cell")
+EquivalentClasses(obo:CL_0011016 ObjectIntersectionOf(obo:CL_0011013 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0030317)))
+SubClassOf(obo:CL_0011016 obo:CL_0011013)
 
 # Class: obo:CL_0011100 (galanergic neuron)
 


### PR DESCRIPTION
per the ticket:
we remove the logical definition from CL sperm cell

added new terms:
CL_0011013 motile sperm cell
CL_0011014 non-motile sperm cell
CL_0011015 amoeboid sperm cell
CL_0011016 flagellated sperm cell

Addresses #587

