### PR TITLE
Fix typos in labels of CL:0002455 and CL:0002456

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -2572,15 +2572,12 @@ Declaration(Class(obo:CL_4023106))
 Declaration(Class(obo:CL_4023107))
 Declaration(Class(obo:CL_4023108))
 Declaration(Class(obo:CL_4023109))
-
+Declaration(Class(obo:CL_4023110))
+Declaration(Class(obo:CL_4023111))
 Declaration(Class(obo:CL_4023112))
 Declaration(Class(obo:CL_4023113))
 Declaration(Class(obo:CL_4023114))
-
-Declaration(Class(obo:CL_4023110))
-Declaration(Class(obo:CL_4023111))
 Declaration(Class(obo:CL_4023118))
-
 Declaration(Class(obo:CP_0000000))
 Declaration(Class(obo:CP_0000025))
 Declaration(Class(obo:CP_0000027))
@@ -19011,25 +19008,25 @@ AnnotationAssertion(rdfs:label obo:CL_0002454 "Cd4-negative, CD8_alpha-negative,
 EquivalentClasses(obo:CL_0002454 ObjectIntersectionOf(obo:CL_0002465 ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001004) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001084)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true"^^xsd:string) obo:CL_0002454 obo:CL_0002465)
 
-# Class: obo:CL_0002455 (CD8_alpha-negative plasmactyoid dendritic cell)
+# Class: obo:CL_0002455 (CD8_alpha-negative plasmacytoid dendritic cell)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "http://www.immgen.org/index_content.html"^^xsd:string) obo:IAO_0000115 obo:CL_0002455 "A CD11c-low plasmacytoid dendritic cell that is CD8alpha-negative and CD4-positive."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:CL_0002455 "tmeehan"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002455 "2010-11-22T01:27:37Z"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0002455 "DC.pDC.8-"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0002455 "cell"^^xsd:string)
-AnnotationAssertion(rdfs:label obo:CL_0002455 "CD8_alpha-negative plasmactyoid dendritic cell"^^xsd:string)
+AnnotationAssertion(rdfs:label obo:CL_0002455 "CD8_alpha-negative plasmacytoid dendritic cell"^^xsd:string)
 EquivalentClasses(obo:CL_0002455 ObjectIntersectionOf(obo:CL_0000989 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001004) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001084)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true"^^xsd:string) obo:CL_0002455 obo:CL_0000989)
 
-# Class: obo:CL_0002456 (CD8_alpha-positive plasmactyoid dendritic cell)
+# Class: obo:CL_0002456 (CD8_alpha-positive plasmacytoid dendritic cell)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "http://www.immgen.org/index_content.html"^^xsd:string) obo:IAO_0000115 obo:CL_0002456 "A CD11c-low plasmacytoid dendritic cell that is CD8alpha-positive and CD4-positive."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:CL_0002456 "tmeehan"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002456 "2010-11-22T01:23:07Z"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0002456 "DC.pDC.8+"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0002456 "cell"^^xsd:string)
-AnnotationAssertion(rdfs:label obo:CL_0002456 "CD8_alpha-positive plasmactyoid dendritic cell"^^xsd:string)
+AnnotationAssertion(rdfs:label obo:CL_0002456 "CD8_alpha-positive plasmacytoid dendritic cell"^^xsd:string)
 EquivalentClasses(obo:CL_0002456 ObjectIntersectionOf(obo:CL_0000989 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001004) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001084)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true"^^xsd:string) obo:CL_0002456 obo:CL_0000989)
 
@@ -28917,6 +28914,19 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023109 <ht
 AnnotationAssertion(rdfs:label obo:CL_4023109 "vasopressin-secreting magnocellular cell")
 EquivalentClasses(obo:CL_4023109 ObjectIntersectionOf(obo:CL_0011003 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0030103)))
 
+# Class: obo:CL_4023110 (amygdala pyramidal neuron)
+
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:1375860"^^xsd:string) obo:IAO_0000115 obo:CL_4023110 "A pyramidal neuron with soma located in the amygdala.")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023110 <http://orcid.org/0000-0001-7258-9596>)
+AnnotationAssertion(rdfs:label obo:CL_4023110 "amygdala pyramidal neuron")
+EquivalentClasses(obo:CL_4023110 ObjectIntersectionOf(obo:CL_0000598 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001876)))
+
+# Class: obo:CL_4023111 (cerebral cortex pyramidal neuron)
+
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30715238"^^xsd:string) obo:IAO_0000115 obo:CL_4023111 "A pyramidal neuron with soma located in the cerebral cortex.")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023111 <http://orcid.org/0000-0001-7258-9596>)
+AnnotationAssertion(rdfs:label obo:CL_4023111 "cerebral cortex pyramidal neuron")
+EquivalentClasses(obo:CL_4023111 ObjectIntersectionOf(obo:CL_0000598 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000956)))
 
 # Class: obo:CL_4023112 (vestibular afferent neuron)
 
@@ -28944,20 +28954,6 @@ SubClassOf(obo:CL_4023114 obo:CL_4023112)
 SubClassOf(obo:CL_4023114 ObjectSomeValuesFrom(obo:RO_0000053 obo:GO_0099096))
 SubClassOf(obo:CL_4023114 ObjectSomeValuesFrom(obo:RO_0002130 obo:CL_0002070))
 
-# Class: obo:CL_4023110 (amygdala pyramidal neuron)
-
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:1375860"^^xsd:string) obo:IAO_0000115 obo:CL_4023110 "A pyramidal neuron with soma located in the amygdala.")
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023110 <http://orcid.org/0000-0001-7258-9596>)
-AnnotationAssertion(rdfs:label obo:CL_4023110 "amygdala pyramidal neuron")
-EquivalentClasses(obo:CL_4023110 ObjectIntersectionOf(obo:CL_0000598 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001876)))
-
-# Class: obo:CL_4023111 (cerebral cortex pyramidal neuron)
-
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30715238"^^xsd:string) obo:IAO_0000115 obo:CL_4023111 "A pyramidal neuron with soma located in the cerebral cortex.")
-AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023111 <http://orcid.org/0000-0001-7258-9596>)
-AnnotationAssertion(rdfs:label obo:CL_4023111 "cerebral cortex pyramidal neuron")
-EquivalentClasses(obo:CL_4023111 ObjectIntersectionOf(obo:CL_0000598 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000956)))
-
 # Class: obo:CL_4023118 (L5/6 non-Martinotti morphology sst expressing GABAergic cortical internueron (Mus musculus))
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:27477017"^^xsd:string) obo:IAO_0000115 obo:CL_4023118 "A sst GABAergic interneuron does not have Martinotti morphology with a soma found in L5/6 of the cerebral cortex.")
@@ -28971,7 +28967,6 @@ SubClassOf(obo:CL_4023118 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000956
 SubClassOf(obo:CL_4023118 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_10090))
 SubClassOf(obo:CL_4023118 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534))
 SubClassOf(obo:CL_4023118 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_P60041))
-
 
 # Class: obo:CP_0000000 (neutrophillic cytoplasm)
 


### PR DESCRIPTION
This commit intends to fix typos in the labels of CL:0002455 and CL:0002456.
If applied, this commit will fix #1293.