### PR TITLE
Make xsd:string normalisation work with MacOS's sed.

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -10190,7 +10190,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true"^^xsd:string) obo:CL_0000787 ob
 
 # Class: obo:CL_0000788 (naive B cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196") Annotation(oboInOwl:hasDbXref "PMID:19447676"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:20081059"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:20839338"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:20933013"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:22343568"^^xsd:string) obo:IAO_0000115 obo:CL_0000788 "A naive B cell is a mature B cell that has the phenotype surface IgD-positive, surface IgM-positive, CD20-positive, CD27-negative and that has not yet been activated by antigen in the periphery."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:19447676"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:20081059"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:20839338"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:20933013"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:22343568"^^xsd:string) obo:IAO_0000115 obo:CL_0000788 "A naive B cell is a mature B cell that has the phenotype surface IgD-positive, surface IgM-positive, CD20-positive, CD27-negative and that has not yet been activated by antigen in the periphery."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000788 "naive B lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000788 "naive B-cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000788 "naive B-lymphocyte"^^xsd:string)
@@ -12155,7 +12155,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true"^^xsd:string) obo:CL_0000947 ob
 
 # Class: obo:CL_0000948 (IgE memory B cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196") obo:IAO_0000115 obo:CL_0000948 "A class switched memory B cell that expresses IgE on the cell surface."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196"^^xsd:string) obo:IAO_0000115 obo:CL_0000948 "A class switched memory B cell that expresses IgE on the cell surface."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000948 "IgE memory B lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000948 "IgE memory B-cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000948 "IgE memory B-lymphocyte"^^xsd:string)
@@ -12421,7 +12421,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true"^^xsd:string) obo:CL_0000969 ob
 
 # Class: obo:CL_0000970 (unswitched memory B cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196") Annotation(oboInOwl:hasDbXref "PMID:20933013"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:22343568"^^xsd:string) obo:IAO_0000115 obo:CL_0000970 "An unswitched memory B cell is a memory B cell that has the phenotype IgM-positive, IgD-positive, CD27-positive, CD138-negative, IgG-negative, IgE-negative, and IgA-negative."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:20933013"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:22343568"^^xsd:string) obo:IAO_0000115 obo:CL_0000970 "An unswitched memory B cell is a memory B cell that has the phenotype IgM-positive, IgD-positive, CD27-positive, CD138-negative, IgG-negative, IgE-negative, and IgA-negative."^^xsd:string)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:22343568"^^xsd:string) oboInOwl:hasBroadSynonym obo:CL_0000970 "IgD+ memory B cell")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "HP:0032126"^^xsd:string) oboInOwl:hasExactSynonym obo:CL_0000970 "non-class-switched memory B cell")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000970 "unswitched memory B lymphocyte"^^xsd:string)
@@ -12436,7 +12436,7 @@ SubClassOf(obo:CL_0000970 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000980))
 
 # Class: obo:CL_0000971 (IgM memory B cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196") Annotation(oboInOwl:hasDbXref "PMID:19447676"^^xsd:string) obo:IAO_0000115 obo:CL_0000971 "An IgM memory B cell is an unswitched memory B cell with the phenotype IgM-positive and IgD-negative."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:19447676"^^xsd:string) obo:IAO_0000115 obo:CL_0000971 "An IgM memory B cell is an unswitched memory B cell with the phenotype IgM-positive and IgD-negative."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000971 "IgM memory B lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000971 "IgM memory B-cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000971 "IgM memory B-lymphocyte"^^xsd:string)
@@ -12452,7 +12452,7 @@ SubClassOf(obo:CL_0000971 obo:CL_0000787)
 
 # Class: obo:CL_0000972 (class switched memory B cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196") Annotation(oboInOwl:hasDbXref "PMID:20933013"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:9295047"^^xsd:string) obo:IAO_0000115 obo:CL_0000972 "A class switched memory B cell is a memory B cell that has undergone Ig class switching and therefore is IgM-negative on the cell surface. These cells are CD27-positive and have either IgG, IgE, or IgA on the cell surface."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:20933013"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:9295047"^^xsd:string) obo:IAO_0000115 obo:CL_0000972 "A class switched memory B cell is a memory B cell that has undergone Ig class switching and therefore is IgM-negative on the cell surface. These cells are CD27-positive and have either IgG, IgE, or IgA on the cell surface."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000972 "class switched memory B lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000972 "class switched memory B-cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000972 "class switched memory B-lymphocyte"^^xsd:string)
@@ -12465,7 +12465,7 @@ SubClassOf(obo:CL_0000972 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000970))
 
 # Class: obo:CL_0000973 (IgA memory B cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:msz"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196") obo:IAO_0000115 obo:CL_0000973 "A class switched memory B cell that expresses IgA."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:msz"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196"^^xsd:string) obo:IAO_0000115 obo:CL_0000973 "A class switched memory B cell that expresses IgA."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000973 "IgA memory B lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000973 "IgA memory B-cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000973 "IgA memory B-lymphocyte"^^xsd:string)
@@ -12523,7 +12523,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true"^^xsd:string) obo:CL_0000978 ob
 
 # Class: obo:CL_0000979 (IgG memory B cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196") obo:IAO_0000115 obo:CL_0000979 "An IgG memory B cell is a class switched memory B cell that is class switched and expresses IgG on the cell surface."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196"^^xsd:string) obo:IAO_0000115 obo:CL_0000979 "An IgG memory B cell is a class switched memory B cell that is class switched and expresses IgG on the cell surface."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000979 "IgG memory B lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000979 "IgG memory B-cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000979 "IgG memory B-lymphocyte"^^xsd:string)
