### PR TITLE
Add obsolete replaced_by check

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -38,7 +38,7 @@ REPORT_FAIL_ON =            ERROR
 REPORT_LABEL =              
 REPORT_PROFILE_OPTS =       
 OBO_FORMAT_OPTIONS =        
-SPARQL_VALIDATION_CHECKS =  equivalent-classes owldef-self-reference nolabels pmid-not-dbxref 
+SPARQL_VALIDATION_CHECKS =  equivalent-classes owldef-self-reference nolabels pmid-not-dbxref obsolete-replaced_by 
 SPARQL_EXPORTS =            basic-report 
 ODK_VERSION_MAKEFILE =      v1.3.0
 

--- a/src/ontology/cl-odk.yaml
+++ b/src/ontology/cl-odk.yaml
@@ -78,5 +78,6 @@ robot_report:
     - owldef-self-reference
     - nolabels
     - pmid-not-dbxref
+    - obsolete-replaced_by
   custom_sparql_exports :
     - basic-report

--- a/src/sparql/obsolete-replaced_by-violation.sparql
+++ b/src/sparql/obsolete-replaced_by-violation.sparql
@@ -1,0 +1,67 @@
+PREFIX obo: <http://purl.obolibrary.org/obo/>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX replaced_by: <http://purl.obolibrary.org/obo/IAO_0100001>
+
+SELECT DISTINCT ?entity ?property ?value ?replaced_by WHERE {
+  {
+   VALUES ?property {
+     rdfs:subClassOf
+   }
+   ?entity a owl:Class;
+           owl:deprecated true ;
+           ?property ?value .
+   OPTIONAL { ?entity replaced_by: ?replaced_by }
+   FILTER ( ?value NOT IN (oboInOwl:ObsoleteClass, owl:Thing) )
+  }
+  UNION
+  {
+   VALUES ?property {
+     owl:equivalentClass
+     owl:disjointWith
+   }
+   ?entity a owl:Class;
+           owl:deprecated true ;
+           ?property ?value .
+    OPTIONAL { ?entity replaced_by: ?replaced_by }
+  }
+  UNION
+  {
+     VALUES ?property {
+       rdfs:subClassOf
+       owl:equivalentClass
+       owl:disjointWith
+     }
+     ?entity a owl:Class;
+             owl:deprecated true .
+     ?value ?property ?entity .
+     OPTIONAL { ?entity replaced_by: ?replaced_by }
+  }
+  UNION
+  {
+   VALUES ?property {
+     owl:ObjectProperty
+     owl:DataProperty
+   }
+   ?entity a owl:Class ;
+           owl:deprecated true ;
+           ?property ?value .
+    OPTIONAL { ?entity replaced_by: ?replaced_by }
+  }
+  UNION
+  {
+   VALUES ?property {
+     owl:someValuesFrom
+     owl:allValuesFrom
+   }
+   ?value a owl:Class ;
+          owl:deprecated true .
+   ?rest a owl:Restriction ;
+         ?property ?value .
+   OPTIONAL { ?value replaced_by: ?replaced_by }
+   BIND("blank node" as ?entity)
+  }
+}
+ORDER BY ?entity


### PR DESCRIPTION
Related to INCATools/ontology-development-kit#512

In CL, some of the `replaced_by` property is inside a comment, so this check won't work as expected.

![Screenshot 2022-04-04 at 11 38 06](https://user-images.githubusercontent.com/2208124/161527388-845654a3-7496-44d9-b6bd-99b2b4991388.png)

