### PR TITLE
Switching has_(not)_completed to RO terms

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -2705,10 +2705,8 @@ Declaration(ObjectProperty(obo:RO_0002202))
 Declaration(ObjectProperty(obo:RO_0002215))
 Declaration(ObjectProperty(obo:RO_0002292))
 Declaration(ObjectProperty(obo:RO_0013001))
-Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/cl#has_completed>))
 Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount>))
 Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/cl#has_low_plasma_membrane_amount>))
-Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/cl#has_not_completed>))
 Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/cl#lacks_part>))
 Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part>))
 Declaration(AnnotationProperty(<http://geneontology.org/formats/oboInOwl#created_by>))
@@ -2869,10 +2867,6 @@ AnnotationAssertion(rdfs:label rdfs:seeAlso "see also"^^xsd:string)
 #   Object Properties
 ############################
 
-# Object Property: <http://purl.obolibrary.org/obo/cl#has_completed> (has_completed)
-
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/cl#has_completed> "has_completed"^^xsd:string)
-
 # Object Property: <http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount> (has_high_plasma_membrane_amount)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:19243617"^^xsd:string) obo:IAO_0000115 <http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount> "A relation between a cell and molecule or complex such that every instance of the cell has a high number of instances of that molecule expressed on the cell surface. For the formal definition, see Masci et al (PMID:19243617)."^^xsd:string)
@@ -2884,10 +2878,6 @@ SubObjectPropertyOf(<http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:19243617"^^xsd:string) obo:IAO_0000115 <http://purl.obolibrary.org/obo/cl#has_low_plasma_membrane_amount> "A relation between a cell and molecule or complex such that every instance of the cell has a low number of instances of that molecule expressed on the cell surface. For the formal definition, see Masci et al (PMID:19243617)."^^xsd:string)
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/cl#has_low_plasma_membrane_amount> "has_low_plasma_membrane_amount"^^xsd:string)
 SubObjectPropertyOf(<http://purl.obolibrary.org/obo/cl#has_low_plasma_membrane_amount> obo:RO_0002104)
-
-# Object Property: <http://purl.obolibrary.org/obo/cl#has_not_completed> (has_not_completed)
-
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/cl#has_not_completed> "has_not_completed"^^xsd:string)
 
 # Object Property: <http://purl.obolibrary.org/obo/cl#lacks_part> (lacks_part)
 
@@ -7412,7 +7402,7 @@ AnnotationAssertion(rdfs:label obo:CL_0000492 "CD4-positive helper T cell"^^xsd:
 EquivalentClasses(obo:CL_0000492 ObjectIntersectionOf(obo:CL_0000624 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0001816)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000492 obo:CL_0000624)
 SubClassOf(obo:CL_0000492 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000896))
-SubClassOf(obo:CL_0000492 ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0030217))
+SubClassOf(obo:CL_0000492 ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0030217))
 
 # Class: obo:CL_0000493 (obsolete regulatory T cell)
 
@@ -9035,7 +9025,7 @@ AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000654 "FMA:18645"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000654 "cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasRelatedSynonym obo:CL_0000654 "primary oogonium"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000654 "primary oocyte"^^xsd:string)
-EquivalentClasses(obo:CL_0000654 ObjectIntersectionOf(obo:CL_0000023 ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_not_completed> obo:GO_0051321)))
+EquivalentClasses(obo:CL_0000654 ObjectIntersectionOf(obo:CL_0000023 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0051321)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000654 obo:CL_0000023)
 SubClassOf(obo:CL_0000654 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000024))
 
@@ -9047,7 +9037,7 @@ AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000655 "FMA:18646"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000655 "cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasRelatedSynonym obo:CL_0000655 "primary oogonium"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000655 "secondary oocyte"^^xsd:string)
-EquivalentClasses(obo:CL_0000655 ObjectIntersectionOf(obo:CL_0000023 ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_not_completed> obo:GO_0007147)))
+EquivalentClasses(obo:CL_0000655 ObjectIntersectionOf(obo:CL_0000023 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0007147)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000655 obo:CL_0000023)
 SubClassOf(obo:CL_0000655 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000654))
 
@@ -10254,7 +10244,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000785 "mature B-lymphocyte
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000785 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0000785 "Mature B cells are also reportedly CD10-negative, CD19-positive, CD22-positive, CD34-negative, CD48-positive, CD79a-positive, CD84-positive, CD127-negative, CD352-positive, RAG-negative, TdT-negative, Vpre-B-negative, and pre-BCR-negative. Transcription factors expressed: Pax5-positive."^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000785 "mature B cell"^^xsd:string)
-EquivalentClasses(obo:CL_0000785 ObjectIntersectionOf(obo:CL_0001201 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0002504) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0042113) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0002335)))
+EquivalentClasses(obo:CL_0000785 ObjectIntersectionOf(obo:CL_0001201 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0002504) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0042113) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0002335)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000785 obo:CL_0001201)
 SubClassOf(obo:CL_0000785 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000818))
 DisjointClasses(obo:CL_0000785 obo:CL_0000816)
