### PR TITLE
added neocortex location to 3 basket cell types

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -29560,7 +29560,7 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:11884355"^^xsd:string) o
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023088 <http://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023088 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(rdfs:label obo:CL_4023088 "large basket cell")
-EquivalentClasses(obo:CL_4023088 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0070004) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534)))
+EquivalentClasses(obo:CL_4023088 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0070004) ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001950) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534)))
 
 # Class: obo:CL_4023089 (nest basket cell)
 
@@ -29568,7 +29568,7 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:11884355"^^xsd:string) o
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023089 <http://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023089 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(rdfs:label obo:CL_4023089 "nest basket cell")
-EquivalentClasses(obo:CL_4023089 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0070005) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534)))
+EquivalentClasses(obo:CL_4023089 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0070005) ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001950) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534)))
 
 # Class: obo:CL_4023090 (small basket cell)
 
@@ -29576,7 +29576,7 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:11884355"^^xsd:string) o
 AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> obo:CL_4023090 <http://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023090 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(rdfs:label obo:CL_4023090 "small basket cell")
-EquivalentClasses(obo:CL_4023090 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0070003) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534)))
+EquivalentClasses(obo:CL_4023090 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0070003) ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001950) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534)))
 
 # Class: obo:CL_4023092 (inverted pyramidal neuron)
 


### PR DESCRIPTION
Fixes https://github.com/obophenotype/cell-ontology/issues/1128
From reading, I think that these basket cells are in neocortex. There are basket cells in cerebellum too (and they already have a class in CL) but they seem to be another type that are multipolar. I didn't create a new class for them as they would be the only child on under cerebellum basket cells, so there isnt a need for it.