### PR TITLE
Fibroblasts are not epithelial cells!

### DIFF
--- a/cl-basic.obo
+++ b/cl-basic.obo
@@ -23676,10 +23676,9 @@ creation_date: 2015-05-26T18:58:34Z
 
 [Term]
 id: CL:2000096
-name: reticular layer of dermis fibroblast
+name: fibroblast of reticular layer of dermis
 namespace: cell
 def: "Any fibroblast that is part of a reticular layer of dermis." [GOC:TermGenie]
-is_a: CL:0000066 ! epithelial cell
 is_a: CL:0002551 ! fibroblast of dermis
 created_by: TermGenie
 creation_date: 2015-08-11T16:28:16Z


### PR DESCRIPTION
Two changes:
- Fibroblasts are not epithelial cells! As such, I removed the "is_a" relation to CL:0000066 ! epithelial cell
- For consistency with other terms, e.g. "fibroblast of papillary layer of dermis" I changed "reticular layer of dermis fibroblast" to "fibroblast of reticular layer of dermis"