### PR TITLE
Fix the stale-issues workflow.

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   stale:
-    runs-ons: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v4
         with:


### PR DESCRIPTION
The 'stale-issues' workflow failed because of a misspelt 'runs-on' directive.