### PR TITLE
Typo fix issue #1368

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -6321,7 +6321,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000358 obo:CL_0000192
 
 # Class: obo:CL_0000359 (vascular associated smooth muscle cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) obo:IAO_0000115 obo:CL_0000359 "A smooth muscle cell assocatiated with the vasculature."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:dsd"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) obo:IAO_0000115 obo:CL_0000359 "A smooth muscle cell associated with the vasculature."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000359 "VSMC"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000359 "vascular smooth muscle cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000359 "cell"^^xsd:string)


### PR DESCRIPTION
Fix typo in def of CL:0000359 vascular associated smooth muscle cell #1368

Third time is a charm... I will appreciate your review of this change.

After running the reasoner, I do see owl:Nothing turn red in the class hierarchy, but I don't see the inferred disjoints like before.

The ^^xsd:string issue also disappeared after following the instructions here: https://obophenotype.github.io/cell-ontology/Fixing_xsdstring_diffs/