@@ -22638,7 +22638,7 @@ EquivalentClasses(obo:CL_0009048 ObjectIntersectionOf(obo:CL_0000235 ObjectSomeV
 
 # Class: obo:CL_0009050 (B cell of anorectum)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "http://orcid.org/0000-0003-3440-1876") obo:IAO_0000115 obo:CL_0009050 "A B cell that is located in the anorectum.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "http://orcid.org/0000-0003-3440-1876"^^xsd:string) obo:IAO_0000115 obo:CL_0009050 "A B cell that is located in the anorectum.")
 AnnotationAssertion(oboInOwl:created_by obo:CL_0009050 <http://orcid.org/0000-0002-2825-0621>)
 AnnotationAssertion(oboInOwl:inSubset obo:CL_0009050 <http://purl.obolibrary.org/obo/pato#location_grouping>)
 AnnotationAssertion(rdfs:label obo:CL_0009050 "B cell of anorectum")
@@ -22646,7 +22646,7 @@ EquivalentClasses(obo:CL_0009050 ObjectIntersectionOf(obo:CL_0000236 ObjectSomeV
 
 # Class: obo:CL_0009051 (T cell of anorectum)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "http://orcid.org/0000-0003-3440-1876") obo:IAO_0000115 obo:CL_0009051 "A T cell that is located in the anorectum.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "http://orcid.org/0000-0003-3440-1876"^^xsd:string) obo:IAO_0000115 obo:CL_0009051 "A T cell that is located in the anorectum.")
 AnnotationAssertion(oboInOwl:created_by obo:CL_0009051 <http://orcid.org/0000-0002-2825-0621>)
 AnnotationAssertion(oboInOwl:inSubset obo:CL_0009051 <http://purl.obolibrary.org/obo/pato#location_grouping>)
 AnnotationAssertion(rdfs:label obo:CL_0009051 "T cell of anorectum")
@@ -22654,7 +22654,7 @@ EquivalentClasses(obo:CL_0009051 ObjectIntersectionOf(obo:CL_0000084 ObjectSomeV
 
 # Class: obo:CL_0009052 (smooth muscle cell of anorectum)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "http://orcid.org/0000-0003-3440-1876") obo:IAO_0000115 obo:CL_0009052 "A smooth muscle cell that is located in the anorectum.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "http://orcid.org/0000-0003-3440-1876"^^xsd:string) obo:IAO_0000115 obo:CL_0009052 "A smooth muscle cell that is located in the anorectum.")
 AnnotationAssertion(oboInOwl:created_by obo:CL_0009052 <http://orcid.org/0000-0002-2825-0621>)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0009052 "anorectum smooth muscle cell")
 AnnotationAssertion(oboInOwl:inSubset obo:CL_0009052 <http://purl.obolibrary.org/obo/pato#location_grouping>)
@@ -22663,7 +22663,7 @@ EquivalentClasses(obo:CL_0009052 ObjectIntersectionOf(obo:CL_0000192 ObjectSomeV
 
 # Class: obo:CL_0009053 (stromal cell of anorectum lamina propria)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "http://orcid.org/0000-0003-3440-1876") obo:IAO_0000115 obo:CL_0009053 "A stromal cell found in the lamina propria of the anorectum.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "http://orcid.org/0000-0003-3440-1876"^^xsd:string) obo:IAO_0000115 obo:CL_0009053 "A stromal cell found in the lamina propria of the anorectum.")
 AnnotationAssertion(oboInOwl:created_by obo:CL_0009053 <http://orcid.org/0000-0002-2825-0621>)
 AnnotationAssertion(oboInOwl:inSubset obo:CL_0009053 <http://purl.obolibrary.org/obo/pato#location_grouping>)
 AnnotationAssertion(rdfs:label obo:CL_0009053 "stromal cell of anorectum lamina propria")

--- a/src/ontology/cl.Makefile
+++ b/src/ontology/cl.Makefile
@@ -254,7 +254,8 @@ all_reports: reports/obo-diff.txt
 
 
 normalise_xsd_string: $(SRC)
-	sed -i -E "s/Annotation[(](oboInOwl[:]hasDbXref [\"][^\"]*[\"])[)]/Annotation(\1^^xsd:string)/" $<
+	sed -i.bak -E "s/Annotation[(](oboInOwl[:]hasDbXref [\"][^\"]*[\"])[)]/Annotation(\1^^xsd:string)/" $<
+	rm $<.bak
 
 ALL_PATTERNS=$(patsubst ../patterns/dosdp-patterns/%.yaml,%,$(wildcard ../patterns/dosdp-patterns/[a-z]*.yaml))
 DOSDPT=dosdp-tools


### PR DESCRIPTION
A difference between GNU sed and MacOS (or BSD) sed is that the latter
expects a *mandatory* argument after the -i option (that argument is the
suffix to use for creating a backup file), whereas that argument may be
omitted with GNU Sed.

A consequence of that difference is that invoking sed as follows:

```
$ sed -i -E ...
```

will work as expected with GNU sed, but with MacOS sed, the -E option
will be interpreted as the argument expected by the -i option. As a
result, the regular expression that follows is interpreted as a "basic"
regular expression instead of an "extended" one.

This makes the xsd:string normalisation rule fail on MacOS with the
following error:

```
sed: 1: "s/Annotation[(](oboInOw ...": \1 not defined in the RE
make: *** [normalise_xsd_string] Error 1
```

because '(' characters are interpreted differently between basic and
extended regular expression.

This patch makes sure an argument is provided to the -i option, so that
the normalisation step can be used portably and without requiring the
use of Docker for a simple sed call.