### PR TITLE
Fixes certain logical errors #559

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -9913,7 +9913,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000787 "memory B-lymphocyte
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000787 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0000787 "Memory B-cells are also reportedly CD5-negative, CD10-negative, CD21-positive, CD22-positive, CD23-negative, CD24-positive, CD25-positive, CD27-positive, CD34-negative, CD38-negative, CD40-positive, CD43-negative, CD44-positive, CD45-positive, CD53-positive, CD80-negative, CD81-negative, CD86-positive, and CD196/CCR6-positive."^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000787 "memory B cell"^^xsd:string)
-EquivalentClasses(obo:CL_0000787 ObjectIntersectionOf(obo:CL_0000785 ObjectSomeValuesFrom(obo:RO_0002104 obo:GO_0042613) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001289) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001963) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0002344) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001935)))
+EquivalentClasses(obo:CL_0000787 ObjectIntersectionOf(obo:CL_0000785 ObjectSomeValuesFrom(obo:RO_0002104 obo:GO_0042613) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001289) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0002344) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001935)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true"^^xsd:string) obo:CL_0000787 obo:CL_0000785)
 
 # Class: obo:CL_0000788 (naive B cell)
@@ -10840,7 +10840,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000860 "inflammatory monocy
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000860 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0000860 "Markers: CCR2+CXCCR1<low> (human, mouse, rat)."^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000860 "classical monocyte"^^xsd:string)
-EquivalentClasses(obo:CL_0000860 ObjectIntersectionOf(obo:CL_0000576 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0002548) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0006909) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0006954) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount> obo:PR_000001199) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_low_plasma_membrane_amount> obo:PR_000001206) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001002) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001020) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001289)))
+EquivalentClasses(obo:CL_0000860 ObjectIntersectionOf(obo:CL_0000576 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0002548) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0006909) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0006954) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount> obo:PR_000001199) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001002) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001020) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001289)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true"^^xsd:string) obo:CL_0000860 obo:CL_0000576)
 
 # Class: obo:CL_0000861 (elicited macrophage)
@@ -10984,7 +10984,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000875 "resident monocyte"^
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000875 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0000875 "Markers: CCR2-CX3CCR1+ (human, mouse, rat); human: CD16+, CCR5+, CD32/FcgRII-high, MHCII+, CD86+; mouse: CD62L-Ly6C-."^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000875 "non-classical monocyte"^^xsd:string)
-EquivalentClasses(obo:CL_0000875 ObjectIntersectionOf(obo:CL_0000576 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0000587) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0031294) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0030224) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount> obo:PR_000001206) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001002) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001020) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001199) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001289)))
+EquivalentClasses(obo:CL_0000875 ObjectIntersectionOf(obo:CL_0000576 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0000587) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0031294) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0030224) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount> obo:PR_000001206) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001002) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001020) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001289)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true"^^xsd:string) obo:CL_0000875 obo:CL_0000576)
 SubClassOf(obo:CL_0000875 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0002393))
 
@@ -13659,7 +13659,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0002028 "BMCP"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0002028 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0002028 "There may be an intermediate cell type. These cells also CD13-positive, CD16-positive, CD32-positive, and integrin beta 7-positive. Transcription factors: GATA1-positive, MCP-1-positive, mitf-positive, PU.1-positive, and CEBP/a-low."^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0002028 "basophil mast progenitor cell"^^xsd:string)
-EquivalentClasses(obo:CL_0002028 ObjectIntersectionOf(obo:CL_0000839 ObjectSomeValuesFrom(obo:BFO_0000051 obo:PR_000005307) ObjectSomeValuesFrom(obo:BFO_0000051 obo:PR_000007857) ObjectSomeValuesFrom(obo:BFO_0000051 obo:PR_000007858) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001867) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000002065) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0030221) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0060374) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000007431) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000016401)))
+EquivalentClasses(obo:CL_0002028 ObjectIntersectionOf(obo:CL_0000839 ObjectSomeValuesFrom(obo:BFO_0000051 obo:PR_000005307) ObjectSomeValuesFrom(obo:BFO_0000051 obo:PR_000007857) ObjectSomeValuesFrom(obo:BFO_0000051 obo:PR_000007858) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001867) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0030221) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0060374) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000007431) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000016401)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true"^^xsd:string) obo:CL_0002028 obo:CL_0000839)
 SubClassOf(obo:CL_0002028 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000557))
 
@@ -18654,12 +18654,12 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true"^^xsd:string) obo:CL_0002457 ob
 
 # Class: obo:CL_0002458 (langerin-positive dermal dendritic cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "http://www.immgen.org/index_content.html"^^xsd:string) obo:IAO_0000115 obo:CL_0002458 "A dermal dendritic cell that is langerin-positive, CD103-positive, and CD11b-negative."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "http://www.immgen.org/index_content.html"^^xsd:string) obo:IAO_0000115 obo:CL_0002458 "A dermal dendritic cell that is langerin-positive and CD103-positive."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:CL_0002458 "tmeehan"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002458 "2010-11-22T04:06:22Z"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0002458 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0002458 "langerin-positive dermal dendritic cell"^^xsd:string)
-EquivalentClasses(obo:CL_0002458 ObjectIntersectionOf(obo:CL_0001006 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001010) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001012)))
+EquivalentClasses(obo:CL_0002458 ObjectIntersectionOf(obo:CL_0001006 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001010)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true"^^xsd:string) obo:CL_0002458 obo:CL_0001006)
 
 # Class: obo:CL_0002459 (langerin-negative dermal dendritic cell)
@@ -18844,7 +18844,7 @@ AnnotationAssertion(oboInOwl:created_by obo:CL_0002475 "tmeehan"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002475 "2010-11-23T04:09:09Z"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0002475 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0002475 "lymphoid MHC-II-negative non-classical monocyte"^^xsd:string)
-EquivalentClasses(obo:CL_0002475 ObjectIntersectionOf(obo:CL_0002469 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001013) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001813) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount> obo:PR_000001012)))
+EquivalentClasses(obo:CL_0002475 ObjectIntersectionOf(obo:CL_0002471 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001013) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001813) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount> obo:PR_000001012)))
 SubClassOf(obo:CL_0002475 obo:CL_0002471)
 
 # Class: obo:CL_0002476 (bone marrow macrophage)


### PR DESCRIPTION
Corrects certain contradictory logical assertions that EL does not normally spot having to do with the use of lacks_plasma_membrane_part per #559.