### PR TITLE
Tracheobronchial tree cells

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -1913,6 +1913,7 @@ Declaration(Class(obo:CL_0017000))
 Declaration(Class(obo:CL_0017001))
 Declaration(Class(obo:CL_0019001))
 Declaration(Class(obo:CL_0019002))
+Declaration(Class(obo:CL_0019003))
 Declaration(Class(obo:CL_1000001))
 Declaration(Class(obo:CL_1000022))
 Declaration(Class(obo:CL_1000042))
@@ -22268,6 +22269,15 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:CL_0019002 "2020-
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0019002 "chondrocyte of tracheobronchial tree")
 AnnotationAssertion(rdfs:label obo:CL_0019002 "tracheobronchial chondrocyte"@en)
 EquivalentClasses(obo:CL_0019002 ObjectIntersectionOf(obo:CL_0000138 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0007196)))
+
+# Class: obo:CL_0019003 (tracheobronchial goblet cell)
+
+AnnotationAssertion(obo:IAO_0000115 obo:CL_0019003 "Any goblet cell that is part of the tracheobronchial epithelium.")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_0019003 <http://orcid.org/0000-0003-2034-601X>)
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:CL_0019003 "2020-05-07T18:14:52Z"^^xsd:dateTime)
+AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0019003 "goblet cell of tracheobronchial tree")
+AnnotationAssertion(rdfs:label obo:CL_0019003 "tracheobronchial goblet cell"@en)
+EquivalentClasses(obo:CL_0019003 ObjectIntersectionOf(obo:CL_0000160 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0007196)))
 
 # Class: obo:CL_1000001 (retrotrapezoid nucleus neuron)
 

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -1911,6 +1911,7 @@ Declaration(Class(obo:CL_0013000))
 Declaration(Class(obo:CL_0015000))
 Declaration(Class(obo:CL_0017000))
 Declaration(Class(obo:CL_0017001))
+Declaration(Class(obo:CL_0019001))
 Declaration(Class(obo:CL_1000001))
 Declaration(Class(obo:CL_1000022))
 Declaration(Class(obo:CL_1000042))
@@ -22248,6 +22249,15 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_0017001 <ht
 AnnotationAssertion(rdfs:label obo:CL_0017001 "splanchnic mesodermal cell")
 SubClassOf(obo:CL_0017001 obo:CL_0011010)
 SubClassOf(obo:CL_0017001 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0004872))
+
+# Class: obo:CL_0019001 (tracheobronchial serous cell)
+
+AnnotationAssertion(obo:IAO_0000115 obo:CL_0019001 "Any serous secreting cell that is part of the tracheobronchial epithelium.")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_0019001 <http://orcid.org/0000-0003-2034-601X>)
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:CL_0019001 "2020-05-07T16:03:27Z"^^xsd:dateTime)
+AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0019001 "serous cell of tracheobronchial tree")
+AnnotationAssertion(rdfs:label obo:CL_0019001 "tracheobronchial serous cell"@en)
+EquivalentClasses(obo:CL_0019001 ObjectIntersectionOf(obo:CL_0000313 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0007196)))
 
 # Class: obo:CL_1000001 (retrotrapezoid nucleus neuron)
 

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -1912,6 +1912,7 @@ Declaration(Class(obo:CL_0015000))
 Declaration(Class(obo:CL_0017000))
 Declaration(Class(obo:CL_0017001))
 Declaration(Class(obo:CL_0019001))
+Declaration(Class(obo:CL_0019002))
 Declaration(Class(obo:CL_1000001))
 Declaration(Class(obo:CL_1000022))
 Declaration(Class(obo:CL_1000042))
@@ -22258,6 +22259,15 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:CL_0019001 "2020-
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0019001 "serous cell of tracheobronchial tree")
 AnnotationAssertion(rdfs:label obo:CL_0019001 "tracheobronchial serous cell"@en)
 EquivalentClasses(obo:CL_0019001 ObjectIntersectionOf(obo:CL_0000313 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0007196)))
+
+# Class: obo:CL_0019002 (tracheobronchial chondrocyte)
+
+AnnotationAssertion(obo:IAO_0000115 obo:CL_0019002 "Any chondrocyte that is part of the tracheobronchial tree.")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_0019002 <http://orcid.org/0000-0003-2034-601X>)
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> obo:CL_0019002 "2020-05-07T17:29:51Z"^^xsd:dateTime)
+AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0019002 "chondrocyte of tracheobronchial tree")
+AnnotationAssertion(rdfs:label obo:CL_0019002 "tracheobronchial chondrocyte"@en)
+EquivalentClasses(obo:CL_0019002 ObjectIntersectionOf(obo:CL_0000138 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0007196)))
 
 # Class: obo:CL_1000001 (retrotrapezoid nucleus neuron)
 

--- a/src/ontology/cl-idranges.owl
+++ b/src/ontology/cl-idranges.owl
@@ -84,6 +84,10 @@ Datatype: idrange:18
 Annotations: allocatedto: "Zoe Pendlington"
 EquivalentTo: xsd:integer[> 18000 , <= 18999]
 
+Datatype: idrange:19
+Annotations: allocatedto: "Maria Keays"
+EquivalentTo: xsd:integer[> 19000 , <= 19999]
+
 Datatype: idrange:20
 Annotations: allocatedto: "Chris Mungall, automatic generation"
 EquivalentTo: xsd:integer[> 1000000 , <= 1999999]


### PR DESCRIPTION
Have added the three terms we discussed for tracheobronchial tree cells: tracheobronchial serous cell, tracheobronchial chondrocyte, and tracheobronchial goblet cell.