### PR TITLE
Add a workflow to automatically close stale issues.

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,18 @@
+name: 'Mark and close stale issues'
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+
+jobs:
+  stale:
+    runs-ons: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          days-before-issue-stale: 180
+          days-before-pr-stale: -1
+          days-before-issue-close: 365
+          close-issue-label: 'autoclosed-unfixed'
+          close-issue-message: 'This issue has been closed automatically because it has not been updated in 6 months. Please re-open if you still need this to be addressed.'
+          start-date: '2021-04-01T00:00:00Z'


### PR DESCRIPTION
As discussed in the technical board meeting of October 11th 2021, this PR does for CL the same thing as obophenotype/Uberon#2030 does for Uberon: it proposes a mechanism to prevent the accumulation of old issues by regularly and automatically closing them.

Parameters used here are the same as in the Uberon repo, that is:
* an issue is to be considered "stale" after 6 months of inactivity;
* a stale issue is to be closed after 1 year of inactivity.