### PR TITLE
relax pyramidal neuron equiv class

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -2829,7 +2829,7 @@ AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/cl#lacks_plasma_m
 
 AnnotationAssertion(oboInOwl:hasDbXref <http://semanticscience.org/resource/SIO_000658> "http://semanticscience.org/resource/SIO_000658"^^xsd:string)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "https://orcid.org/0000-0002-6601-2165"^^xsd:string) oboInOwl:hasExactSynonym <http://semanticscience.org/resource/SIO_000658> "direct_transformation_of"^^xsd:string)
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "SIO:000658") oboInOwl:hasExactSynonym <http://semanticscience.org/resource/SIO_000658> "immediately transforms from"^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "SIO:000658"^^xsd:string) oboInOwl:hasExactSynonym <http://semanticscience.org/resource/SIO_000658> "immediately transforms from"^^xsd:string)
 AnnotationAssertion(oboInOwl:shorthand <http://semanticscience.org/resource/SIO_000658> "immediate_transformation_of"^^xsd:string)
 AnnotationAssertion(rdfs:label <http://semanticscience.org/resource/SIO_000658> "immediate_transformation_of"^^xsd:string)
 
@@ -10210,7 +10210,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true"^^xsd:string) obo:CL_0000787 ob
 
 # Class: obo:CL_0000788 (naive B cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196") Annotation(oboInOwl:hasDbXref "PMID:19447676"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:20081059"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:20839338"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:20933013"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:22343568"^^xsd:string) obo:IAO_0000115 obo:CL_0000788 "A naive B cell is a mature B cell that has the phenotype surface IgD-positive, surface IgM-positive, CD20-positive, CD27-negative and that has not yet been activated by antigen in the periphery."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:19447676"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:20081059"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:20839338"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:20933013"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:22343568"^^xsd:string) obo:IAO_0000115 obo:CL_0000788 "A naive B cell is a mature B cell that has the phenotype surface IgD-positive, surface IgM-positive, CD20-positive, CD27-negative and that has not yet been activated by antigen in the periphery."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000788 "naive B lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000788 "naive B-cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000788 "naive B-lymphocyte"^^xsd:string)
@@ -12175,7 +12175,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true"^^xsd:string) obo:CL_0000947 ob
 
 # Class: obo:CL_0000948 (IgE memory B cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196") obo:IAO_0000115 obo:CL_0000948 "A class switched memory B cell that expresses IgE on the cell surface."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196"^^xsd:string) obo:IAO_0000115 obo:CL_0000948 "A class switched memory B cell that expresses IgE on the cell surface."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000948 "IgE memory B lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000948 "IgE memory B-cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000948 "IgE memory B-lymphocyte"^^xsd:string)
@@ -12441,7 +12441,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true"^^xsd:string) obo:CL_0000969 ob
 
 # Class: obo:CL_0000970 (unswitched memory B cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196") Annotation(oboInOwl:hasDbXref "PMID:20933013"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:22343568"^^xsd:string) obo:IAO_0000115 obo:CL_0000970 "An unswitched memory B cell is a memory B cell that has the phenotype IgM-positive, IgD-positive, CD27-positive, CD138-negative, IgG-negative, IgE-negative, and IgA-negative."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:20933013"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:22343568"^^xsd:string) obo:IAO_0000115 obo:CL_0000970 "An unswitched memory B cell is a memory B cell that has the phenotype IgM-positive, IgD-positive, CD27-positive, CD138-negative, IgG-negative, IgE-negative, and IgA-negative."^^xsd:string)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:22343568"^^xsd:string) oboInOwl:hasBroadSynonym obo:CL_0000970 "IgD+ memory B cell")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "HP:0032126"^^xsd:string) oboInOwl:hasExactSynonym obo:CL_0000970 "non-class-switched memory B cell")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000970 "unswitched memory B lymphocyte"^^xsd:string)
@@ -12456,7 +12456,7 @@ SubClassOf(obo:CL_0000970 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000980))
 
 # Class: obo:CL_0000971 (IgM memory B cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196") Annotation(oboInOwl:hasDbXref "PMID:19447676"^^xsd:string) obo:IAO_0000115 obo:CL_0000971 "An IgM memory B cell is an unswitched memory B cell with the phenotype IgM-positive and IgD-negative."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:19447676"^^xsd:string) obo:IAO_0000115 obo:CL_0000971 "An IgM memory B cell is an unswitched memory B cell with the phenotype IgM-positive and IgD-negative."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000971 "IgM memory B lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000971 "IgM memory B-cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000971 "IgM memory B-lymphocyte"^^xsd:string)
@@ -12472,7 +12472,7 @@ SubClassOf(obo:CL_0000971 obo:CL_0000787)
 
 # Class: obo:CL_0000972 (class switched memory B cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196") Annotation(oboInOwl:hasDbXref "PMID:20933013"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:9295047"^^xsd:string) obo:IAO_0000115 obo:CL_0000972 "A class switched memory B cell is a memory B cell that has undergone Ig class switching and therefore is IgM-negative on the cell surface. These cells are CD27-positive and have either IgG, IgE, or IgA on the cell surface."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:20933013"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:9295047"^^xsd:string) obo:IAO_0000115 obo:CL_0000972 "A class switched memory B cell is a memory B cell that has undergone Ig class switching and therefore is IgM-negative on the cell surface. These cells are CD27-positive and have either IgG, IgE, or IgA on the cell surface."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000972 "class switched memory B lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000972 "class switched memory B-cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000972 "class switched memory B-lymphocyte"^^xsd:string)
@@ -12485,7 +12485,7 @@ SubClassOf(obo:CL_0000972 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000970))
 
 # Class: obo:CL_0000973 (IgA memory B cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:msz"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196") obo:IAO_0000115 obo:CL_0000973 "A class switched memory B cell that expresses IgA."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:msz"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196"^^xsd:string) obo:IAO_0000115 obo:CL_0000973 "A class switched memory B cell that expresses IgA."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000973 "IgA memory B lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000973 "IgA memory B-cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000973 "IgA memory B-lymphocyte"^^xsd:string)
