### PR TITLE
Fix/normalize_xsdstring

### DIFF
--- a/docs/Fixing_xsdstring_diffs.md
+++ b/docs/Fixing_xsdstring_diffs.md
@@ -13,7 +13,7 @@ When you make edits, sometimes there will be large amounts of unintended differe
 
   If you do not have docker installed: ```make normalise_xsd_string```
 
-  If "make" is not installed, on MAC: ``` sed -i '' "s/Annotation[(]\(oboInOwl[:]hasDbXref [\"][^\"]*[\"]\)[)]/Annotation(\1^^xsd:string)/" cl-edit.owl ```
+  If "make" is not installed, on MAC: ``` sed -i '' "s/Annotation[(]\(oboInOwl[:]hasDbXref [\"][^\"]*[\"]\)[)]/Annotation(\1^^xsd:string)/g" cl-edit.owl ```
 
 
 This should resolve your ^^xsd:string issue, after which, you can handle your pull request as per usual.

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -3459,7 +3459,7 @@ DisjointClasses(obo:CL_0000050 obo:CL_0002009)
 
 # Class: obo:CL_0000051 (common lymphoid progenitor)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:10407577"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:16551251") obo:IAO_0000115 obo:CL_0000051 "A oligopotent progenitor cell committed to the lymphoid lineage."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:10407577"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:16551251"^^xsd:string) obo:IAO_0000115 obo:CL_0000051 "A oligopotent progenitor cell committed to the lymphoid lineage."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasAlternativeId obo:CL_0000051 "CL:0000044"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000051 "CLP"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000051 "common lymphocyte precursor"^^xsd:string)
@@ -3798,7 +3798,7 @@ SubClassOf(obo:CL_0000083 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000223))
 
 # Class: obo:CL_0000084 (T cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000084 "A type of lymphocyte whose defining characteristic is the expression of a T cell receptor complex."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000084 "A type of lymphocyte whose defining characteristic is the expression of a T cell receptor complex."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasAlternativeId obo:CL_0000084 "CL:0000804"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasAlternativeId obo:CL_0000084 "CL:0000812"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000084 "BTO:0000782"^^xsd:string)
@@ -3882,7 +3882,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000091 obo:CL_0000864
 
 # Class: obo:CL_0000092 (osteoclast)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") Annotation(oboInOwl:hasDbXref "PMID:10428500"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:15055519"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:17380158"^^xsd:string) obo:IAO_0000115 obo:CL_0000092 "A specialized phagocytic cell associated with the absorption and removal of the mineralized matrix of bone tissue, which typically differentiates from monocytes. This cell has the following markers: tartrate-resistant acid phosphatase type 5-positive, PU.1-positive, c-fos-positive, nuclear factor NF-kappa-B p100 subunit-positive, tumor necrosis factor receptor superfamily member 11A-positive and macrophage colony-stimulating factor 1 receptor-positive."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:10428500"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:15055519"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:17380158"^^xsd:string) obo:IAO_0000115 obo:CL_0000092 "A specialized phagocytic cell associated with the absorption and removal of the mineralized matrix of bone tissue, which typically differentiates from monocytes. This cell has the following markers: tartrate-resistant acid phosphatase type 5-positive, PU.1-positive, c-fos-positive, nuclear factor NF-kappa-B p100 subunit-positive, tumor necrosis factor receptor superfamily member 11A-positive and macrophage colony-stimulating factor 1 receptor-positive."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000092 "BTO:0000968"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000092 "CALOHA:TS-0721"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000092 "FMA:66781"^^xsd:string)
