### PR TITLE
Removing wrong labels for pvalb, snc, sst, vip, lamp5

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -2469,11 +2469,8 @@ Declaration(Class(obo:CL_4023030))
 Declaration(Class(obo:CL_4023031))
 Declaration(Class(obo:CL_4023034))
 Declaration(Class(obo:CL_4023036))
-
 Declaration(Class(obo:CL_4023041))
-
 Declaration(Class(obo:CL_4023042))
-
 Declaration(Class(obo:CP_0000000))
 Declaration(Class(obo:CP_0000025))
 Declaration(Class(obo:CP_0000027))
@@ -6142,7 +6139,7 @@ SubClassOf(obo:CL_0000357 obo:CL_0000036)
 
 # Class: obo:CL_0000358 (sphincter associated smooth muscle cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:cjm") obo:IAO_0000115 obo:CL_0000358 "A smooth muscle cell that is part of a sphincter. A sphincter is a typically circular muscle that normally maintains constriction of a natural body passage or orifice and which relaxes as required by normal physiological functioning."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:cjm"^^xsd:string) obo:IAO_0000115 obo:CL_0000358 "A smooth muscle cell that is part of a sphincter. A sphincter is a typically circular muscle that normally maintains constriction of a natural body passage or orifice and which relaxes as required by normal physiological functioning."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000358 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000358 "sphincter associated smooth muscle cell"^^xsd:string)
 EquivalentClasses(obo:CL_0000358 ObjectIntersectionOf(obo:CL_0000192 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0004590)))
@@ -15190,7 +15187,7 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") obo:IAO_0000115 obo
 AnnotationAssertion(oboInOwl:created_by obo:CL_0002132 "tmeehan"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002132 "2010-08-23T12:10:31Z"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0002132 "FMA:72299"^^xsd:string)
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:cjm") oboInOwl:hasExactSynonym obo:CL_0002132 "ovarian stromal cell"^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:cjm"^^xsd:string) oboInOwl:hasExactSynonym obo:CL_0002132 "ovarian stromal cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0002132 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0002132 "stromal cell of ovary"^^xsd:string)
 EquivalentClasses(obo:CL_0002132 ObjectIntersectionOf(obo:CL_0000499 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0000992)))
@@ -19111,7 +19108,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true"^^xsd:string) obo:CL_0002479 ob
 
 # Class: obo:CL_0002480 (nasal mucosa goblet cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:cjm") Annotation(oboInOwl:hasDbXref "GOC:tfm") obo:IAO_0000115 obo:CL_0002480 "A goblet cell located in the nasal epithelium."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:cjm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm") obo:IAO_0000115 obo:CL_0002480 "A goblet cell located in the nasal epithelium."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:CL_0002480 "tmeehan"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002480 "2010-12-03T03:03:02Z"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0002480 "MP:0002262"^^xsd:string)
@@ -19122,7 +19119,7 @@ SubClassOf(obo:CL_0002480 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_000538
 
 # Class: obo:CL_0002481 (peritubular myoid cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:cjm") Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "MP:0006420"^^xsd:string) obo:IAO_0000115 obo:CL_0002481 "The flattened smooth myoepithelial cells of mesodermal origin that lie just outside the basal lamina of the seminiferous tubule."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:cjm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "MP:0006420"^^xsd:string) obo:IAO_0000115 obo:CL_0002481 "The flattened smooth myoepithelial cells of mesodermal origin that lie just outside the basal lamina of the seminiferous tubule."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:CL_0002481 "tmeehan"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002481 "2010-12-03T03:11:48Z"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0002481 "cell"^^xsd:string)
@@ -19132,7 +19129,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true"^^xsd:string) obo:CL_0002481 ob
 
 # Class: obo:CL_0002482 (dermal melanocyte)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:cjm") Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "MP:0009386"^^xsd:string) obo:IAO_0000115 obo:CL_0002482 "A melanocyte that produces pigment in the dermis."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:cjm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "MP:0009386"^^xsd:string) obo:IAO_0000115 obo:CL_0002482 "A melanocyte that produces pigment in the dermis."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:CL_0002482 "tmeehan"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002482 "2010-12-03T03:17:05Z"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0002482 "cell"^^xsd:string)
@@ -27472,7 +27469,7 @@ SubClassOf(obo:CL_4023010 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_Q9D387))
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30382198") obo:IAO_0000115 obo:CL_4023011 "A GABAergic neuron located in the cerebral cortex that expresses Lamp5")
 AnnotationAssertion(oboInOwl:created_by obo:CL_4023011 <http://orcid.org/0000-0001-7258-9596>)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023011 "ILX:0770149")
+AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023011 "ILX:0770149"^^xsd:string)
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023011 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(rdfs:label obo:CL_4023011 "Lamp5 GABAergic cortical interneuron")
 EquivalentClasses(obo:CL_4023011 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000956) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534) ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000032148)))
@@ -27514,7 +27511,7 @@ SubClassOf(obo:CL_4023014 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_P32648))
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:33186530") obo:IAO_0000115 obo:CL_4023015 "A GABAergic neuron located in the cerebral cortex that expresses Gamma-synuclein")
 AnnotationAssertion(oboInOwl:created_by obo:CL_4023015 <http://orcid.org/0000-0001-7258-9596>)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023015 "ILX:0770150")
+AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023015 "ILX:0770150"^^xsd:string)
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023015 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(rdfs:label obo:CL_4023015 "sncg GABAergic cortical interneuron")
 EquivalentClasses(obo:CL_4023015 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000956) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534) ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000015325)))
