### PR TITLE
Change has characteristic to has part for terminals

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -29745,7 +29745,7 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:10706428"^^xsd:string) o
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023113 <http://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(rdfs:label obo:CL_4023113 "bouton vestibular afferent neuron")
 SubClassOf(obo:CL_4023113 obo:CL_4023112)
-SubClassOf(obo:CL_4023113 ObjectSomeValuesFrom(obo:RO_0000053 obo:GO_0043195))
+SubClassOf(obo:CL_4023113 ObjectSomeValuesFrom(obo:BFO_0000051 obo:GO_0043195))
 SubClassOf(obo:CL_4023113 ObjectSomeValuesFrom(obo:RO_0002130 obo:CL_0002069))
 
 # Class: obo:CL_4023114 (calyx vestibular afferent neuron)
@@ -29754,7 +29754,7 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:25355208"^^xsd:string) o
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023114 <http://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(rdfs:label obo:CL_4023114 "calyx vestibular afferent neuron")
 SubClassOf(obo:CL_4023114 obo:CL_4023112)
-SubClassOf(obo:CL_4023114 ObjectSomeValuesFrom(obo:RO_0000053 obo:GO_0099096))
+SubClassOf(obo:CL_4023114 ObjectSomeValuesFrom(obo:BFO_0000051 obo:GO_0099096))
 SubClassOf(obo:CL_4023114 ObjectSomeValuesFrom(obo:RO_0002130 obo:CL_0002070))
 
 # Class: obo:CL_4023115 (type 1 spiral ganglion neuron)


### PR DESCRIPTION
Changed has characteristics to has part for terminal axioms in vestibular afferent neuron subclasses
See also: https://github.com/geneontology/go-ontology/issues/22587#issuecomment-995902682

Fixes #1552
Fixes #1376

