### PR TITLE
Changed cortical interneuron to use cerebral cortex

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -22204,8 +22204,10 @@ EquivalentClasses(obo:CL_0008030 ObjectIntersectionOf(obo:CL_0000540 ObjectSomeV
 
 # Class: obo:CL_0008031 (cortical interneuron)
 
+AnnotationAssertion(obo:IAO_0000115 obo:CL_0008031 "An interneuron that has its soma located in the cerebral cortex.")
+AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0008031 "cerebral cortex interneuron")
 AnnotationAssertion(rdfs:label obo:CL_0008031 "cortical interneuron"@en)
-EquivalentClasses(obo:CL_0008031 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001851)))
+EquivalentClasses(obo:CL_0008031 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000956)))
 
 # Class: obo:CL_0008032 (rosehip neuron)
 


### PR DESCRIPTION
Fixes #1507
also added a def and a synonym

Not sure if it should be obsoleted instead given it is equivalent to `interneuron and ('has soma location' some 'cerebral cortex')` but I'd rather not as it is used in HCAO, UBERON, and WBPhenotype (from OLS). 

Similar situation to cardiac neuron (https://github.com/obophenotype/cell-ontology/pull/1488)