### PR TITLE
Added information to cardiac neuron

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -23471,8 +23471,11 @@ EquivalentClasses(obo:CL_0010021 ObjectIntersectionOf(obo:CL_0000056 ObjectSomeV
 
 # Class: obo:CL_0010022 (cardiac neuron)
 
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:12486170"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:29265764"^^xsd:string) obo:IAO_0000115 obo:CL_0010022 "A neuron that has its soma in the heart.")
+AnnotationAssertion(rdfs:comment obo:CL_0010022 "This term is used in 3 GO terms that were created as part of the heart development focus project.")
 AnnotationAssertion(rdfs:label obo:CL_0010022 "cardiac neuron"^^xsd:string)
-EquivalentClasses(obo:CL_0010022 ObjectIntersectionOf(obo:CL_0000540 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0000948)))
+AnnotationAssertion(rdfs:seeAlso obo:CL_0010022 "https://github.com/obophenotype/cell-ontology/pull/1488")
+EquivalentClasses(obo:CL_0010022 ObjectIntersectionOf(obo:CL_0000540 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000948)))
 
 # Class: obo:CL_0011000 (dorsal horn interneuron)
 


### PR DESCRIPTION
Related to https://github.com/obophenotype/cell-ontology/pull/1488
Fixes #1074
@dosumis - need feedback here, as it is a neuron I've changed it from part_of to has_soma_location - wonder if that is wise as others might have modelled using part_of rather than overlaps. Happy to change back and change the def accordingly

(will also wait for reasoned diff to see how it affects CL, love this feature :D) 