### PR TITLE
Fix several untyped `ILX` cross-references causing syntax errors in OBO release

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -27388,7 +27388,7 @@ SubClassOf(obo:CL_4023010 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_Q9D387))
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30382198") obo:IAO_0000115 obo:CL_4023011 "A GABAergic neuron located in the cerebral cortex that expresses Lamp5")
 AnnotationAssertion(oboInOwl:created_by obo:CL_4023011 <http://orcid.org/0000-0001-7258-9596>)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023011 "ILX:0770149")
+AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023011 "ILX:0770149"^^xsd:string)
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023011 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(rdfs:label obo:CL_4023011 "Lamp5 GABAergic cortical interneuron")
 EquivalentClasses(obo:CL_4023011 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000956) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534) ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000032148)))
@@ -27397,7 +27397,7 @@ EquivalentClasses(obo:CL_4023011 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeV
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:33186530") obo:IAO_0000115 obo:CL_4023015 "A GABAergic neuron located in the cerebral cortex that expresses Gamma-synuclein")
 AnnotationAssertion(oboInOwl:created_by obo:CL_4023015 <http://orcid.org/0000-0001-7258-9596>)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023015 "ILX:0770150")
+AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023015 "ILX:0770150"^^xsd:string)
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023015 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(rdfs:label obo:CL_4023015 "sncg GABAergic cortical interneuron")
 EquivalentClasses(obo:CL_4023015 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000956) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534) ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000015325)))
@@ -27406,7 +27406,7 @@ EquivalentClasses(obo:CL_4023015 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeV
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:33186530") obo:IAO_0000115 obo:CL_4023016 "A GABAergic neuron located in the cerebral cortex that expresses vasoactive intestinal polypeptide")
 AnnotationAssertion(oboInOwl:created_by obo:CL_4023016 <http://orcid.org/0000-0001-7258-9596>)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023016 "ILX:0770151")
+AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023016 "ILX:0770151"^^xsd:string)
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023016 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(rdfs:label obo:CL_4023016 "Vip GABAergic cortical interneuron")
 EquivalentClasses(obo:CL_4023016 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000956) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534) ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000017299)))
@@ -27415,7 +27415,7 @@ EquivalentClasses(obo:CL_4023016 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeV
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:27477017") obo:IAO_0000115 obo:CL_4023017 "A GABAergic neuron located in the cerebral cortex that expresses somatostatin (sst)")
 AnnotationAssertion(oboInOwl:created_by obo:CL_4023017 <http://orcid.org/0000-0001-7258-9596>)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023017 "ILX:0770152")
+AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023017 "ILX:0770152"^^xsd:string)
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023017 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(rdfs:label obo:CL_4023017 "sst GABAergic cortical interneuron")
 EquivalentClasses(obo:CL_4023017 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000956) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534) ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000015665)))
@@ -27424,7 +27424,7 @@ EquivalentClasses(obo:CL_4023017 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeV
 
 AnnotationAssertion(Annotation(obo:IAO_0000115 "PMID:27477017") obo:IAO_0000115 obo:CL_4023018 "A GABAergic interneuron located in the cerebral cortex that expresses Parvalbumin.")
 AnnotationAssertion(oboInOwl:created_by obo:CL_4023018 <http://orcid.org/0000-0001-7258-9596>)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023018 "ILX:0770154")
+AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023018 "ILX:0770154"^^xsd:string)
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023018 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(rdfs:label obo:CL_4023018 "pvalb GABAergic cortical interneuron")
 EquivalentClasses(obo:CL_4023018 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000956) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534) ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000013502)))
@@ -27528,7 +27528,7 @@ SubClassOf(obo:CL_4023034 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_P60041))
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:27477017") obo:IAO_0000115 obo:CL_4023036 "A Pvalb GABAergic cortical interneuron that is recognizable by the straight terminal axonal 'cartridges' of vertically oriented strings of synaptic boutons. Chandelier PV cells are mostly found in upper L2/3, with some in deep L5. Chandelier PV cells exhibit fast-spiking but lower firing rate compared to basket cells, and have practically absent hyperpolarization sag. Chandelier PV cells' boutons target exclusively the axon initial segment (AIS) of pyramidal cells, with a single cell innervating hundreds of pyramidal cells in a clustered manner.")
 AnnotationAssertion(oboInOwl:created_by obo:CL_4023036 <http://orcid.org/0000-0001-7258-9596>)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023036 "ILX:0107356")
+AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023036 "ILX:0107356"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4023036 "Chandelier PV (Mus)")
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023036 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(rdfs:label obo:CL_4023036 "Chandelier Pvalb GABAergic cortical interneuron (Mus musculus)")


### PR DESCRIPTION
Hi !

The last release of CL contains some issues regarding cross-references, which affect the final OBO product, as reported in althonos/pronto#123 and in fastobo/fastobo-py#202 : some untyped ILX cross-references end up producing the following clauses:
```ini
[Term]
id: CL:4023018
name: pvalb GABAergic cortical interneuron
def: "A GABAergic interneuron located in the cerebral cortex that expresses Parvalbumin." [] {def="PMID:27477017"}
xref: xref:(ILX\:0770154) 
```
or 
```ini
[Term]
id: CL:4023011
name: Lamp5 GABAergic cortical interneuron
def: "A GABAergic neuron located in the cerebral cortex that expresses Lamp5" [PMID:30382198]
xref: xref (ILX:0770149)
```

This PR should address these issues by marking these identifiers as `xsd:string` in the CL edit version.