### PR TITLE
WIP: adding new cell type pulmonary ionocyte

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -1898,6 +1898,7 @@ Declaration(Class(obo:CL_0012000))
 Declaration(Class(obo:CL_0012001))
 Declaration(Class(obo:CL_0013000))
 Declaration(Class(obo:CL_0015000))
+Declaration(Class(obo:CL_0017000))
 Declaration(Class(obo:CL_1000001))
 Declaration(Class(obo:CL_1000022))
 Declaration(Class(obo:CL_1000042))
@@ -2373,7 +2374,6 @@ Declaration(Class(obo:CP_0000039))
 Declaration(Class(obo:CP_0000040))
 Declaration(Class(obo:CP_0000043))
 Declaration(Class(obo:D96882F1-8709-49AB-BCA9-772A67EA6C33))
-Declaration(Class(<http://purl.obolibrary.org/obo/cl.owl#pulmonary_ionocyte>))
 Declaration(ObjectProperty(obo:RO_0001025))
 Declaration(ObjectProperty(obo:RO_0002102))
 Declaration(ObjectProperty(obo:RO_0002134))
@@ -22084,6 +22084,21 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0015000 "cranial motoneuron"
 AnnotationAssertion(rdfs:label obo:CL_0015000 "cranial motor neuron")
 SubClassOf(obo:CL_0015000 obo:CL_0000100)
 
+# Class: obo:CL_0017000 (pulmonary ionocyte)
+
+AnnotationAssertion(obo:IAO_0000115 obo:CL_0017000 "An ionocyte that is part of the lung epithelium. The cells from this type are major sources of the CFTR protein in human and mice. 
+
+References:
+
+1. Plasschaert, L.W., Žilionis, R., Choo-Wing, R. et al. A single-cell atlas of the airway epithelium reveals the CFTR-rich pulmonary ionocyte. Nature 560, 377–381 (2018).https://doi.org/10.1038/s41586-018-0394-6
+
+2. Montoro, D.T., Haber, A.L., Biton, M. et al. A revised airway epithelial hierarchy includes CFTR-expressing ionocytes. Nature 560, 319–324 (2018). https://doi.org/10.1038/s41586-018-0393-7")
+
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_0017000 <https://orcid.org/0000-0003-2473-2313>)
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> obo:CL_0017000 "cell")
+AnnotationAssertion(rdfs:label obo:CL_0017000 "pulmonary ionocyte")
+SubClassOf(obo:CL_0017000 obo:CL_0000082)
+
 # Class: obo:CL_1000001 (retrotrapezoid nucleus neuron)
 
 AnnotationAssertion(rdfs:label obo:CL_1000001 "retrotrapezoid nucleus neuron"^^xsd:string)
@@ -26605,10 +26620,6 @@ SubClassOf(obo:D96882F1-8709-49AB-BCA9-772A67EA6C33 obo:GO_0005634)
 
 AnnotationAssertion(rdfs:label obo:GO_0032634 "interleukin-5 production")
 SubClassOf(obo:GO_0032634 obo:GO_0001816)
-
-# Class: <http://purl.obolibrary.org/obo/cl.owl#pulmonary_ionocyte> (<http://purl.obolibrary.org/obo/cl.owl#pulmonary_ionocyte>)
-
-SubClassOf(<http://purl.obolibrary.org/obo/cl.owl#pulmonary_ionocyte> obo:CL_0000082)
 
 
 )

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -2373,6 +2373,7 @@ Declaration(Class(obo:CP_0000039))
 Declaration(Class(obo:CP_0000040))
 Declaration(Class(obo:CP_0000043))
 Declaration(Class(obo:D96882F1-8709-49AB-BCA9-772A67EA6C33))
+Declaration(Class(<http://purl.obolibrary.org/obo/cl.owl#pulmonary_ionocyte>))
 Declaration(ObjectProperty(obo:RO_0001025))
 Declaration(ObjectProperty(obo:RO_0002102))
 Declaration(ObjectProperty(obo:RO_0002134))
@@ -18906,7 +18907,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true"^^xsd:string) obo:CL_0002488 ob
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "MP:0002407"^^xsd:string) obo:IAO_0000115 obo:CL_0002489 "A thymocyte that lacks expression of CD4 and CD8."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:CL_0002489 "tmeehan"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002489 "2010-12-06T03:03:38Z"^^xsd:string)
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "MP:0002407") oboInOwl:hasExactSynonym obo:CL_0002489 "CD4-CD8- T cell")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "MP:0002407"^^xsd:string) oboInOwl:hasExactSynonym obo:CL_0002489 "CD4-CD8- T cell")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0002489 "double negative T cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0002489 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0002489 "These are precursors to mature T cells; normally, they do not circulate, but are found in the thymus and they have not undergone rearrangement of the alpha and beta T cell receptor genes.")
@@ -26604,6 +26605,10 @@ SubClassOf(obo:D96882F1-8709-49AB-BCA9-772A67EA6C33 obo:GO_0005634)
 
 AnnotationAssertion(rdfs:label obo:GO_0032634 "interleukin-5 production")
 SubClassOf(obo:GO_0032634 obo:GO_0001816)