@@ -10288,7 +10278,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000787 "memory B-lymphocyte
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000787 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0000787 "Memory B-cells are also reportedly CD5-negative, CD10-negative, CD21-positive, CD22-positive, CD23-negative, CD24-positive, CD25-positive, CD27-positive, CD34-negative, CD38-negative, CD40-positive, CD43-negative, CD44-positive, CD45-positive, CD53-positive, CD80-negative, CD81-negative, CD86-positive, and CD196/CCR6-positive."^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000787 "memory B cell"^^xsd:string)
-EquivalentClasses(obo:CL_0000787 ObjectIntersectionOf(obo:CL_0000785 ObjectSomeValuesFrom(obo:RO_0002104 obo:GO_0042613) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001289) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0002344) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001935)))
+EquivalentClasses(obo:CL_0000787 ObjectIntersectionOf(obo:CL_0000785 ObjectSomeValuesFrom(obo:RO_0002104 obo:GO_0042613) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001289) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0002344) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001935)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000787 obo:CL_0000785)
 
 # Class: obo:CL_0000788 (naive B cell)
@@ -10300,7 +10290,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000788 "naive B-lymphocyte"
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000788 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0000788 "This cell type is compatible with the HIPC Lyoplate markers for 'naive B cell'. Per DSD: Naive B cells are also reportedly CD10-negative, CD19-positive, CD20-positive, CD21-positive, CD22-positive, CD25-negative, CD27-negative, CD34-negative, CD40-positive, CD43-negative, CD45-positive, CD48-positive, CD53-positive, CD80-negative, CD81-positive, CD84-positive, CD86-negative, CD95-negative, CD138-negative, CD150-positive, CD184/CXCR4-positive, CD185/CXCR5-positive, CD196/CCR6-positive, CD200-positive, CD229-positive, CD243-positive, CD289-positive, CD290-positive, CD352-positive, MHCII/HLA-DR-positive, cadherin 9-positive, and sIgH-positive, Transcription factors: Pax5-positive, ETS1-positive, FOXO1A-positive, KLF4-positive, KLF9-positive, MiTF-positive, OBF1-positive, PLZF-positive, and SpiB-positive."^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000788 "naive B cell"^^xsd:string)
-EquivalentClasses(obo:CL_0000788 ObjectIntersectionOf(obo:CL_0000785 ObjectSomeValuesFrom(obo:RO_0002104 obo:GO_0071738) ObjectSomeValuesFrom(obo:RO_0002104 obo:GO_0071753) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001289) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_not_completed> obo:GO_0002344) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001963)))
+EquivalentClasses(obo:CL_0000788 ObjectIntersectionOf(obo:CL_0000785 ObjectSomeValuesFrom(obo:RO_0002104 obo:GO_0071738) ObjectSomeValuesFrom(obo:RO_0002104 obo:GO_0071753) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001289) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0002344) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001963)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000788 obo:CL_0000785)
 SubClassOf(obo:CL_0000788 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000818))
 
@@ -10324,7 +10314,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000790 "immature alpha-beta
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000790 "immature alpha-beta T-lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000790 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000790 "immature alpha-beta T cell"^^xsd:string)
-EquivalentClasses(obo:CL_0000790 ObjectIntersectionOf(obo:CL_0000789 ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_not_completed> obo:GO_0045058)))
+EquivalentClasses(obo:CL_0000790 ObjectIntersectionOf(obo:CL_0000789 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0045058)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000790 obo:CL_0000789)
 
 # Class: obo:CL_0000791 (mature alpha-beta T cell)
@@ -10335,7 +10325,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000791 "mature alpha-beta T
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000791 "mature alpha-beta T-lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000791 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000791 "mature alpha-beta T cell"^^xsd:string)
-EquivalentClasses(obo:CL_0000791 ObjectIntersectionOf(obo:CL_0000789 ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0045058)))
+EquivalentClasses(obo:CL_0000791 ObjectIntersectionOf(obo:CL_0000789 ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0045058)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000791 obo:CL_0000789)
 SubClassOf(obo:CL_0000791 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000790))
 
