### PR TITLE
Added missing BDS subset tags

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -2473,30 +2473,12 @@ Declaration(Class(obo:CL_4023038))
 Declaration(Class(obo:CL_4023040))
 Declaration(Class(obo:CL_4023041))
 Declaration(Class(obo:CL_4023042))
-
-
 Declaration(Class(obo:CL_4023043))
-
-
-
 Declaration(Class(obo:CL_4023046))
-
-
-
-Declaration(Class(obo:CL_4023049))
-
-
-Declaration(Class(obo:CL_4023050))
-
-
-Declaration(Class(obo:CL_4023048))
-
 Declaration(Class(obo:CL_4023047))
-
-
-
-
-
+Declaration(Class(obo:CL_4023048))
+Declaration(Class(obo:CL_4023049))
+Declaration(Class(obo:CL_4023050))
 Declaration(Class(obo:CP_0000000))
 Declaration(Class(obo:CP_0000025))
 Declaration(Class(obo:CP_0000027))
@@ -27472,6 +27454,7 @@ SubClassOf(obo:CL_4023008 ObjectSomeValuesFrom(obo:RO_0013001 obo:UBERON_0001893
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "DOI:10.1101/2020.10.19.343129") obo:IAO_0000115 obo:CL_4023009 "A glutamatergic neuron located in the cerebral cortex that projects to structures not derived from telencephalon.")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023009 <http://orcid.org/0000-0001-7258-9596>)
+AnnotationAssertion(oboInOwl:SubsetProperty obo:CL_4023009 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023009 "ILX:0770101")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4023009 "ET projecting neuron")
 AnnotationAssertion(rdfs:label obo:CL_4023009 "extratelencephalic-projecting glutamatergic cortical neuron")
@@ -27504,6 +27487,7 @@ EquivalentClasses(obo:CL_4023011 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeV
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "DOI:10.1101/2020.10.19.343129") obo:IAO_0000115 obo:CL_4023012 "A glutamatergic neuron located in the cerebral cortex that projects axons locally rather than distantly.")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023012 <http://orcid.org/0000-0001-7258-9596>)
+AnnotationAssertion(oboInOwl:SubsetProperty obo:CL_4023012 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023012 "ILX:0770103")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4023012 "NP neuron")
 AnnotationAssertion(rdfs:label obo:CL_4023012 "near-projecting glutamatergic cortical neuron")
@@ -27514,6 +27498,7 @@ SubClassOf(obo:CL_4023012 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000956
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "DOI:10.1101/2020.10.19.343129") obo:IAO_0000115 obo:CL_4023013 "A glutamatergic neuron located in the cerebral cortex that projects to the thalamus.")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023013 <http://orcid.org/0000-0001-7258-9596>)
+AnnotationAssertion(oboInOwl:SubsetProperty obo:CL_4023013 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4023013 "CT projecting neuron")
 AnnotationAssertion(rdfs:label obo:CL_4023013 "corticothalamic-projecting glutamatergic cortical neuron")
 SubClassOf(obo:CL_4023013 obo:CL_0000679)
@@ -27714,22 +27699,6 @@ SubClassOf(obo:CL_4023036 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_P32848))
 
 # Class: obo:CL_4023038 (L6b glutamatergic cortical neuron)
 
-
-# Class: obo:CL_4023043 (L5/6 near-projecting glutamatergic neuron of the primary motor cortex (Mus musculus))
-
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "DOI:10.1101/2020.10.19.343129") Annotation(oboInOwl:hasDbXref "PMID:31209381") obo:IAO_0000115 obo:CL_4023043 "A near-projecting glutamatergic neuron with a soma found in layer 5/6 of the primary motor cortex.")
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023043 <http://orcid.org/0000-0001-7258-9596>)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023043 "ILX:0770161")
-AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4023043 "L5/6 NP")
-AnnotationAssertion(oboInOwl:inSubset obo:CL_4023043 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
-AnnotationAssertion(rdfs:label obo:CL_4023043 "L5/6 near-projecting glutamatergic neuron of the primary motor cortex (Mus musculus)")
-SubClassOf(obo:CL_4023043 obo:CL_4023012)
-SubClassOf(obo:CL_4023043 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001384))
-SubClassOf(obo:CL_4023043 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_10090))
-
-
-
-
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "DOI:10.1101/2020.10.19.34312") Annotation(oboInOwl:hasDbXref "PMID:30382198") obo:IAO_0000115 obo:CL_4023038 "A glutamatergic neuron located in cortical layer 6b. They are transcriptomically related to corticothalamic-projecting neurons but have differential projections to the thalamus or anterior cingulate.")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023038 <http://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023038 "ILX:0770163")
@@ -27737,7 +27706,6 @@ AnnotationAssertion(oboInOwl:inSubset obo:CL_4023038 <http://purl.obolibrary.org
 AnnotationAssertion(rdfs:label obo:CL_4023038 "L6b glutamatergic cortical neuron")
 SubClassOf(obo:CL_4023038 obo:CL_0000679)
 SubClassOf(obo:CL_4023038 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000956))
