### PR TITLE
obsoleting PV-like terms

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -28669,19 +28669,15 @@ SubClassOf(obo:CL_4023031 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_1009
 SubClassOf(obo:CL_4023031 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534))
 SubClassOf(obo:CL_4023031 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_P60041))
 
-# Class: obo:CL_4023034 (L2/3 pvalb-like sst GABAergic cortical interneuron (Mus musculus))
+# Class: obo:CL_4023034 (obsolete L2/3 pvalb-like sst GABAergic cortical interneuron (Mus musculus))
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:33184512"^^xsd:string) obo:IAO_0000115 obo:CL_4023034 "A sst GABAergic cortical interneuron transcriptomically between the sst and the pvalb families with a soma found in L2/3. Some L2/3 PV-like sst cells have Martinotti morphology while some have basket cell morphology. L2/3 PV-like sst cells have lower AP width and higher firing rate than typical Sst subclass cells. L2/3 PV-like sst cells have high maximum firing rate variability, with many classified as belonging to the pvalb subclass on the basis of electrophysiology.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:33184512"^^xsd:string) obo:IAO_0000115 obo:CL_4023034 "OBSOLETE A sst GABAergic cortical interneuron transcriptomically between the sst and the pvalb families with a soma found in L2/3. Some L2/3 PV-like sst cells have Martinotti morphology while some have basket cell morphology. L2/3 PV-like sst cells have lower AP width and higher firing rate than typical Sst subclass cells. L2/3 PV-like sst cells have high maximum firing rate variability, with many classified as belonging to the pvalb subclass on the basis of electrophysiology.")
+AnnotationAssertion(obo:IAO_0100001 obo:CL_4023034 "PCL:1000002")
 AnnotationAssertion(oboInOwl:created_by obo:CL_4023034 <http://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4023034 "L2/3 PV-like SST Mus)")
-AnnotationAssertion(oboInOwl:inSubset obo:CL_4023034 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
-AnnotationAssertion(rdfs:label obo:CL_4023034 "L2/3 pvalb-like sst GABAergic cortical interneuron (Mus musculus)")
-SubClassOf(obo:CL_4023034 obo:CL_0000099)
-SubClassOf(obo:CL_4023034 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000956))
-SubClassOf(obo:CL_4023034 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_8440000))
-SubClassOf(obo:CL_4023034 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_10090))
-SubClassOf(obo:CL_4023034 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534))
-SubClassOf(obo:CL_4023034 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_P60041))
+AnnotationAssertion(rdfs:comment obo:CL_4023034 "Moved to PCL - see https://github.com/obophenotype/brain_data_standards_ontologies/issues/231. Use PCL:1000002 instead.")
+AnnotationAssertion(rdfs:label obo:CL_4023034 "obsolete L2/3 pvalb-like sst GABAergic cortical interneuron (Mus musculus)")
+AnnotationAssertion(owl:deprecated obo:CL_4023034 "true"^^xsd:boolean)
 
 # Class: obo:CL_4023036 (chandelier pvalb GABAergic cortical interneuron)
 
@@ -28919,15 +28915,15 @@ AnnotationAssertion(oboInOwl:inSubset obo:CL_4023066 <http://purl.obolibrary.org
 AnnotationAssertion(rdfs:label obo:CL_4023066 "horizontal pyramidal neuron")
 EquivalentClasses(obo:CL_4023066 ObjectIntersectionOf(obo:CL_0000117 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0070016)))
 