@@ -10389,7 +10379,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000794 "CD8-positive, alpha
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000794 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0000794 "Note that while T cells of this subset are loosely referred to 'cytotoxic T cells,' as many other T cell types, including CD4-positive, alpha-beta T cells and gamma-delta T cells exhibit cytotoxicity in vitro and in vivo."^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000794 "CD8-positive, alpha-beta cytotoxic T cell"^^xsd:string)
-EquivalentClasses(obo:CL_0000794 ObjectIntersectionOf(obo:CL_0000625 ObjectSomeValuesFrom(obo:BFO_0000051 obo:PR_000003466) ObjectSomeValuesFrom(obo:BFO_0000051 obo:PR_000003499) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0001913) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0033380) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0030217)))
+EquivalentClasses(obo:CL_0000794 ObjectIntersectionOf(obo:CL_0000625 ObjectSomeValuesFrom(obo:BFO_0000051 obo:PR_000003466) ObjectSomeValuesFrom(obo:BFO_0000051 obo:PR_000003499) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0001913) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0033380) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0030217)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000794 obo:CL_0000625)
 SubClassOf(obo:CL_0000794 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000906))
 
@@ -10463,7 +10453,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000799 "immature gamma-delt
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000799 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0000799 "Note that gamma-delta T cells have both thymic and extrathymic differentiation pathways."^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000799 "immature gamma-delta T cell"^^xsd:string)
-EquivalentClasses(obo:CL_0000799 ObjectIntersectionOf(obo:CL_0000798 ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_not_completed> obo:GO_0042492) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_not_completed> obo:GO_0045058)))
+EquivalentClasses(obo:CL_0000799 ObjectIntersectionOf(obo:CL_0000798 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0042492) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0045058)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000799 obo:CL_0000798)
 SubClassOf(obo:CL_0000799 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000807))
 
@@ -10475,7 +10465,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000800 "mature gamma-delta 
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000800 "mature gamma-delta T-lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000800 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000800 "mature gamma-delta T cell"^^xsd:string)
-EquivalentClasses(obo:CL_0000800 ObjectIntersectionOf(obo:CL_0000798 ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0045058)))
+EquivalentClasses(obo:CL_0000800 ObjectIntersectionOf(obo:CL_0000798 ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0045058)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000800 obo:CL_0000798)
 SubClassOf(obo:CL_0000800 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000799))
 
@@ -10637,7 +10627,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000813 "memory T-cell"^^xsd
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000813 "memory T-lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000813 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000813 "memory T cell"^^xsd:string)
-EquivalentClasses(obo:CL_0000813 ObjectIntersectionOf(obo:CL_0002419 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0001603) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0002286) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0043379)))
+EquivalentClasses(obo:CL_0000813 ObjectIntersectionOf(obo:CL_0002419 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0001603) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0002286) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0043379)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000813 obo:CL_0002419)
 DisjointClasses(obo:CL_0000813 obo:CL_0000898)
 
@@ -10654,7 +10644,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000814 "mature natural kill
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000814 "mature natural killer T-lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000814 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000814 "mature NK T cell"^^xsd:string)
-EquivalentClasses(obo:CL_0000814 ObjectIntersectionOf(obo:CL_0000791 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001874) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0032394) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0045087) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0030217)))
+EquivalentClasses(obo:CL_0000814 ObjectIntersectionOf(obo:CL_0000791 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001874) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0032394) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0045087) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0030217)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000814 obo:CL_0000791)
 SubClassOf(obo:CL_0000814 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0002042))
 
@@ -10687,7 +10677,7 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "ISBN:781735149"^^xsd:string) 
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000816 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0000816 "Immature B cells are also reportedly CD5-positive, CD10-positive, CD19-positive, CD20-positive, CD21-positive, CD22-positive, CD24-positive, CD25-negative, CD27-negative, CD34-negative, CD38-positive, CD40-positive, CD43-negative, CD45-positive, CD48-positive, CD53-positive, CD79a-positive, CD80-negative, CD81-positive, CD86-negative, CD95-negative, CD127-negative, CD138-negative, CD185-positive, CD196-positive, MHCII/HLA-DR-positive, RAG-positive, TdT-negative, Vpre-B-negative, and preBCR-negative. Transcription factors expressed: Pax5-positive."^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000816 "immature B cell"^^xsd:string)
-EquivalentClasses(obo:CL_0000816 ObjectIntersectionOf(obo:CL_0001201 ObjectSomeValuesFrom(obo:RO_0002104 obo:GO_0071753) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001289) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_not_completed> obo:GO_0045190) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:GO_0071738)))
+EquivalentClasses(obo:CL_0000816 ObjectIntersectionOf(obo:CL_0001201 ObjectSomeValuesFrom(obo:RO_0002104 obo:GO_0071753) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001289) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0045190) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:GO_0071738)))
 SubClassOf(obo:CL_0000816 obo:CL_0001201)
 SubClassOf(obo:CL_0000816 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000954))
 