@@ -3949,7 +3949,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000096 obo:CL_0000775
 
 # Class: obo:CL_0000097 (mast cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:068340007X") Annotation(oboInOwl:hasDbXref "MESH:A11.329.427"^^xsd:string) Annotation(oboInOwl:hasDbXref "MESH:D008407"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMCID:PMC1312421"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMCID:PMC2855166"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:15153310"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:16455980"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:19671378"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:212366338"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:9354811"^^xsd:string) obo:IAO_0000115 obo:CL_0000097 "A cell that is found in almost all tissues containing numerous basophilic granules and capable of releasing large amounts of histamine and heparin upon activation. Progenitors leave bone marrow and mature in connective and mucosal tissue. Mature mast cells are found in all tissues, except the bloodstream. Their phenotype is CD117-high, CD123-negative, CD193-positive, CD200R3-positive, and FceRI-high. Stem-cell factor (KIT-ligand; SCF) is the main controlling signal of their survival and development."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:068340007X"^^xsd:string) Annotation(oboInOwl:hasDbXref "MESH:A11.329.427"^^xsd:string) Annotation(oboInOwl:hasDbXref "MESH:D008407"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMCID:PMC1312421"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMCID:PMC2855166"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:15153310"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:16455980"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:19671378"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:212366338"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:9354811"^^xsd:string) obo:IAO_0000115 obo:CL_0000097 "A cell that is found in almost all tissues containing numerous basophilic granules and capable of releasing large amounts of histamine and heparin upon activation. Progenitors leave bone marrow and mature in connective and mucosal tissue. Mature mast cells are found in all tissues, except the bloodstream. Their phenotype is CD117-high, CD123-negative, CD193-positive, CD200R3-positive, and FceRI-high. Stem-cell factor (KIT-ligand; SCF) is the main controlling signal of their survival and development."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000097 "BTO:0000830"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000097 "CALOHA:TS-0603"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000097 "FMA:66784"^^xsd:string)
@@ -4102,7 +4102,7 @@ SubClassOf(obo:CL_0000112 obo:CL_0000540)
 
 # Class: obo:CL_0000113 (mononuclear phagocyte)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000113 "A vertebrate phagocyte with a single nucleus."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000113 "A vertebrate phagocyte with a single nucleus."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000113 "BTO:0001433"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000113 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000113 "mononuclear phagocyte"^^xsd:string)
@@ -5345,7 +5345,7 @@ SubClassOf(obo:CL_0000235 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000576))
 
 # Class: obo:CL_0000236 (B cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000236 "A lymphocyte of B lineage that is capable of B cell mediated immunity."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000236 "A lymphocyte of B lineage that is capable of B cell mediated immunity."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000236 "BTO:0000776"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000236 "CALOHA:TS-0068"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000236 "FMA:62869"^^xsd:string)
@@ -7374,7 +7374,7 @@ AnnotationAssertion(owl:deprecated obo:CL_0000491 "true"^^xsd:boolean)
 
 # Class: obo:CL_0000492 (CD4-positive helper T cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:pam"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") Annotation(oboInOwl:hasDbXref "MESH:A11.118.637.555.567.569.200.400"^^xsd:string) obo:IAO_0000115 obo:CL_0000492 "A CD4-positive, alpha-beta T cell that cooperates with other lymphocytes via direct contact or cytokine release to initiate a variety of immune functions."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:pam"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) Annotation(oboInOwl:hasDbXref "MESH:A11.118.637.555.567.569.200.400"^^xsd:string) obo:IAO_0000115 obo:CL_0000492 "A CD4-positive, alpha-beta T cell that cooperates with other lymphocytes via direct contact or cytokine release to initiate a variety of immune functions."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000492 "CALOHA:TS-1146"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000492 "FMA:70572"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000492 "CD4-positive T-helper cell"^^xsd:string)
@@ -8706,7 +8706,7 @@ DisjointClasses(obo:CL_0000624 obo:CL_0000625)
 
 # Class: obo:CL_0000625 (CD8-positive, alpha-beta T cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000625 "A T cell expressing an alpha-beta T cell receptor and the CD8 coreceptor."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000625 "A T cell expressing an alpha-beta T cell receptor and the CD8 coreceptor."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000625 "CD8-positive, alpha-beta T lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000625 "CD8-positive, alpha-beta T-cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000625 "CD8-positive, alpha-beta T-lymphocyte"^^xsd:string)
@@ -10273,7 +10273,7 @@ SubClassOf(obo:CL_0000788 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000818))
 
 # Class: obo:CL_0000789 (alpha-beta T cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000789 "A T cell that expresses an alpha-beta T cell receptor complex."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000789 "A T cell that expresses an alpha-beta T cell receptor complex."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000789 "alpha-beta T lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000789 "alpha-beta T-cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000789 "alpha-beta T-lymphocyte"^^xsd:string)
@@ -10285,7 +10285,7 @@ DisjointClasses(obo:CL_0000789 obo:CL_0000798)
 
 # Class: obo:CL_0000790 (immature alpha-beta T cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000790 "An alpha-beta T cell that has an immature phenotype and has not completed T cell selection."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000790 "An alpha-beta T cell that has an immature phenotype and has not completed T cell selection."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000790 "immature alpha-beta T lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000790 "immature alpha-beta T-cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000790 "immature alpha-beta T-lymphocyte"^^xsd:string)