-# Class: obo:CL_4023067 (Martinotti morphology L2/3 pvalb-like sst GABAergic cortical interneuron (Mus musculus))
+# Class: obo:CL_4023067 (obsolete Martinotti morphology L2/3 pvalb-like sst GABAergic cortical interneuron (Mus musculus))
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:33184512"^^xsd:string) obo:IAO_0000115 obo:CL_4023067 "A L2/3 pvalb-like sst GABAergic cortical interneuron (Mus musculus) that has Martinotti morphology.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:33184512"^^xsd:string) obo:IAO_0000115 obo:CL_4023067 "OBSOLETE A L2/3 pvalb-like sst GABAergic cortical interneuron (Mus musculus) that has Martinotti morphology.")
+AnnotationAssertion(obo:IAO_0100001 obo:CL_4023067 "PCL:1000004")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023067 <http://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4023067 "Martinotti L2/3 PV-like SST (Mus)")
-AnnotationAssertion(oboInOwl:inSubset obo:CL_4023067 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
-AnnotationAssertion(rdfs:label obo:CL_4023067 "Martinotti morphology L2/3 pvalb-like sst GABAergic cortical interneuron (Mus musculus)")
-SubClassOf(obo:CL_4023067 obo:CL_4023034)
-SubClassOf(obo:CL_4023067 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0070007))
+AnnotationAssertion(rdfs:comment obo:CL_4023067 "Moved to PCL - see https://github.com/obophenotype/brain_data_standards_ontologies/issues/231. Use PCL:1000004 instead.")
+AnnotationAssertion(rdfs:label obo:CL_4023067 "obsolete Martinotti morphology L2/3 pvalb-like sst GABAergic cortical interneuron (Mus musculus)")
+AnnotationAssertion(owl:deprecated obo:CL_4023067 "true"^^xsd:boolean)
 
 # Class: obo:CL_4023069 (medial ganglionic eminence derived GABAergic cortical interneuron)
 
@@ -28977,15 +28973,15 @@ AnnotationAssertion(oboInOwl:inSubset obo:CL_4023077 <http://purl.obolibrary.org
 AnnotationAssertion(rdfs:label obo:CL_4023077 "bitufted neuron")
 EquivalentClasses(obo:CL_4023077 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0070012)))
 
-# Class: obo:CL_4023078 (basket morphology L2/3 pvalb-like sst GABAergic cortical interneuron (Mus musculus))
+# Class: obo:CL_4023078 (obsolete basket morphology L2/3 pvalb-like sst GABAergic cortical interneuron (Mus musculus))
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:33184512"^^xsd:string) obo:IAO_0000115 obo:CL_4023078 "A L2/3 pvalb-like sst GABAergic cortical interneuron (Mus musculus) that has basket morphology.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:33184512"^^xsd:string) obo:IAO_0000115 obo:CL_4023078 "OBSOLETE A L2/3 pvalb-like sst GABAergic cortical interneuron (Mus musculus) that has basket morphology.")
+AnnotationAssertion(obo:IAO_0100001 obo:CL_4023078 "PCL:1000003")
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023078 <http://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4023078 "basket L2/3 PV-like SST (Mus)")
-AnnotationAssertion(oboInOwl:inSubset obo:CL_4023078 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
-AnnotationAssertion(rdfs:label obo:CL_4023078 "basket morphology L2/3 pvalb-like sst GABAergic cortical interneuron (Mus musculus)")
-SubClassOf(obo:CL_4023078 obo:CL_4023034)
-SubClassOf(obo:CL_4023078 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0070002))
+AnnotationAssertion(rdfs:comment obo:CL_4023078 "Moved to PCL - see https://github.com/obophenotype/brain_data_standards_ontologies/issues/231. Use PCL:1000003 instead.")
+AnnotationAssertion(rdfs:label obo:CL_4023078 "obsolete basket morphology L2/3 pvalb-like sst GABAergic cortical interneuron (Mus musculus)")
+AnnotationAssertion(owl:deprecated obo:CL_4023078 "true"^^xsd:boolean)
 
 # Class: obo:CL_4023080 (stellate L6 intratelencephalic projecting glutamatergic neuron of the primary motor cortex (Mus musculus))
 


### PR DESCRIPTION
Related to https://github.com/obophenotype/brain_data_standards_ontologies/issues/231
moving PV-like terms to PCL