@@ -27523,7 +27520,7 @@ EquivalentClasses(obo:CL_4023015 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeV
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:33186530") obo:IAO_0000115 obo:CL_4023016 "A GABAergic neuron located in the cerebral cortex that expresses vasoactive intestinal polypeptide")
 AnnotationAssertion(oboInOwl:created_by obo:CL_4023016 <http://orcid.org/0000-0001-7258-9596>)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023016 "ILX:0770151")
+AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023016 "ILX:0770151"^^xsd:string)
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023016 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(rdfs:label obo:CL_4023016 "Vip GABAergic cortical interneuron")
 EquivalentClasses(obo:CL_4023016 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000956) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534) ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000017299)))
@@ -27532,7 +27529,7 @@ EquivalentClasses(obo:CL_4023016 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeV
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:27477017") obo:IAO_0000115 obo:CL_4023017 "A GABAergic neuron located in the cerebral cortex that expresses somatostatin (sst)")
 AnnotationAssertion(oboInOwl:created_by obo:CL_4023017 <http://orcid.org/0000-0001-7258-9596>)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023017 "ILX:0770152")
+AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023017 "ILX:0770152"^^xsd:string)
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023017 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(rdfs:label obo:CL_4023017 "sst GABAergic cortical interneuron")
 EquivalentClasses(obo:CL_4023017 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000956) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534) ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000015665)))
@@ -27541,7 +27538,7 @@ EquivalentClasses(obo:CL_4023017 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeV
 
 AnnotationAssertion(Annotation(obo:IAO_0000115 "PMID:27477017") obo:IAO_0000115 obo:CL_4023018 "A GABAergic interneuron located in the cerebral cortex that expresses Parvalbumin.")
 AnnotationAssertion(oboInOwl:created_by obo:CL_4023018 <http://orcid.org/0000-0001-7258-9596>)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023018 "ILX:0770154")
+AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023018 "ILX:0770154"^^xsd:string)
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023018 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(rdfs:label obo:CL_4023018 "pvalb GABAergic cortical interneuron")
 EquivalentClasses(obo:CL_4023018 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000956) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534) ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000013502)))
@@ -27679,7 +27676,7 @@ SubClassOf(obo:CL_4023034 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_P60041))
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:27477017") obo:IAO_0000115 obo:CL_4023036 "A Pvalb GABAergic cortical interneuron that is recognizable by the straight terminal axonal 'cartridges' of vertically oriented strings of synaptic boutons. Chandelier PV cells are mostly found in upper L2/3, with some in deep L5. Chandelier PV cells exhibit fast-spiking but lower firing rate compared to basket cells, and have practically absent hyperpolarization sag. Chandelier PV cells' boutons target exclusively the axon initial segment (AIS) of pyramidal cells, with a single cell innervating hundreds of pyramidal cells in a clustered manner.")
 AnnotationAssertion(oboInOwl:created_by obo:CL_4023036 <http://orcid.org/0000-0001-7258-9596>)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023036 "ILX:0107356")
+AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023036 "ILX:0107356"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4023036 "Chandelier PV (Mus)")
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023036 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(rdfs:label obo:CL_4023036 "Chandelier Pvalb GABAergic cortical interneuron (Mus musculus)")
@@ -27688,7 +27685,6 @@ SubClassOf(obo:CL_4023036 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000956
 SubClassOf(obo:CL_4023036 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_10090))
 SubClassOf(obo:CL_4023036 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534))
 SubClassOf(obo:CL_4023036 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_P32848))
-
 
 # Class: obo:CL_4023041 (L5 extratelencephalic projecting glutamatergic cortical neuron)
 
@@ -27711,7 +27707,6 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4023042 "L6 CT")
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023042 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(rdfs:label obo:CL_4023042 "L6 corticothalamic-projecting projecting glutamatergic cortical neuron")
 SubClassOf(obo:CL_4023042 obo:CL_4023013)
-
 
 # Class: obo:CP_0000000 (neutrophillic cytoplasm)
 
@@ -27806,26 +27801,6 @@ SubClassOf(obo:CP_0000043 obo:GO_0000792)
 AnnotationAssertion(rdfs:label obo:D96882F1-8709-49AB-BCA9-772A67EA6C33 "alobate nucleus"@en)
 EquivalentClasses(obo:D96882F1-8709-49AB-BCA9-772A67EA6C33 ObjectIntersectionOf(obo:GO_0005634 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0002506)))
 SubClassOf(obo:D96882F1-8709-49AB-BCA9-772A67EA6C33 obo:GO_0005634)
-
-# Class: obo:PR_000013502 (parvalbumin alpha)
-
-AnnotationAssertion(rdfs:label obo:PR_000013502 "pvalb")
-
-# Class: obo:PR_000015325 (gamma-synuclein)
-
-AnnotationAssertion(rdfs:label obo:PR_000015325 "sncg")
-
-# Class: obo:PR_000015665 (somatostatin)
-
-AnnotationAssertion(rdfs:label obo:PR_000015665 "sst")
-
-# Class: obo:PR_000017299 (VIP peptides)
-
-AnnotationAssertion(rdfs:label obo:PR_000017299 "vip")
-
-# Class: obo:PR_000032148 (lysosome-associated membrane glycoprotein 5)
-
-AnnotationAssertion(rdfs:label obo:PR_000032148 "Lamp5")
 
 
 SubClassOf(Annotation(oboInOwl:hasDbXref <https://github.com/obophenotype/cell-ontology/issues/757>) ObjectIntersectionOf(obo:CL_0000540 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_7742)) ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000031))


### PR DESCRIPTION
Labels were wrongly placed for pvalb, snc, sst, vip, lamp5 (they are already synonyms)