@@ -10296,7 +10296,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000790 obo:CL_0000789
 
 # Class: obo:CL_0000791 (mature alpha-beta T cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000791 "A alpha-beta T cell that has a mature phenotype."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000791 "A alpha-beta T cell that has a mature phenotype."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000791 "mature alpha-beta T lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000791 "mature alpha-beta T-cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000791 "mature alpha-beta T-lymphocyte"^^xsd:string)
@@ -10308,7 +10308,7 @@ SubClassOf(obo:CL_0000791 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000790))
 
 # Class: obo:CL_0000792 (CD4-positive, CD25-positive, alpha-beta regulatory T cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") Annotation(oboInOwl:hasDbXref "PMID:19464985"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:22343568"^^xsd:string) obo:IAO_0000115 obo:CL_0000792 "A CD4-positive, CD25-positive, alpha-beta T cell that regulates overall immune responses as well as the responses of other T cell subsets through direct cell-cell contact and cytokine release."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:19464985"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:22343568"^^xsd:string) obo:IAO_0000115 obo:CL_0000792 "A CD4-positive, CD25-positive, alpha-beta T cell that regulates overall immune responses as well as the responses of other T cell subsets through direct cell-cell contact and cytokine release."^^xsd:string)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:22343568"^^xsd:string) oboInOwl:hasBroadSynonym obo:CL_0000792 "Treg")
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000792 "suppressor T cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000792 "suppressor T lymphocyte"^^xsd:string)
@@ -10325,7 +10325,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000792 obo:CL_0000624
 
 # Class: obo:CL_0000793 (CD4-positive, alpha-beta intraepithelial T cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000793 "A CD4-positive, alpha-beta T cell that is found in the columnar epithelium of the gastrointestinal tract."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000793 "A CD4-positive, alpha-beta T cell that is found in the columnar epithelium of the gastrointestinal tract."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000793 "IEL"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000793 "intraepithelial lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000793 "CD4-positive, alpha-beta intraepithelial T lymphocyte"^^xsd:string)
@@ -10339,7 +10339,7 @@ SubClassOf(obo:CL_0000793 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000810))
 
 # Class: obo:CL_0000794 (CD8-positive, alpha-beta cytotoxic T cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:pam"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000794 "A CD8-positive, alpha-beta T cell that is capable of killing target cells in an antigen specific manner with the phenotype perforin-positive and granzyme B-positive."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:pam"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000794 "A CD8-positive, alpha-beta T cell that is capable of killing target cells in an antigen specific manner with the phenotype perforin-positive and granzyme B-positive."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000794 "cytotoxic T cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000794 "cytotoxic T lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000794 "cytotoxic T-cell"^^xsd:string)
@@ -10362,7 +10362,7 @@ SubClassOf(obo:CL_0000794 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000906))
 
 # Class: obo:CL_0000795 (CD8-positive, alpha-beta regulatory T cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000795 "A CD8-positive, alpha-beta T cell that regulates overall immune responses as well as the responses of other T cell subsets through direct cell-cell contact and cytokine release."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000795 "A CD8-positive, alpha-beta T cell that regulates overall immune responses as well as the responses of other T cell subsets through direct cell-cell contact and cytokine release."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000795 "suppressor T cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000795 "suppressor T lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000795 "suppressor T-cell"^^xsd:string)
@@ -10396,7 +10396,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000796 obo:CL_0000797
 
 # Class: obo:CL_0000797 (alpha-beta intraepithelial T cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000797 "A mature alpha-beta T cell of the columnar epithelium of the gastrointestinal tract. Intraepithelial T cells often have distinct developmental pathways and activation requirements."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000797 "A mature alpha-beta T cell of the columnar epithelium of the gastrointestinal tract. Intraepithelial T cells often have distinct developmental pathways and activation requirements."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000797 "IEL"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000797 "intraepithelial lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000797 "alpha-beta intraepithelial T lymphocyte"^^xsd:string)
@@ -10409,7 +10409,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000797 obo:CL_0000791
 
 # Class: obo:CL_0000798 (gamma-delta T cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000798 "A T cell that expresses a gamma-delta T cell receptor complex."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000798 "A T cell that expresses a gamma-delta T cell receptor complex."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000798 "gamma-delta T lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000798 "gamma-delta T-cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000798 "gamma-delta T-lymphocyte"^^xsd:string)