-
 
 # Class: obo:CL_4023040 (L2/3-6 intratelencephalic projecting glutamatergic cortical neuron)
 
@@ -27770,8 +27738,19 @@ AnnotationAssertion(oboInOwl:inSubset obo:CL_4023042 <http://purl.obolibrary.org
 AnnotationAssertion(rdfs:label obo:CL_4023042 "L6 corticothalamic-projecting projecting glutamatergic cortical neuron")
 SubClassOf(obo:CL_4023042 obo:CL_4023013)
 
-# Class: obo:CL_4023046 (L6b subplate glutamatergic neuron of the primary motor cortex (Mus musculus))
+# Class: obo:CL_4023043 (L5/6 near-projecting glutamatergic neuron of the primary motor cortex (Mus musculus))
 
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "DOI:10.1101/2020.10.19.343129") Annotation(oboInOwl:hasDbXref "PMID:31209381") obo:IAO_0000115 obo:CL_4023043 "A near-projecting glutamatergic neuron with a soma found in layer 5/6 of the primary motor cortex.")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023043 <http://orcid.org/0000-0001-7258-9596>)
+AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023043 "ILX:0770161")
+AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4023043 "L5/6 NP")
+AnnotationAssertion(oboInOwl:inSubset obo:CL_4023043 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
+AnnotationAssertion(rdfs:label obo:CL_4023043 "L5/6 near-projecting glutamatergic neuron of the primary motor cortex (Mus musculus)")
+SubClassOf(obo:CL_4023043 obo:CL_4023012)
+SubClassOf(obo:CL_4023043 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001384))
+SubClassOf(obo:CL_4023043 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_10090))
+
+# Class: obo:CL_4023046 (L6b subplate glutamatergic neuron of the primary motor cortex (Mus musculus))
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:33184512") obo:IAO_0000115 obo:CL_4023046 "An excitatory glutamatergic neuron transcriptomically related to the CT subclass, with a soma preferentially located in the bottom of L6 of the primary motor cortex.")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023046 <http://orcid.org/0000-0001-7258-9596>)
@@ -27780,6 +27759,29 @@ AnnotationAssertion(rdfs:label obo:CL_4023046 "L6b subplate glutamatergic neuron
 SubClassOf(obo:CL_4023046 obo:CL_4023038)
 SubClassOf(obo:CL_4023046 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001384))
 SubClassOf(obo:CL_4023046 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_10090))