@@ -10716,7 +10706,7 @@ AnnotationAssertion(oboInOwl:hasNarrowSynonym obo:CL_0000818 "T3 B cell"^^xsd:st
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000818 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0000818 "This cell type is compatible with the HIPC Lyoplate markers for 'transitional B cell'.")
 AnnotationAssertion(rdfs:label obo:CL_0000818 "transitional stage B cell"^^xsd:string)
-EquivalentClasses(obo:CL_0000818 ObjectIntersectionOf(obo:CL_0001201 ObjectSomeValuesFrom(obo:RO_0002104 obo:GO_0071753) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001289) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount> obo:PR_000001408) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount> obo:PR_000001932) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_not_completed> obo:GO_0002335)))
+EquivalentClasses(obo:CL_0000818 ObjectIntersectionOf(obo:CL_0001201 ObjectSomeValuesFrom(obo:RO_0002104 obo:GO_0071753) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001289) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount> obo:PR_000001408) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount> obo:PR_000001932) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0002335)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000818 obo:CL_0001201)
 SubClassOf(obo:CL_0000818 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000816))
 
@@ -11361,7 +11351,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000875 "resident monocyte"^
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000875 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0000875 "Markers: CCR2-CX3CCR1+ (human, mouse, rat); human: CD16+, CCR5+, CD32/FcgRII-high, MHCII+, CD86+; mouse: CD62L-Ly6C-."^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000875 "non-classical monocyte"^^xsd:string)
-EquivalentClasses(obo:CL_0000875 ObjectIntersectionOf(obo:CL_0000576 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0000587) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0031294) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0030224) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount> obo:PR_000001206) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001002) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001020) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001289)))
+EquivalentClasses(obo:CL_0000875 ObjectIntersectionOf(obo:CL_0000576 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0000587) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0031294) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0030224) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount> obo:PR_000001206) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001002) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001020) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001289)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000875 obo:CL_0000576)
 SubClassOf(obo:CL_0000875 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0002393))
 
@@ -11522,7 +11512,7 @@ AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000893 "XAO:0003159"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000893 "thymic lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000893 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000893 "thymocyte"^^xsd:string)
-EquivalentClasses(obo:CL_0000893 ObjectIntersectionOf(obo:CL_0000084 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0002370) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_not_completed> obo:GO_0045058)))
+EquivalentClasses(obo:CL_0000893 ObjectIntersectionOf(obo:CL_0000084 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0002370) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0045058)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000893 obo:CL_0002420)
 
 # Class: obo:CL_0000894 (DN1 thymic pro-T cell)
@@ -11579,7 +11569,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000897 "CD4-positive, alpha
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000897 "cell")
 AnnotationAssertion(oboInOwl:hasRelatedSynonym obo:CL_0000897 "T4.Mem.Sp")
 AnnotationAssertion(rdfs:label obo:CL_0000897 "CD4-positive, alpha-beta memory T cell")
-EquivalentClasses(obo:CL_0000897 ObjectIntersectionOf(obo:CL_0000624 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0001603) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0002286) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0043379)))
+EquivalentClasses(obo:CL_0000897 ObjectIntersectionOf(obo:CL_0000624 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0001603) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0002286) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0043379)))
 SubClassOf(obo:CL_0000897 obo:CL_0000624)
 
 # Class: obo:CL_0000898 (naive T cell)
@@ -11590,7 +11580,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000898 "naive T-cell"^^xsd:
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000898 "naive T-lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000898 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000898 "naive T cell"^^xsd:string)
-EquivalentClasses(obo:CL_0000898 ObjectIntersectionOf(obo:CL_0002419 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001015) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001203) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001869) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0045058) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount> obo:PR_000001318) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_low_plasma_membrane_amount> obo:PR_000001307)))
+EquivalentClasses(obo:CL_0000898 ObjectIntersectionOf(obo:CL_0002419 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001015) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001203) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001869) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0045058) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount> obo:PR_000001318) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_low_plasma_membrane_amount> obo:PR_000001307)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000898 obo:CL_0002419)
 
 # Class: obo:CL_0000899 (T-helper 17 cell)
@@ -11744,7 +11734,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000908 "CD8-positive, alpha
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000908 "CD8-positive, alpha-beta cytokine secreting effector T-lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000908 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000908 "CD8-positive, alpha-beta cytokine secreting effector T cell"^^xsd:string)
-EquivalentClasses(obo:CL_0000908 ObjectIntersectionOf(obo:CL_0000625 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001343) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001380) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0001816) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0030217) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001318) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001869)))
+EquivalentClasses(obo:CL_0000908 ObjectIntersectionOf(obo:CL_0000625 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001343) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001380) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0001816) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0030217) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001318) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001869)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000908 obo:CL_0000625)
 SubClassOf(obo:CL_0000908 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000906))
 
