### PR TITLE
Add part_of brain to CL_0000598 (pyramidal neuron)

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -8169,6 +8169,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000598 "pyramidal neuron"^^
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000598 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000598 "pyramidal neuron"^^xsd:string)
 SubClassOf(obo:CL_0000598 obo:CL_0000117)
+SubClassOf(obo:CL_0000598 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0000955))
 
 # Class: obo:CL_0000599 (conidium)
 


### PR DESCRIPTION
This addresses issue  #435 

Currently the definition states: "Pyramidal neurons are found in the cerebral cortex, the hippocampus, and the amygdala." We think it's valid to add a part_of relationship to brain.