@@ -10436,7 +10436,7 @@ SubClassOf(obo:CL_0000799 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000807))
 
 # Class: obo:CL_0000800 (mature gamma-delta T cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000800 "A gamma-delta T cell that has a mature phenotype. These cells can be found in tissues and circulation where they express unique TCR repertoire depending on their location."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000800 "A gamma-delta T cell that has a mature phenotype. These cells can be found in tissues and circulation where they express unique TCR repertoire depending on their location."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000800 "mature gamma-delta T lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000800 "mature gamma-delta T-cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000800 "mature gamma-delta T-lymphocyte"^^xsd:string)
@@ -10448,7 +10448,7 @@ SubClassOf(obo:CL_0000800 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000799))
 
 # Class: obo:CL_0000801 (gamma-delta intraepithelial T cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000801 "A mature gamma-delta T cell that is found in the columnar epithelium of the gastrointestinal tract. These cells participate in mucosal immune responses."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000801 "A mature gamma-delta T cell that is found in the columnar epithelium of the gastrointestinal tract. These cells participate in mucosal immune responses."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000801 "IEL"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000801 "intraepithelial lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000801 "gamma-delta intraepithelial T lymphocyte"^^xsd:string)
@@ -10461,7 +10461,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000801 obo:CL_0000800
 
 # Class: obo:CL_0000802 (CD8-alpha alpha positive, gamma-delta intraepithelial T cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000802 "A gamma-delta intraepithelial T cell that has the phenotype CD8-alpha alpha-positive."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000802 "A gamma-delta intraepithelial T cell that has the phenotype CD8-alpha alpha-positive."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000802 "IEL"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000802 "intraepithelial lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000802 "CD8-positive, gamma-delta intraepithelial T lymphocyte"^^xsd:string)
@@ -10474,7 +10474,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000802 obo:CL_0000801
 
 # Class: obo:CL_0000803 (CD4-negative CD8-negative gamma-delta intraepithelial T cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000803 "A gamma-delta intraepithelial T cell that has the phenotype CD4-negative and CD8-negative."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000803 "A gamma-delta intraepithelial T cell that has the phenotype CD4-negative and CD8-negative."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000803 "IEL"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000803 "intraepithelial lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000803 "CD4-positive, gamma-delta intraepithelial T lymphocyte"^^xsd:string)
@@ -10487,7 +10487,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000803 obo:CL_0000801
 
 # Class: obo:CL_0000805 (immature single positive thymocyte)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") Annotation(oboInOwl:hasDbXref "http://www.immgen.org/index_content.html"^^xsd:string) obo:IAO_0000115 obo:CL_0000805 "A thymocyte that has the phenotype CD4-negative, CD8-positive, CD44-negative, CD25-negative, and pre-TCR-positive."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) Annotation(oboInOwl:hasDbXref "http://www.immgen.org/index_content.html"^^xsd:string) obo:IAO_0000115 obo:CL_0000805 "A thymocyte that has the phenotype CD4-negative, CD8-positive, CD44-negative, CD25-negative, and pre-TCR-positive."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000805 "ISP"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000805 "T.ISP.th"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000805 "immature single positive T cell"^^xsd:string)
@@ -10502,7 +10502,7 @@ SubClassOf(obo:CL_0000805 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000808))
 
 # Class: obo:CL_0000806 (DN2 thymocyte)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000806 "A thymocyte that has the phenotype CD4-negative, CD8-negative, CD44-positive, and CD25-positive."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000806 "A thymocyte that has the phenotype CD4-negative, CD8-negative, CD44-positive, and CD25-positive."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000806 "DN2 alpha-beta immature T lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000806 "DN2 alpha-beta immature T-cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000806 "DN2 alpha-beta immature T-lymphocyte"^^xsd:string)
@@ -10520,7 +10520,7 @@ SubClassOf(obo:CL_0000806 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000894))
 
 # Class: obo:CL_0000807 (DN3 thymocyte)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000807 "A thymocyte that has the phenotype CD4-negative, CD8-negative, CD44-negative, and CD25-positive and expressing the T cell receptor beta-chain in complex with the pre-T cell receptor alpha chain."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000807 "A thymocyte that has the phenotype CD4-negative, CD8-negative, CD44-negative, and CD25-positive and expressing the T cell receptor beta-chain in complex with the pre-T cell receptor alpha chain."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000807 "early cortical thymocyte")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000807 "DN3 alpha-beta immature T lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000807 "DN3 alpha-beta immature T-cell"^^xsd:string)