+
+# Class: <http://purl.obolibrary.org/obo/cl.owl#pulmonary_ionocyte> (<http://purl.obolibrary.org/obo/cl.owl#pulmonary_ionocyte>)
+
+SubClassOf(<http://purl.obolibrary.org/obo/cl.owl#pulmonary_ionocyte> obo:CL_0000082)
 
 
 )

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -22086,8 +22086,7 @@ SubClassOf(obo:CL_0015000 obo:CL_0000100)
 
 # Class: obo:CL_0017000 (pulmonary ionocyte)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID: 30069046 
-PMID: 30069044") obo:IAO_0000115 obo:CL_0017000 "An ionocyte that is part of the lung epithelium. The cells from this type are major sources of the CFTR protein in human and mice.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30069044") Annotation(oboInOwl:hasDbXref "PMID:30069046") obo:IAO_0000115 obo:CL_0017000 "An ionocyte that is part of the lung epithelium. The cells from this type are major sources of the CFTR protein in human and mice.")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_0017000 <https://orcid.org/0000-0003-2473-2313>)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0017000 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0017000 "pulmonary ionocyte")

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -22086,18 +22086,13 @@ SubClassOf(obo:CL_0015000 obo:CL_0000100)
 
 # Class: obo:CL_0017000 (pulmonary ionocyte)
 
-AnnotationAssertion(obo:IAO_0000115 obo:CL_0017000 "An ionocyte that is part of the lung epithelium. The cells from this type are major sources of the CFTR protein in human and mice. 
-
-References:
-
-1. Plasschaert, L.W., Žilionis, R., Choo-Wing, R. et al. A single-cell atlas of the airway epithelium reveals the CFTR-rich pulmonary ionocyte. Nature 560, 377–381 (2018).https://doi.org/10.1038/s41586-018-0394-6
-
-2. Montoro, D.T., Haber, A.L., Biton, M. et al. A revised airway epithelial hierarchy includes CFTR-expressing ionocytes. Nature 560, 319–324 (2018). https://doi.org/10.1038/s41586-018-0393-7")
-
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID: 30069046 
+PMID: 30069044") obo:IAO_0000115 obo:CL_0017000 "An ionocyte that is part of the lung epithelium. The cells from this type are major sources of the CFTR protein in human and mice.")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_0017000 <https://orcid.org/0000-0003-2473-2313>)
-AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> obo:CL_0017000 "cell")
+AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0017000 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0017000 "pulmonary ionocyte")
 SubClassOf(obo:CL_0017000 obo:CL_0000082)
+SubClassOf(obo:CL_0017000 obo:CL_0005006)
 
 # Class: obo:CL_1000001 (retrotrapezoid nucleus neuron)
 


### PR DESCRIPTION
Hello, 

Adding new cell type as indicated by e-mail via Protege 55 (thanks @matentzn) after issue #613.

I don't know where the modification `+ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "MP:0002407"^^xsd:string) oboInOwl:hasExactSynonym obo:CL_0002489 "CD4-CD8- T cell")`
came from, though.

