### PR TITLE
Removing auto assignments from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/b_adding_synonym.md
+++ b/.github/ISSUE_TEMPLATE/b_adding_synonym.md
@@ -1,7 +1,6 @@
 ---
 name: Add synonym
 about: New synonym suggestion for an existing CL term
-assignees: nicolevasilevsky
 title: "[Synonym]"
 labels: synonym
 ---

--- a/.github/ISSUE_TEMPLATE/c_revise_textual_def.md
+++ b/.github/ISSUE_TEMPLATE/c_revise_textual_def.md
@@ -1,7 +1,6 @@
 ---
 name: Revise textual definition
 about: Change the textual definition of a CL term
-assignees: nicolevasilevsky
 title: "[Text def]"
 labels: 'text definition'
 ---

--- a/.github/ISSUE_TEMPLATE/d_revise_subclass.md
+++ b/.github/ISSUE_TEMPLATE/d_revise_subclass.md
@@ -1,7 +1,6 @@
 ---
 name: Revise subclass relationship
 about: Revise the subclass structure for CL terms
-assignees: nicolevasilevsky
 title: "[Class hierarchy]"
 labels: CL-classhierarchy
 ---

--- a/.github/ISSUE_TEMPLATE/e_revise_logical_def.md
+++ b/.github/ISSUE_TEMPLATE/e_revise_logical_def.md
@@ -1,7 +1,6 @@
 ---
 name: Revise logical definition
 about: Improve the OWL-DL statement of a CL term
-assignees: nicolevasilevsky, dosumis, addiehl
 title: "[Logical def]"
 labels: 'logical definition'
 ---

--- a/.github/ISSUE_TEMPLATE/f_obsolete_term.md
+++ b/.github/ISSUE_TEMPLATE/f_obsolete_term.md
@@ -1,7 +1,6 @@
 ---
 name: Obsolete a term
 about: Obsolete or deprecate an existing CL term. Note, please use the 'merge' template if you would like to obsolete one term and merge/replace it with another CL term.
-assignees: nicolevasilevsky, dosumis, addiehl
 title: "[Obsolete]"
 labels: 'obsoletion request'
 ---

--- a/.github/ISSUE_TEMPLATE/g_merge-term.md
+++ b/.github/ISSUE_TEMPLATE/g_merge-term.md
@@ -3,7 +3,6 @@ name: Merge two terms
 about: Obsolete or deprecate an existing CL term and merge with another CL term. Note - use the 'obsolete' template if you would like to obsolete a term without replacing it with another existing CL term.
 title: "[Merge]"
 labels: merge
-assignees: nicolevasilevsky
 
 ---
 


### PR DESCRIPTION
Related to comment in #1489.
Unless decided otherwise in the future, issues generated from a CL template will not be automatically assigned to any user.