@@ -10539,7 +10539,7 @@ SubClassOf(obo:CL_0000807 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000806))
 
 # Class: obo:CL_0000808 (DN4 thymocyte)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000808 "A thymocyte that has the phenotype CD4-negative, CD8-negative, CD44-negative, CD25-negative, and pre-TCR-positive."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000808 "A thymocyte that has the phenotype CD4-negative, CD8-negative, CD44-negative, CD25-negative, and pre-TCR-positive."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000808 "early cortical thymocyte")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000808 "DN4 alpha-beta immature T lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000808 "DN4 alpha-beta immature T-lymphocyte"^^xsd:string)
@@ -10556,7 +10556,7 @@ SubClassOf(obo:CL_0000808 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000807))
 
 # Class: obo:CL_0000809 (double-positive, alpha-beta thymocyte)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000809 "A thymocyte expressing the alpha-beta T cell receptor complex as well as both the CD4 and CD8 coreceptors."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000809 "A thymocyte expressing the alpha-beta T cell receptor complex as well as both the CD4 and CD8 coreceptors."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000809 "late cortical thymocyte")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000809 "DP cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000809 "DP thymocyte"^^xsd:string)
@@ -10570,7 +10570,7 @@ SubClassOf(obo:CL_0000809 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000805))
 
 # Class: obo:CL_0000810 (CD4-positive, alpha-beta thymocyte)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000810 "An immature alpha-beta T cell that is located in the thymus and is CD4-positive and CD8-negative."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000810 "An immature alpha-beta T cell that is located in the thymus and is CD4-positive and CD8-negative."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000810 "CD4-positive, alpha-beta immature T lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000810 "CD4-positive, alpha-beta immature T-cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000810 "CD4-positive, alpha-beta immature T-lymphocyte"^^xsd:string)
@@ -10583,7 +10583,7 @@ SubClassOf(obo:CL_0000810 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000809))
 
 # Class: obo:CL_0000811 (CD8-positive, alpha-beta thymocyte)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000811 "An immature alpha-beta T cell that is located in the thymus and is CD8-positive and CD4-negative."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000811 "An immature alpha-beta T cell that is located in the thymus and is CD8-positive and CD4-negative."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000811 "CD8-positive, alpha-beta immature T lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000811 "CD8-positive, alpha-beta immature T-cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000811 "CD8-positive, alpha-beta immature T-lymphocyte"^^xsd:string)
@@ -10597,7 +10597,7 @@ SubClassOf(obo:CL_0000811 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000809))
 
 # Class: obo:CL_0000813 (memory T cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:pam"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000813 "A long-lived, antigen-experienced T cell that has acquired a memory phenotype including distinct surface markers and the ability to differentiate into an effector T cell upon antigen reexposure."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:pam"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000813 "A long-lived, antigen-experienced T cell that has acquired a memory phenotype including distinct surface markers and the ability to differentiate into an effector T cell upon antigen reexposure."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000813 "BTO:0003435"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000813 "memory T lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000813 "memory T-cell"^^xsd:string)
@@ -10646,7 +10646,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000815 obo:CL_0002419
 
 # Class: obo:CL_0000816 (immature B cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") Annotation(oboInOwl:hasDbXref "PMID:20081059"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:20839338"^^xsd:string) obo:IAO_0000115 obo:CL_0000816 "An immature B cell is a B cell that has the phenotype surface IgM-positive and surface IgD-negative, and have not undergone class immunoglobulin class switching or peripheral encounter with antigen and activation."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:20081059"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:20839338"^^xsd:string) obo:IAO_0000115 obo:CL_0000816 "An immature B cell is a B cell that has the phenotype surface IgM-positive and surface IgD-negative, and have not undergone class immunoglobulin class switching or peripheral encounter with antigen and activation."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000816 "immature B lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000816 "immature B-cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000816 "immature B-lymphocyte"^^xsd:string)
@@ -10742,7 +10742,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000821 obo:CL_0000819
 
 # Class: obo:CL_0000822 (B-2 B cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") Annotation(oboInOwl:hasDbXref "PMID:11861604"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:20933013"^^xsd:string) obo:IAO_0000115 obo:CL_0000822 "A conventional B cell subject to antigenic stimulation and dependent on T cell help and with a distinct surface marker expression pattern from B-1 B cells. These cells are CD43-negative."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:11861604"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:20933013"^^xsd:string) obo:IAO_0000115 obo:CL_0000822 "A conventional B cell subject to antigenic stimulation and dependent on T cell help and with a distinct surface marker expression pattern from B-1 B cells. These cells are CD43-negative."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000822 "B-2 B lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000822 "B-2 B-cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000822 "B-2 B-lymphocyte"^^xsd:string)
