### PR TITLE
Bug fix: current release has inferred equivalencies (added check)

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -57,7 +57,7 @@ RELEASE_ARTEFACTS = $(sort  base full simple basic non-classified base full)
 .PHONY: .FORCE
 all: odkversion all_imports patterns all_main all_subsets sparql_test all_reports all_assets
 test: odkversion sparql_test all_reports
-	$(ROBOT) reason --input $(SRC) --reasoner ELK  --equivalent-classes-allowed all --exclude-tautologies structural --output test.owl && rm test.owl && echo "Success"
+	$(ROBOT) reason --input $(SRC) --reasoner ELK  --equivalent-classes-allowed asserted-only --exclude-tautologies structural --output test.owl && rm test.owl && echo "Success"
 
 odkversion:
 	echo "ODK Makefile version: $(ODK_VERSION_MAKEFILE) (this is the version of the ODK with which this Makefile was generated, not the version of the ODK you are running)" &&\
@@ -217,7 +217,7 @@ $(ONT)-base.owl: $(SRC) $(OTHER_SRC)
 # Full: The full artefacts with imports merged, reasoned
 $(ONT)-full.owl: $(SRC) $(OTHER_SRC)
 	$(ROBOT) merge --input $< \
-		reason --reasoner ELK --equivalent-classes-allowed all --exclude-tautologies structural \
+		reason --reasoner ELK --equivalent-classes-allowed asserted-only --exclude-tautologies structural \
 		relax \
 		reduce -r ELK \
 		annotate --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) --output $@.tmp.owl && mv $@.tmp.owl $@
@@ -232,7 +232,7 @@ $(ONT)-non-classified.owl: $(SRC) $(OTHER_SRC)
 
 $(ONT)-simple.owl: $(SRC) $(OTHER_SRC) $(SIMPLESEED)
 	$(ROBOT) merge --input $< $(patsubst %, -i %, $(OTHER_SRC)) \
-		reason --reasoner ELK --equivalent-classes-allowed all --exclude-tautologies structural \
+		reason --reasoner ELK --equivalent-classes-allowed asserted-only --exclude-tautologies structural \
 		relax \
 		remove --axioms equivalent \
 		relax \
@@ -245,7 +245,7 @@ $(ONT)-simple.owl: $(SRC) $(OTHER_SRC) $(SIMPLESEED)
 
 $(ONT)-basic.owl: $(SRC) $(OTHER_SRC) $(SIMPLESEED) $(KEEPRELATIONS)
 	$(ROBOT) merge --input $< $(patsubst %, -i %, $(OTHER_SRC)) \
-		reason --reasoner ELK --equivalent-classes-allowed all --exclude-tautologies structural \
+		reason --reasoner ELK --equivalent-classes-allowed asserted-only --exclude-tautologies structural \
 		relax \
 		remove --axioms equivalent \
 		remove --axioms disjoint \

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -22100,7 +22100,7 @@ AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0009017 "crypt stem cell of 
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0009017 "https://orcid.org/0000-0003-4183-8865")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0009017 "stem cell of small intestine crypt of Lieberkuhn")
 AnnotationAssertion(rdfs:label obo:CL_0009017 "intestinal crypt stem cell of small intestine")
-EquivalentClasses(obo:CL_0009017 ObjectIntersectionOf(obo:CL_0002250 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0001984)))
+EquivalentClasses(obo:CL_0009017 ObjectIntersectionOf(obo:CL_0002250 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0001241)))
 
 # Class: obo:CL_0009018 (lymphocyte of large intestine lamina propria)
 

--- a/src/ontology/cl-odk.yaml
+++ b/src/ontology/cl-odk.yaml
@@ -35,4 +35,4 @@ pattern_pipelines_group:
     - id: clustering
       dosdp_tools_options: "--obo-prefixes=true"
 robot_java_args: '-Xmx8G'
-
+allow_equivalents: asserted-only


### PR DESCRIPTION
- we were missing a check for inferred equivalent classes, which broke the MP test build:
- I fixed the mistake in the definition (wrong Uberon class used) <http://purl.obolibrary.org/obo/CL_0009016> == <http://purl.obolibrary.org/obo/CL_0009017>
- I added the check to the build