@@ -12543,7 +12543,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true"^^xsd:string) obo:CL_0000978 ob
 
 # Class: obo:CL_0000979 (IgG memory B cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196") obo:IAO_0000115 obo:CL_0000979 "An IgG memory B cell is a class switched memory B cell that is class switched and expresses IgG on the cell surface."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781765196"^^xsd:string) obo:IAO_0000115 obo:CL_0000979 "An IgG memory B cell is a class switched memory B cell that is class switched and expresses IgG on the cell surface."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000979 "IgG memory B lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000979 "IgG memory B-cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000979 "IgG memory B-lymphocyte"^^xsd:string)
@@ -28476,7 +28476,7 @@ SubClassOf(obo:CL_4023065 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_P97367))
 
 # Class: obo:CL_4023066 (horizontal pyramidal neuron)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30715238") obo:IAO_0000115 obo:CL_4023066 "A pyramidal neuron which has an apical tree which is oriented parallel to the pia. This is unlike typical pyramidal neurons which have its apical dendrite aligned vertically.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30715238"^^xsd:string) obo:IAO_0000115 obo:CL_4023066 "A pyramidal neuron which has an apical tree which is oriented parallel to the pia. This is unlike typical pyramidal neurons which have its apical dendrite aligned vertically.")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023066 <http://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023066 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(rdfs:label obo:CL_4023066 "horizontal pyramidal neuron")
@@ -28624,7 +28624,7 @@ EquivalentClasses(obo:CL_4023090 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeV
 
 # Class: obo:CL_4023092 (inverted pyramidal neuron)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30715238") obo:IAO_0000115 obo:CL_4023092 "A pyramidal neuron which has an apical tree which is oriented towards the white matter.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30715238"^^xsd:string) obo:IAO_0000115 obo:CL_4023092 "A pyramidal neuron which has an apical tree which is oriented towards the white matter.")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023092 <http://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023092 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(rdfs:label obo:CL_4023092 "inverted pyramidal neuron")
@@ -28632,7 +28632,7 @@ EquivalentClasses(obo:CL_4023092 ObjectIntersectionOf(obo:CL_0000117 ObjectSomeV
 
 # Class: obo:CL_4023093 (stellate pyramidal neuron)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30715238") obo:IAO_0000115 obo:CL_4023093 "A pyramidal neuron which lacks a tuft formation but extends small radial distances forming a star-like shape.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30715238"^^xsd:string) obo:IAO_0000115 obo:CL_4023093 "A pyramidal neuron which lacks a tuft formation but extends small radial distances forming a star-like shape.")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023093 <http://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023093 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(rdfs:label obo:CL_4023093 "stellate pyramidal neuron")
@@ -28640,7 +28640,7 @@ EquivalentClasses(obo:CL_4023093 ObjectIntersectionOf(obo:CL_0000117 ObjectSomeV
 
 # Class: obo:CL_4023094 (tufted pyramidal neuron)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30715238") obo:IAO_0000115 obo:CL_4023094 "A pyramidal neuron which has a distinctive tuft formation, distal from the soma.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30715238"^^xsd:string) obo:IAO_0000115 obo:CL_4023094 "A pyramidal neuron which has a distinctive tuft formation, distal from the soma.")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023094 <http://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023094 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(rdfs:label obo:CL_4023094 "tufted pyramidal neuron")
@@ -28648,7 +28648,7 @@ EquivalentClasses(obo:CL_4023094 ObjectIntersectionOf(obo:CL_0000117 ObjectSomeV
 
 # Class: obo:CL_4023095 (untufted pyramidal neuron)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30715238") obo:IAO_0000115 obo:CL_4023095 "A pyramidal neuron which lacks a clear tuft formation but extends to large radial distances.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30715238"^^xsd:string) obo:IAO_0000115 obo:CL_4023095 "A pyramidal neuron which lacks a clear tuft formation but extends to large radial distances.")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023095 <http://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023095 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(rdfs:label obo:CL_4023095 "untufted pyramidal neuron")


### PR DESCRIPTION
changed equiv class to neuron from CNS neuron (sensu Vertebrata). Also removed the subclass of CNS neuron (sensu Vertebrata) that was imported in from uberon.