@@ -10799,7 +10799,7 @@ SubClassOf(obo:CL_0000825 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000051))
 
 # Class: obo:CL_0000826 (pro-B cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:12633665"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:16551251") Annotation(oboInOwl:hasDbXref "PMID:18432934"^^xsd:string) obo:IAO_0000115 obo:CL_0000826 "A progenitor cell of the B cell lineage, with some lineage specific activity such as early stages of recombination of B cell receptor genes, but not yet fully committed to the B cell lineage until the expression of PAX5 occurs."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:12633665"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:16551251"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:18432934"^^xsd:string) obo:IAO_0000115 obo:CL_0000826 "A progenitor cell of the B cell lineage, with some lineage specific activity such as early stages of recombination of B cell receptor genes, but not yet fully committed to the B cell lineage until the expression of PAX5 occurs."^^xsd:string)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:17582343"^^xsd:string) oboInOwl:hasBroadSynonym obo:CL_0000826 "pre-pro B cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000826 "BTO:0003104"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000826 "pro-B lymphocyte"^^xsd:string)
@@ -11019,7 +11019,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000843 obo:CL_0000785
 
 # Class: obo:CL_0000844 (germinal center B cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") Annotation(oboInOwl:hasDbXref "PMID:19447676"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:20933013"^^xsd:string) obo:IAO_0000115 obo:CL_0000844 "A rapidly cycling mature B cell that has distinct phenotypic characteristics and is involved in T-dependent immune responses and located typically in the germinal centers of lymph nodes. This cell type expresses Ly77 after activation."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:19447676"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:20933013"^^xsd:string) obo:IAO_0000115 obo:CL_0000844 "A rapidly cycling mature B cell that has distinct phenotypic characteristics and is involved in T-dependent immune responses and located typically in the germinal centers of lymph nodes. This cell type expresses Ly77 after activation."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000844 "GC B cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000844 "GC B lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000844 "GC B-cell"^^xsd:string)
@@ -11582,7 +11582,7 @@ SubClassOf(obo:CL_0000899 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000896))
 
 # Class: obo:CL_0000900 (naive thymus-derived CD8-positive, alpha-beta T cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") Annotation(oboInOwl:hasDbXref "PMID:22343568"^^xsd:string) Annotation(oboInOwl:hasDbXref "http://www.immgen.org/index_content.html"^^xsd:string) obo:IAO_0000115 obo:CL_0000900 "A CD8-positive, alpha-beta T cell that has not experienced activation via antigen contact and has the phenotype CD45RA-positive, CCR7-positive and CD127-positive. This cell type is also described as being CD25-negative, CD62L-high and CD44-low."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:22343568"^^xsd:string) Annotation(oboInOwl:hasDbXref "http://www.immgen.org/index_content.html"^^xsd:string) obo:IAO_0000115 obo:CL_0000900 "A CD8-positive, alpha-beta T cell that has not experienced activation via antigen contact and has the phenotype CD45RA-positive, CCR7-positive and CD127-positive. This cell type is also described as being CD25-negative, CD62L-high and CD44-low."^^xsd:string)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:22343568"^^xsd:string) oboInOwl:hasBroadSynonym obo:CL_0000900 "naive CD8+ T cell")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000900 "naive thymus-dervied CD8-positive, alpha-beta T lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000900 "naive thymus-dervied CD8-positive, alpha-beta T-cell"^^xsd:string)
@@ -12114,7 +12114,7 @@ SubClassOf(obo:CL_0000936 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0002035))
 
 # Class: obo:CL_0000937 (pre-natural killer cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:pam"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:16551251") Annotation(oboInOwl:hasDbXref "PMID:17100874"^^xsd:string) obo:IAO_0000115 obo:CL_0000937 "Cell committed to natural killer cell lineage that has the phenotype CD122-positive, CD34-positive, and CD117-positive. This cell type lacks expression of natural killer receptor proteins."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:pam"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:16551251"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:17100874"^^xsd:string) obo:IAO_0000115 obo:CL_0000937 "Cell committed to natural killer cell lineage that has the phenotype CD122-positive, CD34-positive, and CD117-positive. This cell type lacks expression of natural killer receptor proteins."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000937 "pre-NK cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000937 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0000937 "These cells are also reportedly CD7-low, CD10-negative, CD45RA-positive, alpha-4-beta-7 integrin-high."^^xsd:string)