@@ -11758,7 +11748,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000909 "CD8-positive, alpha
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000909 "cell")
 AnnotationAssertion(oboInOwl:hasRelatedSynonym obo:CL_0000909 "T.8Mem.Sp")
 AnnotationAssertion(rdfs:label obo:CL_0000909 "CD8-positive, alpha-beta memory T cell")
-EquivalentClasses(obo:CL_0000909 ObjectIntersectionOf(obo:CL_0000625 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0001603) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0002286) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0043379)))
+EquivalentClasses(obo:CL_0000909 ObjectIntersectionOf(obo:CL_0000625 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0001603) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0002286) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0043379)))
 
 # Class: obo:CL_0000910 (cytotoxic T cell)
 
@@ -11782,7 +11772,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000911 "effector T-cell"^^x
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000911 "effector T-lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000911 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000911 "effector T cell"^^xsd:string)
-EquivalentClasses(obo:CL_0000911 ObjectIntersectionOf(obo:CL_0002419 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0045026) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0030217) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0045058)))
+EquivalentClasses(obo:CL_0000911 ObjectIntersectionOf(obo:CL_0002419 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0045026) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0030217) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0045058)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000911 obo:CL_0002419)
 
 # Class: obo:CL_0000912 (helper T cell)
@@ -12116,7 +12106,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000934 "CD4-positive, alpha
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000934 "CD4-positive, alpha-beta cytotoxic T-lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000934 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000934 "CD4-positive, alpha-beta cytotoxic T cell"^^xsd:string)
-EquivalentClasses(obo:CL_0000934 ObjectIntersectionOf(obo:CL_0000624 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0001913) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0030217)))
+EquivalentClasses(obo:CL_0000934 ObjectIntersectionOf(obo:CL_0000624 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0001913) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0030217)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000934 obo:CL_0000624)
 SubClassOf(obo:CL_0000934 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000896))
 
@@ -12190,7 +12180,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000940 "mucosal invariant T
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000940 "mucosal invariant T-lymphocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000940 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000940 "mucosal invariant T cell"^^xsd:string)
-EquivalentClasses(obo:CL_0000940 ObjectIntersectionOf(obo:CL_0000791 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0002227) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0032394) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0030217)))
+EquivalentClasses(obo:CL_0000940 ObjectIntersectionOf(obo:CL_0000791 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0002227) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0032394) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0030217)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000940 obo:CL_0000791)
 
 # Class: obo:CL_0000941 (thymic conventional dendritic cell)
@@ -12303,7 +12293,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000951 obo:CL_0000975
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:9785673"^^xsd:string) obo:IAO_0000115 obo:CL_0000952 "An preBRC-positive large pre-B-II cell is a large pre-B-II cell that is pre-B cell receptor-positive, composed of surrogate light chain protein (SL), which is composed of VpreB , Lambda 5/14.1, in complex with immunoglobulin mu heavy chain (IgHmu) on the cell surface."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000952 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000952 "preBCR-positive large pre-B-II cell"^^xsd:string)
-EquivalentClasses(obo:CL_0000952 ObjectIntersectionOf(obo:CL_0000957 ObjectSomeValuesFrom(obo:RO_0002104 obo:GO_0035369) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001858) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001859) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_not_completed> obo:GO_0071708)))
+EquivalentClasses(obo:CL_0000952 ObjectIntersectionOf(obo:CL_0000957 ObjectSomeValuesFrom(obo:RO_0002104 obo:GO_0035369) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001858) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001859) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0071708)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000952 obo:CL_0000957)
 
 # Class: obo:CL_0000953 (preBCR-negative large pre-B-II cell)
@@ -12311,7 +12301,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000952 obo:CL_0000957
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:rhs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO_REF:0000031"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:9785673"^^xsd:string) obo:IAO_0000115 obo:CL_0000953 "A pre-BCR-negative large pre-B-II cell is a large pre-B-II cell that is pre-B cell receptor-negative, composed of surrogate light chain protein (SL), which is composed of VpreB and Lambda 5/14.1, in complex with immunoglobulin mu heavy chain (IgHmu), on the cell surface, and lack a DNA rearrangement of immunoglobulin light chain genes."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000953 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000953 "preBCR-negative large pre-B-II cell"^^xsd:string)
-EquivalentClasses(obo:CL_0000953 ObjectIntersectionOf(obo:CL_0000957 ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_not_completed> obo:GO_0071708) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:GO_0035369) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001858) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001859)))
+EquivalentClasses(obo:CL_0000953 ObjectIntersectionOf(obo:CL_0000957 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0071708) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:GO_0035369) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001858) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001859)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000953 obo:CL_0000957)
 
 # Class: obo:CL_0000954 (small pre-B-II cell)
