### PR TITLE
Fix typos in defs of CL:4023027 and CL:4023031

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -28276,7 +28276,7 @@ SubClassOf(obo:CL_4023025 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_P60041))
 
 # Class: obo:CL_4023027 (L5 T-Martinotti Sst GABAergic cortical interneuron (Mus musculus))
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:28254942"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:29326172"^^xsd:string) obo:IAO_0000115 obo:CL_4023027 "A Sst GABAergic cortical interneuron with a soma found in L5 and possesses 'T-shaped' Martinotti morphologies with local axonal plexus in L5a and trans-laminar axons restricted to the uppermost part of L1. They show low-threshold spiking patterns with strong rebound firing, and inhibit the L1 apical tuft of nearby pyramidal cells.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:28254942"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:29326172"^^xsd:string) obo:IAO_0000115 obo:CL_4023027 "A Sst GABAergic cortical interneuron with a soma found in L5 and possesses 'T-shaped' Martinotti morphologies with local axonal plexus in L5a and translaminar axons restricted to the uppermost part of L1. They show low-threshold spiking patterns with strong rebound firing, and inhibit the L1 apical tuft of nearby pyramidal cells.")
 AnnotationAssertion(oboInOwl:created_by obo:CL_4023027 <http://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4023027 "L5 T Martinotti SST (Mus)")
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023027 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
@@ -28318,7 +28318,7 @@ SubClassOf(obo:CL_4023030 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_P60041))
 
 # Class: obo:CL_4023031 (L4 Sst GABAergic cortical interneuron (Mus musculus))
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:33184512"^^xsd:string) obo:IAO_0000115 obo:CL_4023031 "A Sst GABAergic cortical interneuron with a soma found in lower L2/3 and upper 5, L4 Sst cells have Martinotti morphology with ascending axons but denser local axons and sparser ‘fanning-out’ projections to L1. L4 Sst cells have smaller membrane time constant to calb2 (L2/3/5 Fan Martinotti Cell) and non-zero after depolarization (ADP).")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:33184512"^^xsd:string) obo:IAO_0000115 obo:CL_4023031 "A Sst GABAergic cortical interneuron with a soma found in lower L2/3 and upper 5, L4 Sst cells have Martinotti morphology with ascending axons but denser local axons and sparser ‘fanning-out’ projections to L1. L4 Sst cells have smaller membrane time constant to calb2 (L2/3/5 Fan Martinotti Cell) and non-zero afterdepolarization (ADP).")
 AnnotationAssertion(oboInOwl:created_by obo:CL_4023031 <http://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4023031 "L4 SST (Mus)")
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023031 <http://purl.obolibrary.org/obo/cl#BDS_subset>)


### PR DESCRIPTION
This commit intends to
correct the text definitions of CL:4023027 and CL:4023031.
I see lots of automatic `AnnotationAssertion` changes that I did not make explicitly after making the two definition edits in Protege and then saving the `cl-edit.owl` file.
If applied, this commit will fix #1259.