@@ -12203,7 +12203,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000944 obo:CL_0000968
 
 # Class: obo:CL_0000945 (lymphocyte of B lineage)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000945 "A lymphocyte of B lineage with the commitment to express an immunoglobulin complex."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000945 "A lymphocyte of B lineage with the commitment to express an immunoglobulin complex."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000945 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0000945 "Types of B lineage lymphocytes include B cells and antibody secreting cells (plasmablasts and plasma cells).  Lymphocytes of B cell lineage can be distinguished from those of T cell lineage by their lack of CD3e (as part of the T cell receptor complex)."^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000945 "lymphocyte of B lineage"^^xsd:string)
@@ -12212,7 +12212,7 @@ SubClassOf(obo:CL_0000945 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000826))
 
 # Class: obo:CL_0000946 (antibody secreting cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0721601464"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") obo:IAO_0000115 obo:CL_0000946 "A lymphocyte of B lineage that is devoted to secreting large amounts of immunoglobulin."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0721601464"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) obo:IAO_0000115 obo:CL_0000946 "A lymphocyte of B lineage that is devoted to secreting large amounts of immunoglobulin."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000946 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000946 "antibody secreting cell"^^xsd:string)
 EquivalentClasses(obo:CL_0000946 ObjectIntersectionOf(obo:CL_0000945 ObjectSomeValuesFrom(obo:RO_0003000 obo:GO_0042571)))
@@ -13061,7 +13061,7 @@ DisjointClasses(obo:CL_0001023 obo:CL_0001026)
 
 # Class: obo:CL_0001024 (CD34-positive, CD38-negative hematopoietic stem cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:amm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:10430905"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:11750107"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:16551251") Annotation(oboInOwl:hasDbXref "PMID:20024907"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:9389721"^^xsd:string) obo:IAO_0000115 obo:CL_0001024 "CD133-positive hematopoietic stem cell is a hematopoietic stem cell that is CD34-positive, CD90-positive, and CD133-positive."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:amm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:10430905"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:11750107"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:16551251"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:20024907"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:9389721"^^xsd:string) obo:IAO_0000115 obo:CL_0001024 "CD133-positive hematopoietic stem cell is a hematopoietic stem cell that is CD34-positive, CD90-positive, and CD133-positive."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0001024 "CALOHA:TS-0448"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0001024 "FMA:86475"^^xsd:string)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:16140871"^^xsd:string) oboInOwl:hasExactSynonym obo:CL_0001024 "CD133-positive hematopoietic stem cell"^^xsd:string)
@@ -13427,7 +13427,7 @@ SubClassOf(obo:CL_0001058 obo:CL_0000784)
 
 # Class: obo:CL_0001059 (common myeloid progenitor, CD34-positive)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0878932437") Annotation(oboInOwl:hasDbXref "PMCID:PMC2212039"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:10724173"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:16551251") Annotation(oboInOwl:hasDbXref "PMID:16647566"^^xsd:string) obo:IAO_0000115 obo:CL_0001059 "A progenitor cell committed to myeloid lineage, including the megakaryocyte and erythroid lineages. These cells are CD34-positive, and express Gata1, Gata2, C/EBPa, and Pu.1.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0878932437"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMCID:PMC2212039"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:10724173"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:16551251"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:16647566"^^xsd:string) obo:IAO_0000115 obo:CL_0001059 "A progenitor cell committed to myeloid lineage, including the megakaryocyte and erythroid lineages. These cells are CD34-positive, and express Gata1, Gata2, C/EBPa, and Pu.1.")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "ISBN:0878932437"^^xsd:string) oboInOwl:hasBroadSynonym obo:CL_0001059 "CMP")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0001059 "common myeloid precursor, CD34-positive")
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0001059 "cell")
@@ -13728,7 +13728,7 @@ SubClassOf(obo:CL_0001203 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000906))
 
 # Class: obo:CL_0001204 (CD4-positive, alpha-beta memory T cell, CD45RO-positive)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149") Annotation(oboInOwl:hasDbXref "http://www.immgen.org/index_content.html"^^xsd:string) obo:IAO_0000115 obo:CL_0001204 "CD4-positive, alpha-beta long-lived T cell with the phenotype CD45RO-positive and CD127-positive. This cell type is also described as being CD25-negative, CD44-high, and CD122-high."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0781735149"^^xsd:string) Annotation(oboInOwl:hasDbXref "http://www.immgen.org/index_content.html"^^xsd:string) obo:IAO_0000115 obo:CL_0001204 "CD4-positive, alpha-beta long-lived T cell with the phenotype CD45RO-positive and CD127-positive. This cell type is also described as being CD25-negative, CD44-high, and CD122-high."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0001204 "CD4-positive, alpha-beta memory T lymphocyte, CD45RO-positive"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0001204 "CD4-positive, alpha-beta memory T-cell, CD45RO-positive"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0001204 "CD4-positive, alpha-beta memory T-lymphocyte, CD45RO-positive"^^xsd:string)