@@ -12334,7 +12324,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000955 "pre-BII cell"^^xsd:
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000955 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0000955 "pre-B-II cell are also reportedly CD19-positive, CD22-positive, CD38-positive, CD45-positive, and CD48-positive."^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000955 "pre-B-II cell"^^xsd:string)
-EquivalentClasses(obo:CL_0000955 ObjectIntersectionOf(obo:CL_0000817 ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0071707) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_part> obo:PR_000006611) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001003)))
+EquivalentClasses(obo:CL_0000955 ObjectIntersectionOf(obo:CL_0000817 ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0071707) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_part> obo:PR_000006611) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001003)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000955 obo:CL_0000817)
 SubClassOf(obo:CL_0000955 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000826))
 DisjointClasses(obo:CL_0000955 obo:CL_0000956)
@@ -12480,7 +12470,7 @@ AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000966 "cell"^^xsd:string)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:17992590"^^xsd:string) oboInOwl:hasRelatedSynonym obo:CL_0000966 "centrocyte"^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0000966 "Bm4 B cells are also reportedly CD10-positive, CD23-negative, CD39-negative, CD44-positive, and CD71-positive."^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000966 "Bm4 B cell"^^xsd:string)
-EquivalentClasses(obo:CL_0000966 ObjectIntersectionOf(obo:CL_0000844 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001408) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0016446) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:GO_0071738) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000003516)))
+EquivalentClasses(obo:CL_0000966 ObjectIntersectionOf(obo:CL_0000844 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001408) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0016446) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:GO_0071738) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000003516)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000966 obo:CL_0000844)
 SubClassOf(obo:CL_0000966 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000963))
 
@@ -12493,7 +12483,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000967 "Bm5 B-lymphocyte"^^
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000967 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0000967 "Bm5 B cells are also reportedly CD10-positive, CD23-negative, CD38-negative, CD39-positive, CD44-positive, CD71-positive, and CD77-negative."^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000967 "Bm5 B cell"^^xsd:string)
-EquivalentClasses(obo:CL_0000967 ObjectIntersectionOf(obo:CL_0000787 ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0002314) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0016446) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:GO_0071738)))
+EquivalentClasses(obo:CL_0000967 ObjectIntersectionOf(obo:CL_0000787 ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0002314) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0016446) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:GO_0071738)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000967 obo:CL_0000787)
 SubClassOf(obo:CL_0000967 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000966))
 
@@ -12565,7 +12555,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000972 "class switched memo
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000972 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0000972 "Per DSD: Class switched memory B cells are also reportedly CD48-positive, CD229-positive, and CD352-positive."^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000972 "class switched memory B cell"^^xsd:string)
-EquivalentClasses(obo:CL_0000972 ObjectIntersectionOf(obo:CL_0000787 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001963) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0045190) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:GO_0071753)))
+EquivalentClasses(obo:CL_0000972 ObjectIntersectionOf(obo:CL_0000787 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001963) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0045190) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:GO_0071753)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000972 obo:CL_0000787)
 SubClassOf(obo:CL_0000972 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000970))
 
@@ -13508,7 +13498,7 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:15032595"^^xsd:string) o
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0001062 "cell")
 AnnotationAssertion(rdfs:comment obo:CL_0001062 "This cell type is seen in human but not found in the mouse.")
 AnnotationAssertion(rdfs:label obo:CL_0001062 "effector memory CD8-positive, alpha-beta T cell, terminally differentiated")
-EquivalentClasses(obo:CL_0001062 ObjectIntersectionOf(obo:CL_0000909 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001015) ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_9606) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0043379) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001017) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001203)))
+EquivalentClasses(obo:CL_0001062 ObjectIntersectionOf(obo:CL_0000909 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001015) ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_9606) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0043379) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001017) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001203)))
 SubClassOf(obo:CL_0001062 obo:CL_0000909)
 SubClassOf(obo:CL_0001062 obo:CL_4030002)
 SubClassOf(obo:CL_0001062 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000913))
@@ -13709,7 +13699,7 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:17465678"^^xsd:string) o
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0001087 "cell")
 AnnotationAssertion(rdfs:comment obo:CL_0001087 "This cell type is seen in human but not found in the mouse.")
 AnnotationAssertion(rdfs:label obo:CL_0001087 "effector memory CD4-positive, alpha-beta T cell, terminally differentiated")
