### PR TITLE
Add ID range for Damien Goutte-Gattat and fix bogus prefix.

### DIFF
--- a/src/ontology/cl-idranges.owl
+++ b/src/ontology/cl-idranges.owl
@@ -11,12 +11,12 @@ Prefix: rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 Prefix: idrange: <http://purl.obolibrary.org/obo/ro/idrange/>
 Prefix: owl: <http://www.w3.org/2002/07/owl#>
 
-Ontology: <http://purl.obolibrary.org/obo/covoc/covoc-idranges.owl>
+Ontology: <http://purl.obolibrary.org/obo/cl/cl-idranges.owl>
 
 
 Annotations:
-    idsfor: "COVOC",
-    idprefix: "http://purl.obolibrary.org/obo/COVOC_",
+    idsfor: "CL",
+    idprefix: "http://purl.obolibrary.org/obo/CL_",
     iddigits: 7
 
 AnnotationProperty: idprefix:


### PR DESCRIPTION
This PR adds a new ID range for FlyBase ontology editor Damien Goutte-Gattat (@gouttegd).

It also fixes the bogus `idsfor` and `idsprefix` annotations in the ID ranges file, which were inadvertently changed from the expected `http://purl.obolibrary.org/obo/CL_` to `http://purl.obolibrary.org/obo/COVOC_`.