+
+# Class: obo:CL_4023047 (L2/3 intratelencephalic projecting glutamatergic neuron of the primary motor cortex (Mus musculus))
+
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "DOI:10.1101/2020.10.19.343129") obo:IAO_0000115 obo:CL_4023047 "An intratelencephalic-projecting glutamatergic neuron with a soma found in cortical layer 2/3.")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023047 <http://orcid.org/0000-0001-7258-9596>)
+AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4023047 "L2/3 IT MOp (Mus)")
+AnnotationAssertion(oboInOwl:inSubset obo:CL_4023047 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
+AnnotationAssertion(rdfs:label obo:CL_4023047 "L2/3 intratelencephalic projecting glutamatergic neuron of the primary motor cortex (Mus musculus)")
+SubClassOf(obo:CL_4023047 obo:CL_4023040)
+SubClassOf(obo:CL_4023047 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001384))
+SubClassOf(obo:CL_4023047 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_10090))
+
+# Class: obo:CL_4023048 (L4/5 intratelencephalic projecting glutamatergic neuron of the primary motor cortex (Mus musculus))
+
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:33184512") obo:IAO_0000115 obo:CL_4023048 "An intratelencephalic-projecting glutamatergic with a soma located in upper L5 of the primary motor cortex. These cells have thin untufted apical dendrites.")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023048 <http://orcid.org/0000-0001-7258-9596>)
+AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023048 "ILX:0770174")
+AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4023048 "L4/5 IT MOp (Mus)")
+AnnotationAssertion(oboInOwl:inSubset obo:CL_4023048 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
+AnnotationAssertion(rdfs:label obo:CL_4023048 "L4/5 intratelencephalic projecting glutamatergic neuron of the primary motor cortex (Mus musculus)")
+SubClassOf(obo:CL_4023048 obo:CL_4023040)
+SubClassOf(obo:CL_4023048 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001384))
+SubClassOf(obo:CL_4023048 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_10090))
 
 # Class: obo:CL_4023049 (L5 intratelencephalic projecting glutamatergic neuron of the primary motor cortex (Mus musculus))
 
@@ -27795,7 +27797,6 @@ SubClassOf(obo:CL_4023049 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_1009
 
 # Class: obo:CL_4023050 (L6 intratelencephalic projecting glutamatergic neuron of the primary motor cortex (Mus musculus))
 
-
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:9236245") obo:IAO_0000115 obo:CL_4023050 "An intratelencephalic-projecting glutamatergic neuron with a soma found in L6 of the primary motor cortex. These cells are short untufted pyramidal cells, which could be stellate or inverted.")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023050 <http://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023050 "ILX:0770158")
@@ -27805,34 +27806,6 @@ AnnotationAssertion(rdfs:label obo:CL_4023050 "L6 intratelencephalic projecting 
 SubClassOf(obo:CL_4023050 obo:CL_4023040)
 SubClassOf(obo:CL_4023050 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001384))
 SubClassOf(obo:CL_4023050 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_10090))
-
-# Class: obo:CL_4023048 (L4/5 intratelencephalic projecting glutamatergic neuron of the primary motor cortex (Mus musculus))
-
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:33184512") obo:IAO_0000115 obo:CL_4023048 "An intratelencephalic-projecting glutamatergic with a soma located in upper L5 of the primary motor cortex. These cells have thin untufted apical dendrites.")
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023048 <http://orcid.org/0000-0001-7258-9596>)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023048 "ILX:0770174")
-AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4023048 "L4/5 IT MOp (Mus)")
-AnnotationAssertion(oboInOwl:inSubset obo:CL_4023048 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
-AnnotationAssertion(rdfs:label obo:CL_4023048 "L4/5 intratelencephalic projecting glutamatergic neuron of the primary motor cortex (Mus musculus)")
-SubClassOf(obo:CL_4023048 obo:CL_4023040)
-SubClassOf(obo:CL_4023048 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001384))
-SubClassOf(obo:CL_4023048 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_10090))
-
-# Class: obo:CL_4023047 (L2/3 intratelencephalic projecting glutamatergic neuron of the primary motor cortex (Mus musculus))
-
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "DOI:10.1101/2020.10.19.343129") obo:IAO_0000115 obo:CL_4023047 "An intratelencephalic-projecting glutamatergic neuron with a soma found in cortical layer 2/3.")
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023047 <http://orcid.org/0000-0001-7258-9596>)
-AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4023047 "L2/3 IT MOp (Mus)")
-AnnotationAssertion(oboInOwl:inSubset obo:CL_4023047 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
-AnnotationAssertion(rdfs:label obo:CL_4023047 "L2/3 intratelencephalic projecting glutamatergic neuron of the primary motor cortex (Mus musculus)")
-SubClassOf(obo:CL_4023047 obo:CL_4023040)
-SubClassOf(obo:CL_4023047 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001384))
-SubClassOf(obo:CL_4023047 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_10090))
-
-
-
-
-
 
 # Class: obo:CP_0000000 (neutrophillic cytoplasm)
 


### PR DESCRIPTION
Added missing BDS subset tags to the following: 
CL_4023009 ET-projecting glut 
CL_4023013 CT-projecting glut
CL_4023012 NP glut
