### PR TITLE
Fix typo in CL:0005026

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -3263,7 +3263,7 @@ SubClassOf(obo:CL_0000057 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000134))
 
 # Class: obo:CL_0000058 (chondroblast)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "GO_REF:0000034"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0618947256"^^xsd:string) obo:IAO_0000115 obo:CL_0000058 "Skeletogenic cell that is typically non-terminally differentiated, secretes an avascular, GAG rich matrix; is not buried in cartilage tissue matrix, retains the ability to divide, located adjacent to cartilage tissue (including within the perichondrium), and develops from prechondroblast (and thus prechondrogenic) cell."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "GO_REF:0000034") Annotation(oboInOwl:hasDbXref "ISBN:0618947256"^^xsd:string) obo:IAO_0000115 obo:CL_0000058 "Skeletogenic cell that is typically non-terminally differentiated, secretes an avascular, GAG rich matrix; is not buried in cartilage tissue matrix, retains the ability to divide, located adjacent to cartilage tissue (including within the perichondrium), and develops from prechondroblast (and thus prechondrogenic) cell."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000058 "BTO:0003607"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000058 "FMA:66783"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000058 "chrondoplast"^^xsd:string)
@@ -3276,7 +3276,7 @@ SubClassOf(obo:CL_0000058 ObjectSomeValuesFrom(obo:RO_0003000 obo:UBERON_0002418
 
 # Class: obo:CL_0000059 (ameloblast)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "GO_REF:0000034"^^xsd:string) Annotation(oboInOwl:hasDbXref "MESH:A11.436.107"^^xsd:string) obo:IAO_0000115 obo:CL_0000059 "Skeletogenic cell that produces enamel, overlies the odontogenic papilla, and arises from the differentiation of a preameloblast cell."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "GO_REF:0000034") Annotation(oboInOwl:hasDbXref "MESH:A11.436.107"^^xsd:string) obo:IAO_0000115 obo:CL_0000059 "Skeletogenic cell that produces enamel, overlies the odontogenic papilla, and arises from the differentiation of a preameloblast cell."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasAlternativeId obo:CL_0000059 "CL:0000053"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasAlternativeId obo:CL_0000059 "CL:0000139"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000059 "BTO:0001663"^^xsd:string)
@@ -3296,7 +3296,7 @@ SubClassOf(obo:CL_0000059 ObjectSomeValuesFrom(obo:RO_0003000 obo:UBERON_0001752
 
 # Class: obo:CL_0000060 (odontoblast)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0618947256"^^xsd:string) obo:IAO_0000115 obo:CL_0000060 "Skeletogenic cell that secretes dentine matrix, is derived from the odontogenic papilla, and develops from a preodontoblast cell."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034") Annotation(oboInOwl:hasDbXref "ISBN:0618947256"^^xsd:string) obo:IAO_0000115 obo:CL_0000060 "Skeletogenic cell that secretes dentine matrix, is derived from the odontogenic papilla, and develops from a preodontoblast cell."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000060 "BTO:0001769"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000060 "CALOHA:TS-0696"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000060 "FMA:62999"^^xsd:string)
@@ -3311,7 +3311,7 @@ SubClassOf(obo:CL_0000060 ObjectSomeValuesFrom(obo:RO_0003000 obo:UBERON_0001751
 
 # Class: obo:CL_0000061 (cementoblast)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781733901"^^xsd:string) obo:IAO_0000115 obo:CL_0000061 "Skeletogenic cell that produces cementum (a bony substance that covers the root of a tooth), is part of the odontogenic papilla, and develops from a precementoblast cell."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034") Annotation(oboInOwl:hasDbXref "ISBN:0781733901"^^xsd:string) obo:IAO_0000115 obo:CL_0000061 "Skeletogenic cell that produces cementum (a bony substance that covers the root of a tooth), is part of the odontogenic papilla, and develops from a precementoblast cell."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasAlternativeId obo:CL_0000061 "CL:0000859"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000061 "CALOHA:TS-1164"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000061 "FMA:63002"^^xsd:string)
@@ -3327,7 +3327,7 @@ SubClassOf(obo:CL_0000061 ObjectSomeValuesFrom(obo:RO_0003000 obo:UBERON_0001753
 
 # Class: obo:CL_0000062 (osteoblast)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034"^^xsd:string) Annotation(oboInOwl:hasDbXref "MESH:A11.329.629"^^xsd:string) obo:IAO_0000115 obo:CL_0000062 "Skeletogenic cell that secretes osteoid, is capable of producing mineralized (hydroxyapatite) matrix, is located adjacent to or within osteoid tissue, and arises from the transformation of a preosteoblast cell."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034") Annotation(oboInOwl:hasDbXref "MESH:A11.329.629"^^xsd:string) obo:IAO_0000115 obo:CL_0000062 "Skeletogenic cell that secretes osteoid, is capable of producing mineralized (hydroxyapatite) matrix, is located adjacent to or within osteoid tissue, and arises from the transformation of a preosteoblast cell."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000062 "BTO:0001593"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000062 "CALOHA:TS-0720"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000062 "FMA:66780"^^xsd:string)
@@ -4117,7 +4117,7 @@ SubClassOf(obo:CL_0000137 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0001040))
 
 # Class: obo:CL_0000138 (chondrocyte)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034"^^xsd:string) Annotation(oboInOwl:hasDbXref "MESH:A11.329.171"^^xsd:string) obo:IAO_0000115 obo:CL_0000138 "Skeletogenic cell that is terminally differentiated, secretes an avascular, GAG-rich matrix, is embedded in cartilage tissue matrix, retains the ability to divide, and develops from a chondroblast cell."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034") Annotation(oboInOwl:hasDbXref "MESH:A11.329.171"^^xsd:string) obo:IAO_0000115 obo:CL_0000138 "Skeletogenic cell that is terminally differentiated, secretes an avascular, GAG-rich matrix, is embedded in cartilage tissue matrix, retains the ability to divide, and develops from a chondroblast cell."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000138 "BTO:0000249"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000138 "CALOHA:TS-0138"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000138 "FMA:66782"^^xsd:string)
@@ -4132,7 +4132,7 @@ SubClassOf(obo:CL_0000138 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000058))
 
 # Class: obo:CL_0000140 (odontocyte)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034"^^xsd:string) obo:IAO_0000115 obo:CL_0000140 "Skeletogenic cell that secretes dentine matrix, is derived from odontogenic papilla. Embedded in dentine tissue, and is the transformation of a non-terminally differentiated odontoblast cell."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034") obo:IAO_0000115 obo:CL_0000140 "Skeletogenic cell that secretes dentine matrix, is derived from odontogenic papilla. Embedded in dentine tissue, and is the transformation of a non-terminally differentiated odontoblast cell."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000140 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000140 "odontocyte"^^xsd:string)
 SubClassOf(obo:CL_0000140 obo:CL_0002320)
@@ -9448,7 +9448,7 @@ SubClassOf(obo:CL_0000742 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_001099
 
 # Class: obo:CL_0000743 (hypertrophic chondrocyte)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:15951842"^^xsd:string) obo:IAO_0000115 obo:CL_0000743 "Chondrocyte that is terminally differentiated, produces type X collagen, is large in size, and often associated with the replacement of cartilage by bone (endochondral ossification)."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034") Annotation(oboInOwl:hasDbXref "PMID:15951842"^^xsd:string) obo:IAO_0000115 obo:CL_0000743 "Chondrocyte that is terminally differentiated, produces type X collagen, is large in size, and often associated with the replacement of cartilage by bone (endochondral ossification)."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000743 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0000743 "is hypertrophic pathological or normal? and can it be described using a pato term?"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000743 "hypertrophic chondrocyte"^^xsd:string)
@@ -12868,7 +12868,7 @@ SubClassOf(obo:CL_0001034 obo:CL_0000000)
 
 # Class: obo:CL_0001035 (bone cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000034"^^xsd:string) obo:IAO_0000115 obo:CL_0001035 "A connective tissue cell found in bone."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000034") obo:IAO_0000115 obo:CL_0001035 "A connective tissue cell found in bone."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:CL_0001035 "adiehl"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0001035 "2011-11-16T04:28:16Z"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0001035 "cell"^^xsd:string)
@@ -19042,7 +19042,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true"^^xsd:string) obo:CL_0002485 ob
 
 # Class: obo:CL_0002486 (strial intermediate cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "MP:0000048"^^xsd:string) obo:IAO_0000115 obo:CL_0002486 "A melanocyte located between the epithelial marginal cell layer and the mesodermal basal cell layer within the intrastrial space; the predominant cellular component of the electrogenic machinery that generates an endocochlear potential (80-100 mV) ."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "MP:0000048") obo:IAO_0000115 obo:CL_0002486 "A melanocyte located between the epithelial marginal cell layer and the mesodermal basal cell layer within the intrastrial space; the predominant cellular component of the electrogenic machinery that generates an endocochlear potential (80-100 mV) ."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:CL_0002486 "tmeehan"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002486 "2010-12-03T03:29:15Z"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0002486 "cell"^^xsd:string)
@@ -21298,13 +21298,13 @@ SubClassOf(obo:CL_0005025 ObjectSomeValuesFrom(obo:RO_0002120 obo:CL_0011102))
 
 # Class: obo:CL_0005026 (hepatoblast)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:CVS") Annotation(oboInOwl:hasDbXref "PMID:18356246") Annotation(oboInOwl:hasDbXref "PMID:20483998") obo:IAO_0000115 obo:CL_0005026 "Multi fate stem cell that gives rise to to both hepatocytes and cholangiocytes as descendants.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:CVS") Annotation(oboInOwl:hasDbXref "PMID:18356246") Annotation(oboInOwl:hasDbXref "PMID:20483998") obo:IAO_0000115 obo:CL_0005026 "Multi fate stem cell that gives rise to both hepatocytes and cholangiocytes as descendants.")
 AnnotationAssertion(rdfs:label obo:CL_0005026 "hepatoblast"@en)
 SubClassOf(obo:CL_0005026 obo:CL_0000048)
 
 # Class: obo:CL_0007000 (preameloblast)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMCID:PMC2737325"^^xsd:string) obo:IAO_0000115 obo:CL_0007000 "Skeletogenic cell that has the potential to develop into an ameloblast. Located in the inner enamel epithelium, these cells elongate, their nuclei shift distally (away from the dental papilla), and their cytoplasm becomes filled with organelles needed for synthesis and secretion of enamel proteins."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034") Annotation(oboInOwl:hasDbXref "PMCID:PMC2737325"^^xsd:string) obo:IAO_0000115 obo:CL_0007000 "Skeletogenic cell that has the potential to develop into an ameloblast. Located in the inner enamel epithelium, these cells elongate, their nuclei shift distally (away from the dental papilla), and their cytoplasm becomes filled with organelles needed for synthesis and secretion of enamel proteins."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:CL_0007000 "haendel"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0007000 "2012-06-15T01:27:01Z"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0007000 "cell"^^xsd:string)
@@ -21317,10 +21317,10 @@ SubClassOf(obo:CL_0007000 ObjectSomeValuesFrom(obo:RO_0002220 obo:UBERON_0001763
 
 # Class: obo:CL_0007001 (skeletogenic cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034"^^xsd:string) obo:IAO_0000115 obo:CL_0007001 "Cell that has the potential to form a skeletal cell type (e.g. cells in periosteum, cells in marrow) and produce extracellular matrix (often mineralized) and skeletal tissue (often mineralized)."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034") obo:IAO_0000115 obo:CL_0007001 "Cell that has the potential to form a skeletal cell type (e.g. cells in periosteum, cells in marrow) and produce extracellular matrix (often mineralized) and skeletal tissue (often mineralized)."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:CL_0007001 "haendel"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0007001 "2012-06-15T02:51:27Z"^^xsd:string)
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034"^^xsd:string) oboInOwl:hasExactSynonym obo:CL_0007001 "scleroblast"^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034") oboInOwl:hasExactSynonym obo:CL_0007001 "scleroblast"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0007001 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0007001 "Needs logical definition. Should be capable_of skeletal system morphogenesis? or skeletal tissue development? needs to be added to GO. NOTES:a cell type of the early embryo (see also: mesenchymal cells) that will give rise to mineralized connective tissue. Scleroblasts can differentiate into osteoblasts (bone-forming cells), chondroblasts (cartilage-forming cells), odontoblasts (dentin-forming cells), ameloblasts (enamel-forming cells). The mesenchymal cells developing into osteoblasts and chondroblasts are derived from the mesoderm. Those developing into odontoblasts are neural crest cells. Those developing into ameloblasts are derived from the ectoderm. (http://www.copewithcytokines.de/cope.cgi?key=scleroblasts)"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0007001 "skeletogenic cell"^^xsd:string)
@@ -21328,7 +21328,7 @@ SubClassOf(obo:CL_0007001 obo:CL_0000003)
 
 # Class: obo:CL_0007002 (precementoblast)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034"^^xsd:string) obo:IAO_0000115 obo:CL_0007002 "Skeletogenic cell that has the potential to develop into a cementoblast."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034") obo:IAO_0000115 obo:CL_0007002 "Skeletogenic cell that has the potential to develop into a cementoblast."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:CL_0007002 "haendel"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0007002 "2012-06-15T04:37:13Z"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0007002 "cell"^^xsd:string)
@@ -21338,7 +21338,7 @@ SubClassOf(obo:CL_0007002 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_000517
 
 # Class: obo:CL_0007003 (preodontoblast)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034"^^xsd:string) obo:IAO_0000115 obo:CL_0007003 "Skeletogenic cell that has the potential to form an odontoblast, deposits predentine, and arises from a cranial neural crest cell."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034") obo:IAO_0000115 obo:CL_0007003 "Skeletogenic cell that has the potential to form an odontoblast, deposits predentine, and arises from a cranial neural crest cell."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:CL_0007003 "haendel"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0007003 "2012-06-15T05:15:11Z"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0007003 "cell"^^xsd:string)
@@ -21360,7 +21360,7 @@ SubClassOf(obo:CL_0007004 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000133))
 
 # Class: obo:CL_0007005 (notochordal cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034"^^xsd:string) obo:IAO_0000115 obo:CL_0007005 "Cell that is part of the notochord."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034") obo:IAO_0000115 obo:CL_0007005 "Cell that is part of the notochord."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:CL_0007005 "haendel"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0007005 "2012-06-27T08:47:31Z"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0007005 "cell"^^xsd:string)
@@ -21372,7 +21372,7 @@ SubClassOf(obo:CL_0007005 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0007006))
 
 # Class: obo:CL_0007006 (chordamesodermal cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034"^^xsd:string) obo:IAO_0000115 obo:CL_0007006 "Mesodermal cell that is axially located and gives rise to the cells of the notochord."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034") obo:IAO_0000115 obo:CL_0007006 "Mesodermal cell that is axially located and gives rise to the cells of the notochord."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:CL_0007006 "haendel"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0007006 "2012-06-27T08:52:41Z"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0007006 "axial mesodermal cell")
@@ -21395,7 +21395,7 @@ SubClassOf(obo:CL_0007007 obo:CL_0007005)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "CL:MAH"^^xsd:string) obo:IAO_0000115 obo:CL_0007008 "Notochordal cell that is inner portion of the notochord and becomes vacuolated as development proceeds."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:CL_0007008 "haendel"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0007008 "2012-06-27T09:29:30Z"^^xsd:string)
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034"^^xsd:string) oboInOwl:hasExactSynonym obo:CL_0007008 "chordablast"^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034") oboInOwl:hasExactSynonym obo:CL_0007008 "chordablast"^^xsd:string)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:14574572"^^xsd:string) oboInOwl:hasExactSynonym obo:CL_0007008 "chordoblast"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0007008 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0007008 "notochordal vacuole cell"^^xsd:string)
@@ -21403,7 +21403,7 @@ SubClassOf(obo:CL_0007008 obo:CL_0007005)
 
 # Class: obo:CL_0007009 (prechondroblast)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034"^^xsd:string) obo:IAO_0000115 obo:CL_0007009 "Skeletogenic cell that has the potential to develop into a chondroblast; and arises from neural crest, meseosdermal and notochordal and connective tissue cells."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034") obo:IAO_0000115 obo:CL_0007009 "Skeletogenic cell that has the potential to develop into a chondroblast; and arises from neural crest, meseosdermal and notochordal and connective tissue cells."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:CL_0007009 "haendel"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0007009 "2012-06-27T10:44:01Z"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0007009 "cell"^^xsd:string)
@@ -21412,7 +21412,7 @@ SubClassOf(obo:CL_0007009 obo:CL_0000055)
 
 # Class: obo:CL_0007010 (preosteoblast)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034"^^xsd:string) obo:IAO_0000115 obo:CL_0007010 "Skeletogenic cell that has the potential to transform into an osteoblast, and develops from neural crest or mesodermal cells."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034") obo:IAO_0000115 obo:CL_0007010 "Skeletogenic cell that has the potential to transform into an osteoblast, and develops from neural crest or mesodermal cells."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:CL_0007010 "haendel"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0007010 "2012-06-27T10:57:21Z"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0007010 "osteoprogenitor cell"^^xsd:string)
@@ -21437,14 +21437,14 @@ SubClassOf(obo:CL_0007011 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0002607))
 
 # Class: obo:CL_0007012 (non-terminally differentiated odontoblast)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034"^^xsd:string) Annotation(oboInOwl:hasDbXref "PSPUB:0000170"^^xsd:string) obo:IAO_0000115 obo:CL_0007012 "Odontoblast that non-terminally differentiated, located in the odontogenic papilla and dentine tissue, and transforms from a odontoblast cell."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034") Annotation(oboInOwl:hasDbXref "PSPUB:0000170"^^xsd:string) obo:IAO_0000115 obo:CL_0007012 "Odontoblast that non-terminally differentiated, located in the odontogenic papilla and dentine tissue, and transforms from a odontoblast cell."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0007012 "cl"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0007012 "non-terminally differentiated odontoblast"^^xsd:string)
 SubClassOf(obo:CL_0007012 obo:CL_0000060)
 
 # Class: obo:CL_0007013 (terminally differentiated odontoblast)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034"^^xsd:string) obo:IAO_0000115 obo:CL_0007013 "Odontoblast that is terminally differentiated and derived from an odontogenic papilla and associated with dentine."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO_REF:0000034") obo:IAO_0000115 obo:CL_0007013 "Odontoblast that is terminally differentiated and derived from an odontogenic papilla and associated with dentine."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0007013 "cl"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0007013 "terminally differentiated odontoblast"^^xsd:string)
 SubClassOf(obo:CL_0007013 obo:CL_0000060)


### PR DESCRIPTION
Fix typo in def of CL:0005026 'hepatoblast' by removing extra "to".
Fixes #776