-EquivalentClasses(obo:CL_0001087 ObjectIntersectionOf(obo:CL_0000897 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001015) ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_9606) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0043379) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001017) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001203)))
+EquivalentClasses(obo:CL_0001087 ObjectIntersectionOf(obo:CL_0000897 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001015) ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_9606) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0043379) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001017) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001203)))
 SubClassOf(obo:CL_0001087 obo:CL_0000897)
 SubClassOf(obo:CL_0001087 obo:CL_4030002)
 SubClassOf(obo:CL_0001087 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000905))
@@ -13757,7 +13747,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0001203 "CD8-positive, alpha
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0001203 "CD8-positive, alpha-beta memory T-lymphocyte, CD45RO-positive"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0001203 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0001203 "CD8-positive, alpha-beta memory T cell, CD45RO-positive"^^xsd:string)
-EquivalentClasses(obo:CL_0001203 ObjectIntersectionOf(obo:CL_0000909 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001017) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001869) ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_9606) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0043379) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount> obo:PR_000001307) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount> obo:PR_000001381) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001380)))
+EquivalentClasses(obo:CL_0001203 ObjectIntersectionOf(obo:CL_0000909 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001017) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001869) ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_9606) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0043379) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount> obo:PR_000001307) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount> obo:PR_000001381) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001380)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0001203 obo:CL_0000909)
 SubClassOf(obo:CL_0001203 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000906))
 
@@ -13769,7 +13759,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0001204 "CD4-positive, alpha
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0001204 "CD4-positive, alpha-beta memory T-lymphocyte, CD45RO-positive"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0001204 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0001204 "CD4-positive, alpha-beta memory T cell, CD45RO-positive"^^xsd:string)
-EquivalentClasses(obo:CL_0001204 ObjectIntersectionOf(obo:CL_0000897 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001017) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001869) ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_9606) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0043379) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount> obo:PR_000001307) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount> obo:PR_000001381) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001380)))
+EquivalentClasses(obo:CL_0001204 ObjectIntersectionOf(obo:CL_0000897 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001017) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001869) ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_9606) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0043379) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount> obo:PR_000001307) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_high_plasma_membrane_amount> obo:PR_000001381) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001380)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0001204 obo:CL_0000897)
 SubClassOf(obo:CL_0001204 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000896))
 
@@ -14391,7 +14381,7 @@ AnnotationAssertion(oboInOwl:creation_date obo:CL_0002049 "2010-04-28T02:04:01Z"
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0002049 "cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasRelatedSynonym obo:CL_0002049 "Fraction C"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0002049 "Fraction C precursor B cell"^^xsd:string)
-EquivalentClasses(obo:CL_0002049 ObjectIntersectionOf(obo:CL_0002400 ObjectSomeValuesFrom(obo:BFO_0000051 obo:PR_000001858) ObjectSomeValuesFrom(obo:BFO_0000051 obo:PR_000001859) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001014) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001932) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000002039) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000003457) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000003460) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_not_completed> obo:GO_0071707)))
+EquivalentClasses(obo:CL_0002049 ObjectIntersectionOf(obo:CL_0002400 ObjectSomeValuesFrom(obo:BFO_0000051 obo:PR_000001858) ObjectSomeValuesFrom(obo:BFO_0000051 obo:PR_000001859) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001014) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001932) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000002039) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000003457) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000003460) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0071707)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0002049 obo:CL_0002400)
 SubClassOf(obo:CL_0002049 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0002047))
 
@@ -14431,7 +14421,7 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) oboInOw
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0002052 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0002052 "Fraction D precursor B cells are also reportedly CD24-positive and sIgD-negative."^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0002052 "Fraction D precursor B cell"^^xsd:string)
-EquivalentClasses(obo:CL_0002052 ObjectIntersectionOf(obo:CL_0000817 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001002) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001014) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001380) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001932) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000002037) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000002039) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_low_plasma_membrane_amount> obo:PR_000001879) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_not_completed> obo:GO_0071708) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:GO_0035369)))
+EquivalentClasses(obo:CL_0002052 ObjectIntersectionOf(obo:CL_0000817 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001002) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001014) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001380) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001932) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000002037) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000002039) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_low_plasma_membrane_amount> obo:PR_000001879) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0071708) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:GO_0035369)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0002052 obo:CL_0000817)
 SubClassOf(obo:CL_0002052 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0002050))
 