@@ -18175,7 +18175,7 @@ SubClassOf(obo:CL_0002373 obo:CL_0000167)
 
 # Class: obo:CL_0002374 (ear hair cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:dph"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0192801023") obo:IAO_0000115 obo:CL_0002374 "A hair cell of the ear that contains the organs of balance and hearing."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:dph"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0192801023"^^xsd:string) obo:IAO_0000115 obo:CL_0002374 "A hair cell of the ear that contains the organs of balance and hearing."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:CL_0002374 "tmeehan"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002374 "2010-09-24T01:49:31Z"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0002374 "ear receptor cell"^^xsd:string)
@@ -18196,7 +18196,7 @@ SubClassOf(obo:CL_0002375 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000333))
 
 # Class: obo:CL_0002376 (non-myelinating Schwann cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:cvs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0721662544") obo:IAO_0000115 obo:CL_0002376 "A glial cell that ensheaths multiple small diameter axons in the peripheral nervous system. The non-myelinating Schwann cell is embedded among neurons (axons) with minimal extracellular spaces separating them from nerve cell membranes and has a basal lamina. Cells can survive without an axon present. These cells can de-differentiate into immature Schwann cells."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:cvs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0721662544"^^xsd:string) obo:IAO_0000115 obo:CL_0002376 "A glial cell that ensheaths multiple small diameter axons in the peripheral nervous system. The non-myelinating Schwann cell is embedded among neurons (axons) with minimal extracellular spaces separating them from nerve cell membranes and has a basal lamina. Cells can survive without an axon present. These cells can de-differentiate into immature Schwann cells."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:CL_0002376 "tmeehan"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002376 "2010-09-24T02:10:26Z"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0002376 "Schwann cell"^^xsd:string)
@@ -18207,7 +18207,7 @@ SubClassOf(obo:CL_0002376 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0002377))
 
 # Class: obo:CL_0002377 (immature Schwann cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:cvs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0721662544") obo:IAO_0000115 obo:CL_0002377 "A glial cell that develops from a Schwann cell precursor. The immature Schwann cell is embedded among neurons (axons) with minimal extracellular spaces separating them from nerve cell membranes and has a basal lamina. Cells can survive without an axon present. Immature Schwann cell can be found communally ensheathing large groups of axons."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:cvs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0721662544"^^xsd:string) obo:IAO_0000115 obo:CL_0002377 "A glial cell that develops from a Schwann cell precursor. The immature Schwann cell is embedded among neurons (axons) with minimal extracellular spaces separating them from nerve cell membranes and has a basal lamina. Cells can survive without an axon present. Immature Schwann cell can be found communally ensheathing large groups of axons."^^xsd:string)
 AnnotationAssertion(oboInOwl:created_by obo:CL_0002377 "tmeehan"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002377 "2010-09-24T02:10:31Z"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0002377 "Schwann cell"^^xsd:string)

--- a/src/ontology/cl.Makefile
+++ b/src/ontology/cl.Makefile
@@ -272,7 +272,7 @@ all_reports: reports/obo-diff.txt
 
 
 normalise_xsd_string: $(SRC)
-	sed -i.bak -E "s/Annotation[(](oboInOwl[:]hasDbXref [\"][^\"]*[\"])[)]/Annotation(\1^^xsd:string)/" $<
+	sed -i.bak -E "s/Annotation[(](oboInOwl[:]hasDbXref [\"][^\"]*[\"])[)]/Annotation(\1^^xsd:string)/g" $<
 	rm $<.bak
 
 ALL_PATTERNS=$(patsubst ../patterns/dosdp-patterns/%.yaml,%,$(wildcard ../patterns/dosdp-patterns/[a-z]*.yaml))


### PR DESCRIPTION
The previous PR did not include all xsdstring fixes. I added the global flag "g" to the end of the sed command to ensure all hasDbXref annotations within a single line are updated, not just the first one. This ensures that the command does not need to be run multiple times.