### PR TITLE
Motor neuron classification cleanup

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -6512,7 +6512,6 @@ SubClassOf(obo:CL_0000420 obo:CL_0002371)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "ISBN:0721662544"^^xsd:string) obo:IAO_0000115 obo:CL_0000421 "A free floating cell, including amebocytes and eleocytes, in the coelom of certain animals, especially annelids."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000421 "BTO:0002856"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000421 "WBbt:0005751"^^xsd:string)
-AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000421 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000421 "coelomocyte"^^xsd:string)
 SubClassOf(obo:CL_0000421 obo:CL_0000080)
 SubClassOf(obo:CL_0000421 obo:CL_0000519)
@@ -9432,7 +9431,7 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:16267219"^^xsd:string) o
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000741 "SACMN"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000741 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000741 "spinal accessory motor neuron"^^xsd:string)
-SubClassOf(obo:CL_0000741 obo:CL_0000100)
+SubClassOf(obo:CL_0000741 obo:CL_0008039)
 
 # Class: obo:CL_0000742 (periarticular chondrocyte)
 
@@ -21230,16 +21229,14 @@ AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0005023 "PMID:14699587")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0005023 "branchi motor neuron")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0005023 "special visceral motor neuron")
 AnnotationAssertion(rdfs:label obo:CL_0005023 "branchiomotor neuron"@en)
-EquivalentClasses(obo:CL_0005023 ObjectIntersectionOf(obo:CL_0000100 ObjectSomeValuesFrom(obo:RO_0002130 obo:UBERON_0004164)))
-SubClassOf(obo:CL_0005023 obo:CL_0015000)
+EquivalentClasses(obo:CL_0005023 ObjectIntersectionOf(obo:CL_0015000 ObjectSomeValuesFrom(obo:RO_0002130 obo:UBERON_0004164)))
 
 # Class: obo:CL_0005024 (somatomotor neuron)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "ZFIN:CVS") obo:IAO_0000115 obo:CL_0005024 "A motor neuron that innervates a skeletal muscle.  These motor neurons are all excitatory and cholinergic.")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0005024 "somatic motor neuron"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0005024 "somatomotor neuron"@en)
-EquivalentClasses(obo:CL_0005024 ObjectIntersectionOf(obo:CL_0000100 ObjectSomeValuesFrom(obo:RO_0002130 obo:UBERON_0014892)))
-SubClassOf(obo:CL_0005024 obo:CL_0008014)
+EquivalentClasses(obo:CL_0005024 ObjectIntersectionOf(obo:CL_0000100 ObjectSomeValuesFrom(obo:RO_0002120 obo:CL_0008002)))
 SubClassOf(obo:CL_0005024 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0014055))
 
 # Class: obo:CL_0005025 (visceromotor neuron)
@@ -21574,7 +21571,7 @@ EquivalentClasses(obo:CL_0008009 ObjectIntersectionOf(obo:CL_0008007 ObjectInter
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:14699587") obo:IAO_0000115 obo:CL_0008010 "A cranial motor neuron whose soma is located in the midbrain andor hindbrain and which innervates the skeletal muscles of the eye or tongue."^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0008010 "cranial somatomotor neuron"^^xsd:string)
-EquivalentClasses(obo:CL_0008010 ObjectIntersectionOf(obo:CL_0015000 ObjectSomeValuesFrom(obo:RO_0002130 obo:UBERON_0014892)))
+EquivalentClasses(obo:CL_0008010 ObjectIntersectionOf(obo:CL_0015000 ObjectSomeValuesFrom(obo:RO_0002120 obo:CL_0008002)))
 
 # Class: obo:CL_0008011 (skeletal muscle satellite stem cell)
 
@@ -21595,20 +21592,21 @@ SubClassOf(obo:CL_0008012 obo:CL_0000594)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:14699587") obo:IAO_0000115 obo:CL_0008013 "A visceromotor motor neuron whose soma is located in the hindbrain, and which synapses to parasympathetic neurons that innervate tear glands, sweat glands, and the smooth muscles of the head.")
 AnnotationAssertion(rdfs:label obo:CL_0008013 "cranial visceromotor neuron"@en)
-SubClassOf(obo:CL_0008013 obo:CL_0005025)
+EquivalentClasses(obo:CL_0008013 ObjectIntersectionOf(obo:CL_0005025 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0002028)))
 SubClassOf(obo:CL_0008013 obo:CL_0015000)
-SubClassOf(obo:CL_0008013 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0002028))
 
-# Class: obo:CL_0008014 (excitatory motor neuron)
+# Class: obo:CL_0008014 (obsolete excitatory motor neuron)
 
 AnnotationAssertion(obo:IAO_0000115 obo:CL_0008014 "A motor neuron that is capable of directly inducing muscle contraction.")
 AnnotationAssertion(rdfs:comment obo:CL_0008014 "In vertebrates, all motor neurons are excitatory, but various types of inhibitory motor neurons exist in invertebrates.")
-AnnotationAssertion(rdfs:label obo:CL_0008014 "excitatory motor neuron"@en)
-SubClassOf(obo:CL_0008014 obo:CL_0000100)
+AnnotationAssertion(rdfs:comment obo:CL_0008014 "false"^^xsd:boolean)
+AnnotationAssertion(rdfs:label obo:CL_0008014 "obsolete excitatory motor neuron"@en)
+AnnotationAssertion(owl:deprecated obo:CL_0008014 "true"^^xsd:boolean)
 
 # Class: obo:CL_0008015 (inhibitory motor neuron)
 
 AnnotationAssertion(obo:IAO_0000115 obo:CL_0008015 "A motor neuron that is capable of directly inhibiting muscle contraction.")
+AnnotationAssertion(obo:RO_0002161 obo:CL_0008015 obo:NCBITaxon_7742)
 AnnotationAssertion(rdfs:comment obo:CL_0008015 "In vertebrates, all motor neurons are excitatory, but various types of inhibitory motor neurons exist in invertebrates.")
 AnnotationAssertion(rdfs:label obo:CL_0008015 "inhibitory motor neuron"@en)
 SubClassOf(obo:CL_0008015 obo:CL_0000100)


### PR DESCRIPTION
Obsoleted excitatory neuron - too confusing for vertebrate neurobiologists

Necessary and Sufficient def for somatic muscle cell and auto-population under it.

General cleanup.

New classification.

![image](https://user-images.githubusercontent.com/112839/94297669-c70fd880-ff5c-11ea-927d-d6cd5f7e7c6d.png)