@@ -15319,7 +15309,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0002124 "gammadelta27-positi
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0002124 "gd27-positive"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0002124 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0002124 "CD27-positive gamma-delta T cell"^^xsd:string)
-EquivalentClasses(obo:CL_0002124 ObjectIntersectionOf(obo:CL_0000800 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001963) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0032609) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0030217)))
+EquivalentClasses(obo:CL_0002124 ObjectIntersectionOf(obo:CL_0000800 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001963) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0032609) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0030217)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0002124 obo:CL_0000800)
 SubClassOf(obo:CL_0002124 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0002126))
 
@@ -15331,7 +15321,7 @@ AnnotationAssertion(oboInOwl:creation_date obo:CL_0002125 "2010-08-18T09:57:29Z"
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:21976777"^^xsd:string) oboInOwl:hasExactSynonym obo:CL_0002125 "gammadelta-17 cells"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0002125 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0002125 "CD27-negative gamma-delta T cell"^^xsd:string)
-EquivalentClasses(obo:CL_0002125 ObjectIntersectionOf(obo:CL_0000800 ObjectSomeValuesFrom(obo:BFO_0000051 obo:PR_000003455) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0032620) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0030217) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001963)))
+EquivalentClasses(obo:CL_0002125 ObjectIntersectionOf(obo:CL_0000800 ObjectSomeValuesFrom(obo:BFO_0000051 obo:PR_000003455) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0032620) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0030217) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001963)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0002125 obo:CL_0000800)
 SubClassOf(obo:CL_0002125 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0002126))
 
@@ -18418,7 +18408,7 @@ AnnotationAssertion(oboInOwl:created_by obo:CL_0002393 "tmeehan"^^xsd:string)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002393 "2010-10-04T10:52:03Z"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0002393 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0002393 "intermediate monocyte"^^xsd:string)
-EquivalentClasses(obo:CL_0002393 ObjectIntersectionOf(obo:CL_0000576 ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_not_completed> obo:GO_0030224) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001002) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001020) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001199) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001289)))
+EquivalentClasses(obo:CL_0002393 ObjectIntersectionOf(obo:CL_0000576 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0030224) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001002) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001020) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001199) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#lacks_plasma_membrane_part> obo:PR_000001289)))
 SubClassOf(obo:CL_0002393 obo:CL_0000576)
 SubClassOf(obo:CL_0002393 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000860))
 
@@ -18705,7 +18695,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0002419 "mature T-cell"^^xsd
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0002419 "cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasRelatedSynonym obo:CL_0002419 "CD3epsilon T cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0002419 "mature T cell"^^xsd:string)
-EquivalentClasses(obo:CL_0002419 ObjectIntersectionOf(obo:CL_0000084 ObjectSomeValuesFrom(obo:RO_0002104 obo:GO_0042101) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0045058)))
+EquivalentClasses(obo:CL_0002419 ObjectIntersectionOf(obo:CL_0000084 ObjectSomeValuesFrom(obo:RO_0002104 obo:GO_0042101) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0045058)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0002419 obo:CL_0000084)
 
 # Class: obo:CL_0002420 (immature T cell)
@@ -18718,7 +18708,7 @@ AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0002420 "CALOHA:TS-1042"^^xsd:stri
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0002420 "immature T-cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0002420 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0002420 "immature T cell"^^xsd:string)
-EquivalentClasses(obo:CL_0002420 ObjectIntersectionOf(obo:CL_0000084 ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_not_completed> obo:GO_0045058)))
+EquivalentClasses(obo:CL_0002420 ObjectIntersectionOf(obo:CL_0000084 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0045058)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0002420 obo:CL_0000084)
 
 # Class: obo:CL_0002421 (nucleated reticulocyte)
@@ -21440,7 +21430,7 @@ AnnotationAssertion(oboInOwl:creation_date obo:CL_0002678 "2011-08-25T03:17:34Z"
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0002678 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0002678 "Cell has been described as being CD45RA-positive in human, but this doesn't fit with our current definition memory T cell."^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0002678 "memory regulatory T cell"^^xsd:string)
-EquivalentClasses(obo:CL_0002678 ObjectIntersectionOf(obo:CL_0000792 ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/cl#has_completed> obo:GO_0043379)))
+EquivalentClasses(obo:CL_0002678 ObjectIntersectionOf(obo:CL_0000792 ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0043379)))
 SubClassOf(obo:CL_0002678 obo:CL_0000792)
 SubClassOf(obo:CL_0002678 obo:CL_0000813)
 


### PR DESCRIPTION
Switch has_completed to output_of
Switch has_not_completed to capable_of
See https://github.com/oborel/obo-relations/issues/574
Related to https://github.com/obophenotype/cell-ontology/issues/1481
tagging @bpeters42
will not merge unless we have approval from @addiehl 