### PR TITLE
Switch FBbt mappings to SSSOM

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -46,7 +46,7 @@ TODAY ?=                    $(shell date +%Y-%m-%d)
 OBODATE ?=                  $(shell date +'%d:%m:%Y %H:%M')
 VERSION=                    $(TODAY)
 ANNOTATE_ONTOLOGY_VERSION = annotate -V $(ONTBASE)/releases/$(VERSION)/$@ --annotation owl:versionInfo $(VERSION)
-OTHER_SRC =                 $(PATTERNDIR)/definitions.owl 
+OTHER_SRC =                 $(PATTERNDIR)/definitions.owl $(COMPONENTSDIR)/mappings.owl 
 ONTOLOGYTERMS =             $(TMPDIR)/ontologyterms.txt
 PATTERNDIR=                 ../patterns
 PATTERN_TESTER=              dosdp validate -i
@@ -326,6 +326,32 @@ refresh-%:
 .PHONY: no-mirror-refresh-%
 no-mirror-refresh-%:
 	$(MAKE) IMP=true IMP_LARGE=true MIR=false PAT=false $(IMPORTDIR)/$*_import.owl -B
+
+
+# ----------------------------------------
+# Components
+# ----------------------------------------
+# Some ontologies contain external and internal components. A component is included in the ontology in its entirety.
+
+COMP=true # Global parameter to bypass component generation
+
+.PHONY: all_components
+all_components: $(OTHER_SRC)
+
+.PHONY: recreate-components
+recreate-components:
+	$(MAKE) IMP=true MIR=true PAT=true IMP_LARGE=true all_components -B
+
+.PHONY: recreate-%
+recreate-%:
+	$(MAKE) IMP=true IMP_LARGE=true MIR=true PAT=true $(COMPONENTSDIR)/$*.owl -B
+
+$(COMPONENTSDIR)/%: | $(COMPONENTSDIR)
+	touch $@
+.PRECIOUS: $(COMPONENTSDIR)/%
+
+
+
 
 
 # ----------------------------------------

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -14,5 +14,6 @@
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/cl/imports/nif_import.owl" uri="imports/nif_import.owl"/>
     <uri id="User Entered Import Resolution" name="http://purl.obolibrary.org/obo/cl/imports/nif_cell.owl" uri="imports/nif_cell.owl"/>
     <uri id="User Entered Import Resolution" name="http://ontology.neuinfo.org/NIF/BiomaterialEntities/NIF-Cell.owl" uri="mirror/NIF-Cell.owl"/>
+    <uri name="http://purl.obolibrary.org/obo/cl/components/mappings.owl" uri="components/mappings.owl"/>
     <group id="Folder Repository, directory=, recursive=false, Auto-Update=false, version=2" prefer="public" xml:base=""/>
 </catalog>

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -3122,7 +3122,6 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotat
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000017 "BTO:0001275"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000017 "CALOHA:TS-0951"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000017 "EMAPA:31484"^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000017 "FBbt:00004936"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000017 "FMA:84049"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000017 "WBbt:0006799"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000017 "cell"^^xsd:string)
@@ -3137,7 +3136,6 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "MESH:A05.360.490.890.860"^^xs
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000018 "BTO:0001274"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000018 "CALOHA:TS-0950"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000018 "EMAPA:31486"^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000018 "FBbt:00004942"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000018 "FMA:72294"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000018 "WBbt:0006800"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000018 "nematoblast"^^xsd:string)
@@ -3153,7 +3151,6 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotat
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000019 "BTO:0001277"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000019 "BTO:0002046"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000019 "CALOHA:TS-0949"^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000019 "FBbt:00004954"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000019 "FMA:67338"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000019 "WBbt:0006798"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000019 "sperm cell"^^xsd:string)
@@ -3170,7 +3167,6 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "MESH:A05.360.490.890.900"^^xs
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000020 "BTO:0000958"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000020 "CALOHA:TS-2193"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000020 "EMAPA:31482"^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000020 "FBbt:00004935"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000020 "FMA:72291"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000020 "spermatogonial cell")
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000020 "cell"^^xsd:string)
@@ -3201,7 +3197,6 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000022 obo:CL_0000021
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0721662544"^^xsd:string) obo:IAO_0000115 obo:CL_0000023 "A female germ cell that has entered meiosis."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000023 "BTO:0000964"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000023 "CALOHA:TS-0711"^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000023 "FBbt:00004886"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000023 "FMA:18644"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000023 "MESH:D009865"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000023 "WBbt:0006797"^^xsd:string)
@@ -3228,7 +3223,6 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotat
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000025 "BTO:0000369"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000025 "BTO:0003801"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000025 "CALOHA:TS-2191"^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000025 "FBbt:00057012"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000025 "FMA:67343"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000025 "MA:0000388"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000025 "MESH:D010063"^^xsd:string)
@@ -3244,7 +3238,6 @@ SubClassOf(obo:CL_0000025 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000023))
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:15848391"^^xsd:string) obo:IAO_0000115 obo:CL_0000026 "A germline cell that contributes to the development of the oocyte by transferring cytoplasm directly to oocyte."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000026 "BTO:0000953"^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000026 "FBbt:00004878"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000026 "cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasRelatedSynonym obo:CL_0000026 "nurse cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000026 "invertebrate nurse cell"^^xsd:string)
@@ -3280,7 +3273,6 @@ SubClassOf(obo:CL_0000029 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0002676))
 
 # Class: obo:CL_0000030 (glioblast)
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000030 "FBbt:00005145"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000030 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000030 "glioblast"^^xsd:string)
 SubClassOf(obo:CL_0000030 obo:CL_0000055)
@@ -3588,7 +3580,6 @@ SubClassOf(obo:CL_0000055 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0030154))
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "MESH:A11.635"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:21849021"^^xsd:string) obo:IAO_0000115 obo:CL_0000056 "A cell that is commited to differentiating into a muscle cell.  Embryonic myoblasts develop from the mesoderm. They undergo proliferation, migrate to their various sites, and then differentiate into the appropriate form of myocytes.  Myoblasts also occur as transient populations of cells in muscles undergoing repair."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000056 "BTO:0000222"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000056 "CALOHA:TS-0650"^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000056 "FBbt:00005083"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000056 "FMA:70335"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000056 "VHOG:0001529"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000056 "cell"^^xsd:string)
@@ -3724,7 +3715,6 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "FB:ma"^^xsd:string) Annotatio
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000066 "BTO:0000414"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000066 "CALOHA:TS-2026"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000066 "CARO:0000077"^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000066 "FBbt:00000124"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000066 "FMA:66768"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000066 "WBbt:0003672"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000066 "epitheliocyte"^^xsd:string)
@@ -3909,7 +3899,6 @@ SubClassOf(obo:CL_0000085 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_7742
 
 # Class: obo:CL_0000086 (germ line stem cell (sensu Nematoda and Protostomia))
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000086 "FBbt:00004861"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000086 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000086 "germ line stem cell (sensu Nematoda and Protostomia)"^^xsd:string)
 SubClassOf(obo:CL_0000086 obo:CL_0000014)
@@ -3917,7 +3906,6 @@ SubClassOf(obo:CL_0000086 ObjectAllValuesFrom(obo:RO_0002162 ObjectComplementOf(
 
 # Class: obo:CL_0000087 (male germ line stem cell (sensu Nematoda and Protostomia))
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000087 "FBbt:00004929"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000087 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000087 "male germ line stem cell (sensu Nematoda and Protostomia)"^^xsd:string)
 SubClassOf(obo:CL_0000087 obo:CL_0000016)
@@ -3925,7 +3913,6 @@ SubClassOf(obo:CL_0000087 obo:CL_0000086)
 
 # Class: obo:CL_0000088 (female germ line stem cell (sensu Nematoda and Protostomia))
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000088 "FBbt:00004873"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000088 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000088 "female germ line stem cell (sensu Nematoda and Protostomia)"^^xsd:string)
 SubClassOf(obo:CL_0000088 obo:CL_0000022)
@@ -4066,7 +4053,6 @@ SubClassOf(obo:CL_0000098 obo:CL_0002371)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "MESH:A08.663.358"^^xsd:string) obo:IAO_0000115 obo:CL_0000099 "Most generally any neuron which is not motor or sensory. Interneurons may also refer to neurons whose axons remain within a particular brain region as contrasted with projection neurons which have axons projecting to other brain regions."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000099 "BTO:0003811"^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000099 "FBbt:00005125"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000099 "FMA:67313"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000099 "WBbt:0005113"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000099 "cell"^^xsd:string)
@@ -4088,7 +4074,6 @@ SubClassOf(obo:CL_0000100 obo:CL_0000527)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "ISBN:0721662544"^^xsd:string) obo:IAO_0000115 obo:CL_0000101 "Any neuron having a sensory function; an afferent neuron conveying sensory impulses."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000101 "BTO:0001037"^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000101 "FBbt:00005124"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000101 "FMA:84649"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000101 "MESH:D011984"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000101 "WBbt:0005759"^^xsd:string)
@@ -4223,7 +4208,6 @@ SubClassOf(obo:CL_0000115 obo:CL_0002078)
 # Class: obo:CL_0000116 (pioneer neuron)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:cvs"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) obo:IAO_0000115 obo:CL_0000116 "Pioneer neurons establish a pathway in the developing central nervous system and then undergo programmed cell death once the adult axons, which follow them, have made connections with the target site. Thus, they are a transient cell type involved in axon guidance."^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000116 "FBbt:00005128"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000116 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000116 "pioneer neuron"^^xsd:string)
 SubClassOf(obo:CL_0000116 obo:CL_0000540)
@@ -4300,7 +4284,6 @@ SubClassOf(obo:CL_0000123 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000333))
 
 # Class: obo:CL_0000124 (obsolete glial cell (sensu Nematoda and Protostomia))
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000124 "FBbt:00005144"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000124 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0000124 "This is a grouping class that is no longer needed or wanted.")
 AnnotationAssertion(rdfs:label obo:CL_0000124 "obsolete glial cell (sensu Nematoda and Protostomia)"^^xsd:string)
@@ -4979,7 +4962,6 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "MESH:A11.620"^^xsd:string) ob
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000187 "BTO:0000888"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000187 "BTO:0000902"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000187 "CALOHA:TS-2032"^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000187 "FBbt:00005074"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000187 "FMA:67328"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000187 "WBbt:0003675"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000187 "muscle fiber"^^xsd:string)
@@ -5179,7 +5161,6 @@ SubClassOf(obo:CL_0000209 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_000202
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "MESH:A08.663.650.650"^^xsd:string) obo:IAO_0000115 obo:CL_0000210 "A cell specialized to detect and transduce light."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000210 "BTO:0001060"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000210 "CALOHA:TS-0868"^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000210 "FBbt:00004211"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000210 "FMA:86740"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000210 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000210 "photoreceptor cell"^^xsd:string)
@@ -5927,7 +5908,6 @@ AnnotationAssertion(owl:deprecated obo:CL_0000299 "true"^^xsd:boolean)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0721662544"^^xsd:string) obo:IAO_0000115 obo:CL_0000300 "A mature sexual reproductive cell having a single set of unpaired chromosomes."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000300 "CALOHA:TS-0395"^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000300 "FBbt:00005412"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000300 "FMA:18649"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000300 "haploid nucleated cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000300 "cell"^^xsd:string)
@@ -5938,7 +5918,6 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000300 obo:CL_0000586
 
 # Class: obo:CL_0000301 (pole cell)
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000301 "FBbt:00000092"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000301 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000301 "pole cell"^^xsd:string)
 SubClassOf(obo:CL_0000301 obo:CL_0000670)
@@ -5977,7 +5956,6 @@ AnnotationAssertion(owl:deprecated obo:CL_0000305 "true"^^xsd:boolean)
 
 # Class: obo:CL_0000306 (crystallin accumulating cell)
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000306 "FBbt:00004193"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000306 "lens cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000306 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000306 "crystallin accumulating cell"^^xsd:string)
@@ -6532,14 +6510,12 @@ SubClassOf(obo:CL_0000371 ObjectSomeValuesFrom(obo:RO_0002162 ObjectComplementOf
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "ISBN:978-0801481253"^^xsd:string) obo:IAO_0000115 obo:CL_0000372 "An epidermal cell that is part of a cell cluster organ of the insect integument (such as a sensillum) and that secretes a cuticular specialization that forms a socket around the base of a cuticular specialization produced by a trichogen cell."^^xsd:string)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "ISBN:978-0801481253"^^xsd:string) oboInOwl:hasBroadSynonym obo:CL_0000372 "socket cell"^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000372 "FBbt:00005171"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000372 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000372 "tormogen cell"^^xsd:string)
 SubClassOf(obo:CL_0000372 obo:CL_0000463)
 
 # Class: obo:CL_0000373 (histoblast)
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000373 "FBbt:00001789"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000373 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000373 "histoblast"^^xsd:string)
 SubClassOf(obo:CL_0000373 obo:CL_0000146)
@@ -6549,7 +6525,6 @@ SubClassOf(obo:CL_0000373 obo:CL_0000146)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "ISBN:978-0801481253"^^xsd:string) obo:IAO_0000115 obo:CL_0000374 "An epidermal cell that is part of a cell cluster organ of the insect integument (such as a sensillum) and that secretes a cuticular specialization, often in the form of a hair, bristle, peg or scale. The base of this specialization is often surrounded by a socket produced by a closely associated tormogen cell."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000374 "hair cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000374 "BTO:0004744"^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000374 "FBbt:00005169"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000374 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000374 "trichogen cell"^^xsd:string)
 SubClassOf(obo:CL_0000374 obo:CL_0000463)
@@ -6597,7 +6572,6 @@ SubClassOf(obo:CL_0000380 obo:CL_0000378)
 
 # Class: obo:CL_0000381 (neurosecretory neuron)
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000381 "FBbt:00005130"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000381 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000381 "neurosecretory neuron"^^xsd:string)
 EquivalentClasses(obo:CL_0000381 ObjectIntersectionOf(obo:CL_0000540 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0046879)))
@@ -6605,7 +6579,6 @@ SubClassOf(obo:CL_0000381 obo:CL_0000527)
 
 # Class: obo:CL_0000382 (scolopale cell)
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000382 "FBbt:00005219"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000382 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000382 "scolopale cell"^^xsd:string)
 SubClassOf(obo:CL_0000382 obo:CL_0000378)
@@ -6625,7 +6598,6 @@ SubClassOf(obo:CL_0000384 obo:CL_0000630)
 
 # Class: obo:CL_0000385 (prohemocyte (sensu Nematoda and Protostomia))
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000385 "FBbt:00005062"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000385 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000385 "prohemocyte (sensu Nematoda and Protostomia)"^^xsd:string)
 SubClassOf(obo:CL_0000385 obo:CL_0000390)
@@ -6639,7 +6611,6 @@ SubClassOf(obo:CL_0000386 obo:CL_0000630)
 
 # Class: obo:CL_0000387 (hemocyte (sensu Arthropoda))
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000387 "FBbt:00005063"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000387 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000387 "hemocyte (sensu Arthropoda)"^^xsd:string)
 SubClassOf(obo:CL_0000387 obo:CL_0000519)
@@ -6675,7 +6646,6 @@ SubClassOf(obo:CL_0000390 ObjectAllValuesFrom(obo:RO_0002162 ObjectComplementOf(
 # Class: obo:CL_0000391 (podocyte (sensu Diptera))
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:12930778"^^xsd:string) obo:IAO_0000115 obo:CL_0000391 "An insect immune cell that develops from plasmatocyte."^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000391 "FBbt:00001688"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000391 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000391 "podocyte (sensu Diptera)"^^xsd:string)
 SubClassOf(obo:CL_0000391 obo:CL_0000387)
@@ -6697,21 +6667,18 @@ SubClassOf(obo:CL_0000393 obo:CL_0000211)
 
 # Class: obo:CL_0000394 (plasmatocyte)
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000394 "FBbt:00001685"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000394 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000394 "plasmatocyte"^^xsd:string)
 SubClassOf(obo:CL_0000394 obo:CL_0000387)
 
 # Class: obo:CL_0000395 (procrystal cell)
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000395 "FBbt:00001689"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000395 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000395 "procrystal cell"^^xsd:string)
 SubClassOf(obo:CL_0000395 obo:CL_0000387)
 
 # Class: obo:CL_0000396 (lamellocyte)
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000396 "FBbt:00001687"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000396 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000396 "lamellocyte"^^xsd:string)
 SubClassOf(obo:CL_0000396 obo:CL_0000394)
@@ -6725,7 +6692,6 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000397 obo:CL_0000099
 
 # Class: obo:CL_0000398 (polygonal cell)
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000398 "FBbt:00001691"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000398 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000398 "polygonal cell"^^xsd:string)
 SubClassOf(obo:CL_0000398 obo:CL_0000387)
@@ -6747,7 +6713,6 @@ AnnotationAssertion(owl:deprecated obo:CL_0000400 "true"^^xsd:boolean)
 
 # Class: obo:CL_0000401 (macrophage (sensu Diptera))
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000401 "FBbt:00001686"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000401 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000401 "macrophage (sensu Diptera)"^^xsd:string)
 SubClassOf(obo:CL_0000401 obo:CL_0000394)
@@ -6769,7 +6734,6 @@ SubClassOf(obo:CL_0000404 obo:CL_0000211)
 
 # Class: obo:CL_0000405 (neuroepidermoblast)
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000405 "FBbt:00005148"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000405 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000405 "neuroepidermoblast"^^xsd:string)
 SubClassOf(obo:CL_0000405 obo:CL_0000338)
@@ -6782,7 +6746,6 @@ SubClassOf(obo:CL_0000406 obo:CL_0000402)
 
 # Class: obo:CL_0000407 (scolopidial ligament cell)
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000407 "FBbt:00005221"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000407 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000407 "scolopidial ligament cell"^^xsd:string)
 SubClassOf(obo:CL_0000407 obo:CL_0000384)
@@ -6799,7 +6762,6 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000408 obo:CL_0000300
 
 # Class: obo:CL_0000409 (scolopidial sheath cell)
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000409 "FBbt:00005219"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000409 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000409 "scolopidial sheath cell"^^xsd:string)
 SubClassOf(obo:CL_0000409 obo:CL_0000618)
@@ -7059,7 +7021,6 @@ EquivalentClasses(obo:CL_0000440 ObjectIntersectionOf(obo:CL_0000151 ObjectSomeV
 
 # Class: obo:CL_0000441 (follicle stem cell)
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000441 "FBbt:00004903"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000441 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000441 "follicle stem cell"^^xsd:string)
 SubClassOf(obo:CL_0000441 obo:CL_0000036)
@@ -7239,7 +7200,6 @@ EquivalentClasses(obo:CL_0000460 ObjectIntersectionOf(obo:CL_0000151 ObjectSomeV
 
 # Class: obo:CL_0000462 (adepithelial cell)
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000462 "FBbt:00003219"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000462 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000462 "adepithelial cell"^^xsd:string)
 SubClassOf(obo:CL_0000462 obo:CL_0000680)
@@ -7256,7 +7216,6 @@ SubClassOf(obo:CL_0000463 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000464))
 # Class: obo:CL_0000464 (epidermoblast)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:7576311"^^xsd:string) obo:IAO_0000115 obo:CL_0000464 "An epidermal progenitor cell that arises from neuroectoderm and in turn gives rise to the epidermal sheath of ventral and cephalic regions."^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000464 "FBbt:00004994"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000464 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000464 "epidermoblast"^^xsd:string)
 SubClassOf(obo:CL_0000464 obo:CL_0000055)
@@ -7265,7 +7224,6 @@ SubClassOf(obo:CL_0000464 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000114))
 
 # Class: obo:CL_0000465 (cardioblast (sensu Arthropoda))
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000465 "FBbt:00001666"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000465 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000465 "cardioblast (sensu Arthropoda)"^^xsd:string)
 SubClassOf(obo:CL_0000465 obo:CL_0010021)
@@ -7285,7 +7243,6 @@ EquivalentClasses(obo:CL_0000467 ObjectIntersectionOf(obo:CL_0000151 ObjectSomeV
 
 # Class: obo:CL_0000468 (neuroglioblast (sensu Nematoda and Protostomia))
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000468 "FBbt:00005147"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000468 "neuroglioblast")
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000468 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000468 "neuroglioblast (sensu Nematoda and Protostomia)"^^xsd:string)
@@ -7295,7 +7252,6 @@ SubClassOf(obo:CL_0000468 ObjectAllValuesFrom(obo:RO_0002162 ObjectComplementOf(
 # Class: obo:CL_0000469 (ganglion mother cell)
 
 AnnotationAssertion(obo:IAO_0000115 obo:CL_0000469 "A neural progenitor cell that is the daughter of a neuroblast (sensu arthopoda).  The progeny of ganglion mother cells develop into neurons, glia and (occasionally) epithelial cells.")
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000469 "FBbt:00005149"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000469 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000469 "ganglion mother cell"^^xsd:string)
 SubClassOf(obo:CL_0000469 obo:CL_0011020)
@@ -7325,7 +7281,6 @@ SubClassOf(obo:CL_0000473 obo:CL_0000003)
 # Class: obo:CL_0000474 (pericardial nephrocyte)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "FBbt:00003184"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO:0061320"^^xsd:string) Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:19783135"^^xsd:string) obo:IAO_0000115 obo:CL_0000474 "An insect renal cell that filters hemolymph and is found with other pericardial nephrocytes in two rows flanking the dorsal vessel."^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000474 "FBbt:00005058"^^xsd:string)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "FBbt:00005058"^^xsd:string) Annotation(oboInOwl:hasDbXref "GO:0061320"^^xsd:string) oboInOwl:hasNarrowSynonym obo:CL_0000474 "pericardial cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000474 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000474 "pericardial nephrocyte"^^xsd:string)
@@ -7358,7 +7313,6 @@ SubClassOf(obo:CL_0000476 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0070460))
 AnnotationAssertion(obo:IAO_0000115 obo:CL_0000477 "A somatic epithelial cell of the insect egg chamber.")
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000477 "follicle cell")
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000477 "ovarian follicle cell")
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000477 "FBbt:00004904"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000477 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000477 "follicle cell of egg chamber"^^xsd:string)
 SubClassOf(obo:CL_0000477 obo:CL_0000500)
@@ -7437,7 +7391,6 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000485 obo:CL_0000097
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:19783135"^^xsd:string) Annotation(oboInOwl:hasDbXref "fbbt:00005059"^^xsd:string) obo:IAO_0000115 obo:CL_0000486 "A large binucleate cell that forms a 'garland' around the anterior end of the proventriculus (cardia) at its junction with the esophagus in both adults and larvae flies. Each cell is surrounded by a basement membrane and there are numerous micro-invaginations (lacunae) extending from the surface into the cytoplasm. At the mouth of each lacuna is a doubled filament forming a specialised filtration system (diaphragm). The filtrate is endocytosed from the lacunae."^^xsd:string)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO:0061321"^^xsd:string) oboInOwl:hasBroadSynonym obo:CL_0000486 "garland nephrocyte"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000486 "BTO:0004596"^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000486 "FBbt:00005059"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000486 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000486 "garland cell"^^xsd:string)
 SubClassOf(obo:CL_0000486 obo:CL_0000227)
@@ -7447,7 +7400,6 @@ SubClassOf(obo:CL_0000486 obo:CL_0002520)
 # Class: obo:CL_0000487 (oenocyte)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:bf"^^xsd:string) Annotation(oboInOwl:hasDbXref "PMID:11171397"^^xsd:string) obo:IAO_0000115 obo:CL_0000487 "A large secretory cell found in clusters underlying the epidermis of the abdominal segments of larval abdominal segments."^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000487 "FBbt:00004995"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000487 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000487 "oenocyte"^^xsd:string)
 SubClassOf(obo:CL_0000487 obo:CL_0000151)
@@ -7898,7 +7850,6 @@ AnnotationAssertion(owl:deprecated obo:CL_0000539 "true"^^xsd:boolean)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "MESH:A08.663"^^xsd:string) Annotation(oboInOwl:hasDbXref "MESH:D009474"^^xsd:string) Annotation(oboInOwl:hasDbXref "http://en.wikipedia.org/wiki/Neuron"^^xsd:string) obo:IAO_0000115 obo:CL_0000540 "The basic cellular unit of nervous tissue. Each neuron consists of a body, an axon, and dendrites. Their purpose is to receive, conduct, and transmit impulses in the nervous system."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000540 "BTO:0000938"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000540 "CALOHA:TS-0683"^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000540 "FBbt:00005106"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000540 "FMA:54527"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000540 "VHOG:0001483"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000540 "WBbt:0003679"^^xsd:string)
@@ -8365,7 +8316,6 @@ SubClassOf(obo:CL_0000578 obo:CL_0001034)
 
 # Class: obo:CL_0000579 (border follicle cell)
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000579 "FBbt:00004905"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000579 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000579 "border follicle cell"^^xsd:string)
 SubClassOf(obo:CL_0000579 obo:CL_0000477)
@@ -9162,7 +9112,6 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000656 obo:CL_0000017
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:0721662544"^^xsd:string) obo:IAO_0000115 obo:CL_0000657 "One of the two haploid cells into which a primary spermatocyte divides, and which in turn gives origin to spermatids."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000657 "BTO:0000709"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000657 "CALOHA:TS-2195"^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000657 "FBbt:00004941"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000657 "FMA:72293"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000657 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000657 "secondary spermatocyte"^^xsd:string)
@@ -9285,7 +9234,6 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000670 obo:CL_0000219
 
 # Class: obo:CL_0000671 (centripetally migrating follicle cell)
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000671 "FBbt:00004906"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000671 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000671 "centripetally migrating follicle cell"^^xsd:string)
 SubClassOf(obo:CL_0000671 obo:CL_0000477)
@@ -9306,7 +9254,6 @@ SubClassOf(obo:CL_0000673 obo:CL_0000028)
 
 # Class: obo:CL_0000674 (interfollicle cell)
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000674 "FBbt:00004910"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000674 "fly stalk cell"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0000674 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000674 "interfollicle cell"^^xsd:string)
@@ -11235,7 +11182,6 @@ SubClassOf(obo:CL_0000849 obo:CL_0000207)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "SANBI:mhl"^^xsd:string) obo:IAO_0000115 obo:CL_0000850 "A neuron that releases serotonin as a neurotransmitter."^^xsd:string)
 AnnotationAssertion(oboInOwl:hasAlternativeId obo:CL_0000850 "CL:0000403"^^xsd:string)
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000850 "FBbt:00005133"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000850 "MESH:D059326"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000850 "WBbt:0006837"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000850 "5-HT neuron"^^xsd:string)
@@ -13890,7 +13836,6 @@ SubClassOf(obo:CL_0001204 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000896))
 
 # Class: obo:CL_0001658 (visual pigment cell (sensu Nematoda and Protostomia))
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0001658 "FBbt:00004230"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasOBONamespace obo:CL_0001658 "cell"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0001658 "visual pigment cell (sensu Nematoda and Protostomia)"^^xsd:string)
 SubClassOf(obo:CL_0001658 obo:CL_0000149)
@@ -24568,7 +24513,6 @@ EquivalentClasses(obo:CL_1000147 ObjectIntersectionOf(obo:CL_0000663 ObjectSomeV
 # Class: obo:CL_1000155 (Malpighian tubule stellate cell)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO:0061330"^^xsd:string) obo:IAO_0000115 obo:CL_1000155 "A specialized epithelial secretory cell that moves chloride ions and water across the tubule epithelium.")
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_1000155 "FBbt:00005797")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "FBbt:00005797"^^xsd:string) oboInOwl:hasExactSynonym obo:CL_1000155 "Malpighian tubule Type II cell")
 AnnotationAssertion(rdfs:label obo:CL_1000155 "Malpighian tubule stellate cell"^^xsd:string)
 SubClassOf(obo:CL_1000155 obo:CL_0000151)

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -10,6 +10,7 @@ Prefix(oboInOwl:=<http://www.geneontology.org/formats/oboInOwl#>)
 
 Ontology(<http://purl.obolibrary.org/obo/cl.owl>
 Import(<http://purl.obolibrary.org/obo/cl/imports/merged_import.owl>)
+Import(<http://purl.obolibrary.org/obo/cl/components/mappings.owl>)
 Annotation(obo:IAO_0000700 obo:CL_0000000)
 Annotation(<http://purl.org/dc/elements/1.1/contributor> "Alexander Diehl")
 Annotation(<http://purl.org/dc/elements/1.1/contributor> "Ceri van Slyke")

--- a/src/ontology/cl-odk.yaml
+++ b/src/ontology/cl-odk.yaml
@@ -83,3 +83,6 @@ robot_report:
     - obsolete-replaced_by
   custom_sparql_exports :
     - basic-report
+components:
+  products:
+    - filename: mappings.owl

--- a/src/ontology/cl.Makefile
+++ b/src/ontology/cl.Makefile
@@ -284,3 +284,20 @@ dosdp_%:
 	wget "$(DOSDP_URL)" -O ../patterns/data/default/$*.tsv
 
 gs_dosdp: dosdp_cellPartOfAnatomicalEntity
+
+
+## FBbt mappings component
+
+# Download the FBbt mapping file
+.PHONY: $(TMPDIR)/fbbt-mappings.sssom.tsv
+$(TMPDIR)/fbbt-mappings.sssom.tsv:
+	if [ $(IMP) = true ]; then wget -O $@ http://purl.obolibrary.org/obo/fbbt/fbbt-mappings.sssom.tsv ; fi
+
+# Attempt to update the canonical FBbt mapping file from a freshly downloaded one
+# (no update if the downloaded file is absent or identical to the one we already have)
+mappings/fbbt-mappings.sssom.tsv: $(TMPDIR)/fbbt-mappings.sssom.tsv
+	if [ -f $< ]; then if ! cmp $< $@ ; then cat $< > $@ ; fi ; fi
+
+# Generate cross-reference component from the FBbt mapping file
+$(COMPONENTSDIR)/mappings.owl: mappings/fbbt-mappings.sssom.tsv ../scripts/sssom2xrefs.awk
+	awk -f ../scripts/sssom2xrefs.awk $< > $@

--- a/src/ontology/components/mappings.owl
+++ b/src/ontology/components/mappings.owl
@@ -1,0 +1,196 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://www.w3.org/2002/07/owl#"
+  xml:base="http://www.w3.org/2002/07/owl"
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
+  <Ontology rdf:about="http://purl.obolibrary.org/obo/cl/components/mappings.owl"/>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000301">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000092</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000066">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00000124</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000465">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001666</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000394">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001685</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000396">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001687</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000395">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001689</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000715">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001690</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000398">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001691</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000373">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00001789</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000462">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00003219</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000718">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004193</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_2000019">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004211</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0001658">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004230</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000086">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004861</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000022">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004873</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000026">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004878</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000023">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004886</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000441">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004903</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000477">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004904</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000579">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004905</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000671">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004906</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000674">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004910</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000087">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004929</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000020">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004934</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000020">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004935</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000017">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004936</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000657">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004941</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000018">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004942</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000019">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004954</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000464">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004994</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000487">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00004995</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000307">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005038</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000474">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005058</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000486">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005059</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000385">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005062</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000387">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005063</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0008007">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005070</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0008004">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005073</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000187">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005074</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000056">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005083</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000540">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005106</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000100">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005123</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000101">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005124</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000099">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005125</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000116">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005128</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000381">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005130</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000403">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005133</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000125">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005144</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000340">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005145</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000338">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005146</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000468">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005147</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000405">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005148</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000469">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005149</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000374">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005169</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000372">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005171</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000382">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005219</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000407">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005221</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000300">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005412</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_1000155">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005797</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0002372">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005812</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000735">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005917</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000000">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00007002</oboInOwl:hasDbXref>
+  </Class>
+  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000025">
+    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00057012</oboInOwl:hasDbXref>
+  </Class>
+</rdf:RDF>

--- a/src/ontology/components/mappings.owl
+++ b/src/ontology/components/mappings.owl
@@ -142,9 +142,6 @@
   <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000381">
     <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005130</oboInOwl:hasDbXref>
   </Class>
-  <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000403">
-    <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005133</oboInOwl:hasDbXref>
-  </Class>
   <Class rdf:about="http://purl.obolibrary.org/obo/CL_0000125">
     <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">FBbt:00005144</oboInOwl:hasDbXref>
   </Class>

--- a/src/ontology/mappings/fbbt-mappings.sssom.tsv
+++ b/src/ontology/mappings/fbbt-mappings.sssom.tsv
@@ -302,7 +302,6 @@ FBbt:00005124	sensory neuron	skos:exactMatch	CL:0000101	HumanCurated
 FBbt:00005125	interneuron	skos:exactMatch	CL:0000099	HumanCurated
 FBbt:00005128	pioneer neuron	skos:exactMatch	CL:0000116	HumanCurated
 FBbt:00005130	neurosecretory neuron	skos:exactMatch	CL:0000381	HumanCurated
-FBbt:00005133	serotonergic neuron	skos:exactMatch	CL:0000403	HumanCurated
 FBbt:00005136	sensory nerve	skos:exactMatch	UBERON:0001027	HumanCurated
 FBbt:00005139	neuropil	skos:exactMatch	UBERON:0002606	HumanCurated
 FBbt:00005144	glial cell	skos:exactMatch	CL:0000125	HumanCurated

--- a/src/ontology/mappings/fbbt-mappings.sssom.tsv
+++ b/src/ontology/mappings/fbbt-mappings.sssom.tsv
@@ -1,0 +1,453 @@
+#curie_map:
+#  FBbt: "http://purl.obolibrary.org/obo/FBbt_"
+#  UBERON: "http://purl.obolibrary.org/obo/UBERON_"
+#  CL: "http://purl.obolibrary.org/obo/CL_"
+#  skos: "http://www.w3.org/2004/02/skos/core"
+#mapping_provider: "http://purl.obolibrary.org/obo/FBbt.owl"
+subject_id	subject_label	predicate_id	object_id	match_type
+FBbt:00000001	organism	skos:exactMatch	UBERON:0000468	HumanCurated
+FBbt:00000002	tagma	skos:exactMatch	UBERON:6000002	HumanCurated
+FBbt:00000003	segment	skos:exactMatch	UBERON:0000914	HumanCurated
+FBbt:00000004	head	skos:exactMatch	UBERON:0000033	HumanCurated
+FBbt:00000004	head	skos:exactMatch	UBERON:6000004	HumanCurated
+FBbt:00000005	ocular segment	skos:exactMatch	UBERON:6000005	HumanCurated
+FBbt:00000006	head segment	skos:exactMatch	UBERON:6000006	HumanCurated
+FBbt:00000007	procephalic segment	skos:exactMatch	UBERON:6000007	HumanCurated
+FBbt:00000008	labral segment	skos:exactMatch	UBERON:6000008	HumanCurated
+FBbt:00000009	antennal segment	skos:exactMatch	UBERON:6000009	HumanCurated
+FBbt:00000011	gnathal segment	skos:exactMatch	UBERON:6000011	HumanCurated
+FBbt:00000014	labial segment	skos:exactMatch	UBERON:6000014	HumanCurated
+FBbt:00000015	thorax	skos:exactMatch	UBERON:6000015	HumanCurated
+FBbt:00000016	thoracic segment	skos:exactMatch	UBERON:6000016	HumanCurated
+FBbt:00000017	prothoracic segment	skos:exactMatch	UBERON:6000017	HumanCurated
+FBbt:00000018	mesothoracic segment	skos:exactMatch	UBERON:6000018	HumanCurated
+FBbt:00000019	metathoracic segment	skos:exactMatch	UBERON:6000019	HumanCurated
+FBbt:00000020	abdomen	skos:exactMatch	UBERON:6000020	HumanCurated
+FBbt:00000021	abdominal segment	skos:exactMatch	UBERON:6000021	HumanCurated
+FBbt:00000029	abdominal segment 8	skos:exactMatch	UBERON:6000029	HumanCurated
+FBbt:00000030	abdominal segment 9	skos:exactMatch	UBERON:6000030	HumanCurated
+FBbt:00000038	chorion	skos:exactMatch	UBERON:0000920	HumanCurated
+FBbt:00000042	vitelline membrane	skos:exactMatch	UBERON:0003125	HumanCurated
+FBbt:00000046	dorsal appendage	skos:exactMatch	UBERON:6000046	HumanCurated
+FBbt:00000052	embryo	skos:exactMatch	UBERON:0000922	HumanCurated
+FBbt:00000092	primordial germ cell	skos:exactMatch	CL:0000301	HumanCurated
+FBbt:00000093	ventral midline of embryo	skos:exactMatch	UBERON:0009571	HumanCurated
+FBbt:00000094	clypeo-labral anlage in statu nascendi	skos:exactMatch	UBERON:6000094	HumanCurated
+FBbt:00000095	amnioserosa	skos:exactMatch	UBERON:0010302	HumanCurated
+FBbt:00000096	ventral furrow	skos:exactMatch	UBERON:6000096	HumanCurated
+FBbt:00000097	cephalic furrow	skos:exactMatch	UBERON:6000097	HumanCurated
+FBbt:00000104	mesoderm anlage	skos:exactMatch	UBERON:6000104	HumanCurated
+FBbt:00000110	germ layer	skos:exactMatch	UBERON:0000923	HumanCurated
+FBbt:00000111	ectoderm	skos:exactMatch	UBERON:0000924	HumanCurated
+FBbt:00000112	dorsal ectoderm	skos:exactMatch	UBERON:6000112	HumanCurated
+FBbt:00000119	anterior ectoderm	skos:exactMatch	UBERON:6000119	HumanCurated
+FBbt:00000123	amnioproctodeal invagination	skos:exactMatch	UBERON:0000931	HumanCurated
+FBbt:00000124	epithelial cell	skos:exactMatch	CL:0000066	HumanCurated
+FBbt:00000125	endoderm	skos:exactMatch	UBERON:0000925	HumanCurated
+FBbt:00000126	mesoderm	skos:exactMatch	UBERON:0000926	HumanCurated
+FBbt:00000128	trunk mesoderm	skos:exactMatch	UBERON:6000128	HumanCurated
+FBbt:00000130	visceral mesoderm	skos:exactMatch	UBERON:6000130	HumanCurated
+FBbt:00000131	mesodermal crest	skos:exactMatch	UBERON:6000131	HumanCurated
+FBbt:00000132	mesodermal crest of segment T3	skos:exactMatch	UBERON:6000132	HumanCurated
+FBbt:00000136	mesectoderm	skos:exactMatch	UBERON:0000927	HumanCurated
+FBbt:00000137	embryonic tagma	skos:exactMatch	UBERON:6000137	HumanCurated
+FBbt:00000154	embryonic segment	skos:exactMatch	UBERON:6000154	HumanCurated
+FBbt:00000155	embryonic head	skos:exactMatch	UBERON:0008816	HumanCurated
+FBbt:00000157	embryonic head segment	skos:exactMatch	UBERON:6000157	HumanCurated
+FBbt:00000158	embryonic procephalic segment	skos:exactMatch	UBERON:6000158	HumanCurated
+FBbt:00000160	embryonic antennal segment	skos:exactMatch	UBERON:6000160	HumanCurated
+FBbt:00000162	embryonic gnathal segment	skos:exactMatch	UBERON:6000162	HumanCurated
+FBbt:00000165	embryonic labial segment	skos:exactMatch	UBERON:6000165	HumanCurated
+FBbt:00000166	embryonic thorax	skos:exactMatch	UBERON:6000166	HumanCurated
+FBbt:00000167	embryonic thoracic segment	skos:exactMatch	UBERON:6000167	HumanCurated
+FBbt:00000168	embryonic prothoracic segment	skos:exactMatch	UBERON:6000168	HumanCurated
+FBbt:00000169	embryonic mesothoracic segment	skos:exactMatch	UBERON:6000169	HumanCurated
+FBbt:00000170	embryonic metathoracic segment	skos:exactMatch	UBERON:6000170	HumanCurated
+FBbt:00000171	embryonic abdomen	skos:exactMatch	UBERON:6000171	HumanCurated
+FBbt:00000172	embryonic abdominal segment	skos:exactMatch	UBERON:6000172	HumanCurated
+FBbt:00000180	embryonic abdominal segment 8	skos:exactMatch	UBERON:6000180	HumanCurated
+FBbt:00000181	embryonic abdominal segment 9	skos:exactMatch	UBERON:6000181	HumanCurated
+FBbt:00000186	embryonic optic lobe primordium	skos:exactMatch	UBERON:6000186	HumanCurated
+FBbt:00000439	stomodeum	skos:exactMatch	UBERON:0000930	HumanCurated
+FBbt:00001055	presumptive embryonic/larval nervous system	skos:exactMatch	UBERON:6001055	HumanCurated
+FBbt:00001056	presumptive embryonic/larval central nervous system	skos:exactMatch	UBERON:6001056	HumanCurated
+FBbt:00001057	neurogenic region	skos:exactMatch	UBERON:0002346	HumanCurated
+FBbt:00001059	visual primordium	skos:exactMatch	UBERON:6001059	HumanCurated
+FBbt:00001060	embryonic brain	skos:exactMatch	UBERON:6001060	HumanCurated
+FBbt:00001135	proneural cluster	skos:exactMatch	UBERON:6001135	HumanCurated
+FBbt:00001648	embryonic imaginal tissue	skos:exactMatch	UBERON:6001648	HumanCurated
+FBbt:00001649	imaginal disc primordium	skos:exactMatch	UBERON:6001649	HumanCurated
+FBbt:00001650	labial disc primordium	skos:exactMatch	UBERON:6001650	HumanCurated
+FBbt:00001652	eye-antennal disc primordium	skos:exactMatch	UBERON:6001652	HumanCurated
+FBbt:00001653	dorsal thoracic disc primordium	skos:exactMatch	UBERON:6001653	HumanCurated
+FBbt:00001655	dorsal mesothoracic disc primordium	skos:exactMatch	UBERON:6001655	HumanCurated
+FBbt:00001656	dorsal metathoracic disc primordium	skos:exactMatch	UBERON:6001656	HumanCurated
+FBbt:00001657	ventral thoracic disc primordium	skos:exactMatch	UBERON:6001657	HumanCurated
+FBbt:00001658	ventral prothoracic disc primordium	skos:exactMatch	UBERON:6001658	HumanCurated
+FBbt:00001661	genital disc primordium	skos:exactMatch	UBERON:6001661	HumanCurated
+FBbt:00001662	male genital disc primordium	skos:exactMatch	UBERON:6001662	HumanCurated
+FBbt:00001663	female genital disc primordium	skos:exactMatch	UBERON:6001663	HumanCurated
+FBbt:00001664	embryonic/larval circulatory system	skos:exactMatch	UBERON:6001664	HumanCurated
+FBbt:00001666	cardioblast	skos:exactMatch	CL:0000465	HumanCurated
+FBbt:00001668	embryonic/larval lymph gland	skos:exactMatch	UBERON:6001668	HumanCurated
+FBbt:00001685	embryonic/larval plasmatocyte	skos:exactMatch	CL:0000394	HumanCurated
+FBbt:00001687	lamellocyte	skos:exactMatch	CL:0000396	HumanCurated
+FBbt:00001689	procrystal cell	skos:exactMatch	CL:0000395	HumanCurated
+FBbt:00001690	embryonic/larval crystal cell	skos:exactMatch	CL:0000715	HumanCurated
+FBbt:00001691	polygonal cell	skos:exactMatch	CL:0000398	HumanCurated
+FBbt:00001718	retrocerebral complex	skos:exactMatch	UBERON:0012325	HumanCurated
+FBbt:00001722	ring gland	skos:exactMatch	UBERON:6001722	HumanCurated
+FBbt:00001727	larva	skos:exactMatch	UBERON:0002548	HumanCurated
+FBbt:00001728	larval tagma	skos:exactMatch	UBERON:6001728	HumanCurated
+FBbt:00001729	larval segment	skos:exactMatch	UBERON:6001729	HumanCurated
+FBbt:00001730	larval head	skos:exactMatch	UBERON:6001730	HumanCurated
+FBbt:00001731	larval ocular segment	skos:exactMatch	UBERON:6001731	HumanCurated
+FBbt:00001732	larval head segment	skos:exactMatch	UBERON:6001732	HumanCurated
+FBbt:00001733	larval procephalic segment	skos:exactMatch	UBERON:6001733	HumanCurated
+FBbt:00001734	larval labral segment	skos:exactMatch	UBERON:6001734	HumanCurated
+FBbt:00001735	larval antennal segment	skos:exactMatch	UBERON:6001735	HumanCurated
+FBbt:00001737	larval gnathal segment	skos:exactMatch	UBERON:6001737	HumanCurated
+FBbt:00001740	larval labial segment	skos:exactMatch	UBERON:6001740	HumanCurated
+FBbt:00001741	larval thorax	skos:exactMatch	UBERON:6001741	HumanCurated
+FBbt:00001742	larval thoracic segment	skos:exactMatch	UBERON:6001742	HumanCurated
+FBbt:00001743	larval prothoracic segment	skos:exactMatch	UBERON:6001743	HumanCurated
+FBbt:00001744	larval mesothoracic segment	skos:exactMatch	UBERON:6001744	HumanCurated
+FBbt:00001745	larval metathoracic segment	skos:exactMatch	UBERON:6001745	HumanCurated
+FBbt:00001746	larval abdomen	skos:exactMatch	UBERON:6001746	HumanCurated
+FBbt:00001747	larval abdominal segment	skos:exactMatch	UBERON:6001747	HumanCurated
+FBbt:00001755	larval abdominal segment 8	skos:exactMatch	UBERON:6001755	HumanCurated
+FBbt:00001756	larval abdominal segment 9	skos:exactMatch	UBERON:6001756	HumanCurated
+FBbt:00001760	larval imaginal tissue	skos:exactMatch	UBERON:6001760	HumanCurated
+FBbt:00001761	imaginal disc	skos:exactMatch	UBERON:0000939	HumanCurated
+FBbt:00001764	labial disc	skos:exactMatch	UBERON:6001764	HumanCurated
+FBbt:00001765	clypeo-labral disc	skos:exactMatch	UBERON:6001765	HumanCurated
+FBbt:00001766	eye-antennal disc	skos:exactMatch	UBERON:6001766	HumanCurated
+FBbt:00001767	antennal disc	skos:exactMatch	UBERON:6001767	HumanCurated
+FBbt:00001776	dorsal thoracic disc	skos:exactMatch	UBERON:6001776	HumanCurated
+FBbt:00001778	wing disc	skos:exactMatch	UBERON:6001778	HumanCurated
+FBbt:00001779	haltere disc	skos:exactMatch	UBERON:6001779	HumanCurated
+FBbt:00001780	ventral thoracic disc	skos:exactMatch	UBERON:6001780	HumanCurated
+FBbt:00001781	prothoracic leg disc	skos:exactMatch	UBERON:6001781	HumanCurated
+FBbt:00001784	genital disc	skos:exactMatch	UBERON:6001784	HumanCurated
+FBbt:00001785	male genital disc	skos:exactMatch	UBERON:6001785	HumanCurated
+FBbt:00001787	female genital disc	skos:exactMatch	UBERON:6001787	HumanCurated
+FBbt:00001789	histoblast	skos:exactMatch	CL:0000373	HumanCurated
+FBbt:00001789	histoblast	skos:exactMatch	UBERON:6001789	HumanCurated
+FBbt:00001790	histoblast nest	skos:exactMatch	UBERON:6001790	HumanCurated
+FBbt:00001791	dorsal histoblast nest abdominal	skos:exactMatch	UBERON:6001791	HumanCurated
+FBbt:00001792	anterior dorsal histoblast nest abdominal	skos:exactMatch	UBERON:6001792	HumanCurated
+FBbt:00001809	posterior dorsal histoblast nest abdominal	skos:exactMatch	UBERON:6001809	HumanCurated
+FBbt:00001842	embryonic/larval digestive system	skos:exactMatch	UBERON:6001842	HumanCurated
+FBbt:00001845	cephalopharyngeal skeleton	skos:exactMatch	UBERON:6001845	HumanCurated
+FBbt:00001848	epipharyngeal sclerite	skos:exactMatch	UBERON:6001848	HumanCurated
+FBbt:00001911	embryonic/larval nervous system	skos:exactMatch	UBERON:6001911	HumanCurated
+FBbt:00001919	embryonic/larval central nervous system	skos:exactMatch	UBERON:6001919	HumanCurated
+FBbt:00001920	embryonic/larval brain	skos:exactMatch	UBERON:6001920	HumanCurated
+FBbt:00001925	embryonic/larval protocerebrum	skos:exactMatch	UBERON:6001925	HumanCurated
+FBbt:00001956	optic nerve	skos:exactMatch	UBERON:0004904	HumanCurated
+FBbt:00002639	embryonic/larval sense organ	skos:exactMatch	UBERON:6002639	HumanCurated
+FBbt:00002642	embryonic/larval ocular segment sensillum	skos:exactMatch	UBERON:6002642	HumanCurated
+FBbt:00002952	prepupa	skos:exactMatch	UBERON:0003142	HumanCurated
+FBbt:00002953	pupa	skos:exactMatch	UBERON:0003143	HumanCurated
+FBbt:00003004	adult	skos:exactMatch	UBERON:0007023	HumanCurated
+FBbt:00003005	adult tagma	skos:exactMatch	UBERON:6003005	HumanCurated
+FBbt:00003006	adult segment	skos:exactMatch	UBERON:6003006	HumanCurated
+FBbt:00003007	adult head	skos:exactMatch	UBERON:6003007	HumanCurated
+FBbt:00003009	adult head segment	skos:exactMatch	UBERON:6003009	HumanCurated
+FBbt:00003010	adult procephalic segment	skos:exactMatch	UBERON:6003010	HumanCurated
+FBbt:00003011	adult labral segment	skos:exactMatch	UBERON:6003011	HumanCurated
+FBbt:00003012	adult antennal segment	skos:exactMatch	UBERON:6003012	HumanCurated
+FBbt:00003018	adult thorax	skos:exactMatch	UBERON:6003018	HumanCurated
+FBbt:00003019	adult thoracic segment	skos:exactMatch	UBERON:6003019	HumanCurated
+FBbt:00003020	adult prothoracic segment	skos:exactMatch	UBERON:6003020	HumanCurated
+FBbt:00003021	adult mesothoracic segment	skos:exactMatch	UBERON:6003021	HumanCurated
+FBbt:00003023	adult abdomen	skos:exactMatch	UBERON:6003023	HumanCurated
+FBbt:00003024	adult abdominal segment	skos:exactMatch	UBERON:6003024	HumanCurated
+FBbt:00003039	adult dorsal trunk	skos:exactMatch	UBERON:6003039	HumanCurated
+FBbt:00003125	alimentary canal	skos:exactMatch	UBERON:0001555	HumanCurated
+FBbt:00003126	adult mouth	skos:exactMatch	UBERON:0000165	HumanCurated
+FBbt:00003154	adult heart	skos:exactMatch	UBERON:0015230	HumanCurated
+FBbt:00003218	adult muscle system	skos:exactMatch	UBERON:6003218	HumanCurated
+FBbt:00003219	adepithelial cell	skos:exactMatch	CL:0000462	HumanCurated
+FBbt:00003259	adult somatic muscle	skos:exactMatch	UBERON:6003259	HumanCurated
+FBbt:00003559	adult nervous system	skos:exactMatch	UBERON:6003559	HumanCurated
+FBbt:00003623	adult central nervous system	skos:exactMatch	UBERON:6003623	HumanCurated
+FBbt:00003624	adult brain	skos:exactMatch	UBERON:6003624	HumanCurated
+FBbt:00003626	supraesophageal ganglion	skos:exactMatch	UBERON:6003626	HumanCurated
+FBbt:00003627	protocerebrum	skos:exactMatch	UBERON:6003627	HumanCurated
+FBbt:00003632	adult central complex	skos:exactMatch	UBERON:6003632	HumanCurated
+FBbt:00003701	adult optic lobe	skos:exactMatch	UBERON:0006795	HumanCurated
+FBbt:00004114	head sensillum	skos:exactMatch	UBERON:0000963	HumanCurated
+FBbt:00004193	cone cell	skos:exactMatch	CL:0000718	HumanCurated
+FBbt:00004199	lens	skos:exactMatch	UBERON:0000207	HumanCurated
+FBbt:00004200	retina	skos:exactMatch	UBERON:0005388	HumanCurated
+FBbt:00004203	adult clypeo-labral anlage	skos:exactMatch	UBERON:6004203	HumanCurated
+FBbt:00004208	developing embryonic structure	skos:exactMatch	UBERON:0002050	HumanCurated
+FBbt:00004211	photoreceptor cell	skos:exactMatch	CL:2000019	HumanCurated
+FBbt:00004230	pigment cell	skos:exactMatch	CL:0001658	HumanCurated
+FBbt:00004296	sex comb	skos:exactMatch	UBERON:6004296	HumanCurated
+FBbt:00004340	wing hair	skos:exactMatch	UBERON:6004340	HumanCurated
+FBbt:00004475	sclerite	skos:exactMatch	UBERON:6004475	HumanCurated
+FBbt:00004476	tergite	skos:exactMatch	UBERON:6004476	HumanCurated
+FBbt:00004477	sternite	skos:exactMatch	UBERON:6004477	HumanCurated
+FBbt:00004481	adult external head	skos:exactMatch	UBERON:6004481	HumanCurated
+FBbt:00004482	head capsule	skos:exactMatch	UBERON:0003153	HumanCurated
+FBbt:00004492	occiput	skos:exactMatch	UBERON:0003155	HumanCurated
+FBbt:00004505	ocellus	skos:exactMatch	UBERON:0003161	HumanCurated
+FBbt:00004506	lateral ocellus	skos:exactMatch	UBERON:0003162	HumanCurated
+FBbt:00004507	medial ocellus	skos:exactMatch	UBERON:0003211	HumanCurated
+FBbt:00004508	eye	skos:exactMatch	UBERON:0000018	HumanCurated
+FBbt:00004510	ommatidium	skos:exactMatch	UBERON:0000971	HumanCurated
+FBbt:00004511	antenna	skos:exactMatch	UBERON:0000972	HumanCurated
+FBbt:00004519	arista	skos:exactMatch	UBERON:6004519	HumanCurated
+FBbt:00004520	mouthpart	skos:exactMatch	UBERON:6004520	HumanCurated
+FBbt:00004521	clypeus	skos:exactMatch	UBERON:6004521	HumanCurated
+FBbt:00004522	labrum	skos:exactMatch	UBERON:0005905	HumanCurated
+FBbt:00004535	proboscis	skos:exactMatch	UBERON:6004535	HumanCurated
+FBbt:00004540	rostrum	skos:exactMatch	UBERON:6004540	HumanCurated
+FBbt:00004551	adult external thorax	skos:exactMatch	UBERON:6004551	HumanCurated
+FBbt:00004552	tergum	skos:exactMatch	UBERON:6004552	HumanCurated
+FBbt:00004557	sternum	skos:exactMatch	UBERON:0003130	HumanCurated
+FBbt:00004578	adult external mesothorax	skos:exactMatch	UBERON:6004578	HumanCurated
+FBbt:00004579	dorsal mesothorax	skos:exactMatch	UBERON:6004579	HumanCurated
+FBbt:00004580	mesothoracic tergum	skos:exactMatch	UBERON:6004580	HumanCurated
+FBbt:00004640	leg	skos:exactMatch	UBERON:0005895	HumanCurated
+FBbt:00004642	tibia	skos:exactMatch	UBERON:0003131	HumanCurated
+FBbt:00004646	tarsal segment	skos:exactMatch	UBERON:6004646	HumanCurated
+FBbt:00004648	metatarsus	skos:exactMatch	UBERON:6004648	HumanCurated
+FBbt:00004663	prothoracic leg	skos:exactMatch	UBERON:6004663	HumanCurated
+FBbt:00004668	prothoracic tarsal segment	skos:exactMatch	UBERON:6004668	HumanCurated
+FBbt:00004670	prothoracic metatarsus	skos:exactMatch	UBERON:6004670	HumanCurated
+FBbt:00004729	wing	skos:exactMatch	UBERON:0000984	HumanCurated
+FBbt:00004751	wing vein	skos:exactMatch	UBERON:0003194	HumanCurated
+FBbt:00004783	haltere	skos:exactMatch	UBERON:0000987	HumanCurated
+FBbt:00004788	adult external abdomen	skos:exactMatch	UBERON:6004788	HumanCurated
+FBbt:00004823	analia	skos:exactMatch	UBERON:6004823	HumanCurated
+FBbt:00004824	female analia	skos:exactMatch	UBERON:6004824	HumanCurated
+FBbt:00004825	male analia	skos:exactMatch	UBERON:6004825	HumanCurated
+FBbt:00004850	phallus	skos:exactMatch	UBERON:0008811	HumanCurated
+FBbt:00004856	organ system	skos:exactMatch	UBERON:0000467	HumanCurated
+FBbt:00004857	reproductive system	skos:exactMatch	UBERON:0000990	HumanCurated
+FBbt:00004858	gonad	skos:exactMatch	UBERON:0000991	HumanCurated
+FBbt:00004861	germline stem cell	skos:exactMatch	CL:0000086	HumanCurated
+FBbt:00004864	female reproductive system	skos:exactMatch	UBERON:0000474	HumanCurated
+FBbt:00004865	ovary	skos:exactMatch	UBERON:0000992	HumanCurated
+FBbt:00004873	female germline stem cell	skos:exactMatch	CL:0000022	HumanCurated
+FBbt:00004878	nurse cell	skos:exactMatch	CL:0000026	HumanCurated
+FBbt:00004886	oocyte	skos:exactMatch	CL:0000023	HumanCurated
+FBbt:00004894	egg chamber	skos:exactMatch	UBERON:0003199	HumanCurated
+FBbt:00004903	follicle stem cell	skos:exactMatch	CL:0000441	HumanCurated
+FBbt:00004904	follicle cell	skos:exactMatch	CL:0000477	HumanCurated
+FBbt:00004905	border follicle cell	skos:exactMatch	CL:0000579	HumanCurated
+FBbt:00004906	centripetal follicle cell	skos:exactMatch	CL:0000671	HumanCurated
+FBbt:00004910	stalk follicle cell	skos:exactMatch	CL:0000674	HumanCurated
+FBbt:00004921	spermathecum	skos:exactMatch	UBERON:0000994	HumanCurated
+FBbt:00004924	uterus	skos:exactMatch	UBERON:0006834	HumanCurated
+FBbt:00004927	male reproductive system	skos:exactMatch	UBERON:0000079	HumanCurated
+FBbt:00004928	testis	skos:exactMatch	UBERON:0000473	HumanCurated
+FBbt:00004929	male germline stem cell	skos:exactMatch	CL:0000087	HumanCurated
+FBbt:00004934	primary gonial cell	skos:exactMatch	CL:0000020	HumanCurated
+FBbt:00004935	spermatogonium	skos:exactMatch	CL:0000020	HumanCurated
+FBbt:00004936	spermatocyte	skos:exactMatch	CL:0000017	HumanCurated
+FBbt:00004941	secondary spermatocyte	skos:exactMatch	CL:0000657	HumanCurated
+FBbt:00004942	spermatid	skos:exactMatch	CL:0000018	HumanCurated
+FBbt:00004954	spermatozoon	skos:exactMatch	CL:0000019	HumanCurated
+FBbt:00004958	seminal vesicle	skos:exactMatch	UBERON:0006868	HumanCurated
+FBbt:00004969	integumentary system	skos:exactMatch	UBERON:0002416	HumanCurated
+FBbt:00004970	cuticle	skos:exactMatch	UBERON:0001001	HumanCurated
+FBbt:00004973	exocuticle	skos:exactMatch	UBERON:0003201	HumanCurated
+FBbt:00004974	endocuticle	skos:exactMatch	UBERON:0003202	HumanCurated
+FBbt:00004979	trichome	skos:exactMatch	UBERON:6004979	HumanCurated
+FBbt:00004983	embryonic/larval cuticle	skos:exactMatch	UBERON:6004983	HumanCurated
+FBbt:00004986	third instar larval cuticle	skos:exactMatch	UBERON:6004986	HumanCurated
+FBbt:00004987	puparium cuticle	skos:exactMatch	UBERON:0018656	HumanCurated
+FBbt:00004993	epidermis	skos:exactMatch	UBERON:0007376	HumanCurated
+FBbt:00004994	epidermoblast	skos:exactMatch	CL:0000464	HumanCurated
+FBbt:00004995	oenocyte	skos:exactMatch	CL:0000487	HumanCurated
+FBbt:00005023	imaginal precursor	skos:exactMatch	UBERON:6005023	HumanCurated
+FBbt:00005024	tracheal system	skos:exactMatch	UBERON:0005155	HumanCurated
+FBbt:00005036	tracheal pit	skos:exactMatch	UBERON:6005036	HumanCurated
+FBbt:00005037	tracheal primordium	skos:exactMatch	UBERON:6005037	HumanCurated
+FBbt:00005038	tracheocyte	skos:exactMatch	CL:0000307	HumanCurated
+FBbt:00005043	trachea	skos:exactMatch	UBERON:6005043	HumanCurated
+FBbt:00005054	spiracle	skos:exactMatch	UBERON:6005054	HumanCurated
+FBbt:00005055	digestive system	skos:exactMatch	UBERON:0001007	HumanCurated
+FBbt:00005056	excretory system	skos:exactMatch	UBERON:0001008	HumanCurated
+FBbt:00005057	circulatory system	skos:exactMatch	UBERON:0009054	HumanCurated
+FBbt:00005058	pericardial cell	skos:exactMatch	CL:0000474	HumanCurated
+FBbt:00005059	garland cell	skos:exactMatch	CL:0000486	HumanCurated
+FBbt:00005060	hemocoel	skos:exactMatch	UBERON:0002323	HumanCurated
+FBbt:00005061	hemolymph	skos:exactMatch	UBERON:0001011	HumanCurated
+FBbt:00005062	prohemocyte	skos:exactMatch	CL:0000385	HumanCurated
+FBbt:00005063	hemocyte	skos:exactMatch	CL:0000387	HumanCurated
+FBbt:00005066	fat body	skos:exactMatch	UBERON:0003917	HumanCurated
+FBbt:00005068	endocrine system	skos:exactMatch	UBERON:0000949	HumanCurated
+FBbt:00005069	muscle system	skos:exactMatch	UBERON:0000383	HumanCurated
+FBbt:00005070	visceral muscle cell	skos:exactMatch	CL:0008007	HumanCurated
+FBbt:00005073	somatic muscle cell	skos:exactMatch	CL:0008004	HumanCurated
+FBbt:00005074	muscle cell	skos:exactMatch	CL:0000187	HumanCurated
+FBbt:00005083	myoblast	skos:exactMatch	CL:0000056	HumanCurated
+FBbt:00005093	nervous system	skos:exactMatch	UBERON:0001016	HumanCurated
+FBbt:00005094	central nervous system	skos:exactMatch	UBERON:0001017	HumanCurated
+FBbt:00005095	brain	skos:exactMatch	UBERON:0000955	HumanCurated
+FBbt:00005096	stomatogastric nervous system	skos:exactMatch	UBERON:6005096	HumanCurated
+FBbt:00005097	ventral nerve cord	skos:exactMatch	UBERON:0000934	HumanCurated
+FBbt:00005098	peripheral nervous system	skos:exactMatch	UBERON:0000010	HumanCurated
+FBbt:00005099	neuron projection bundle	skos:exactMatch	UBERON:0000122	HumanCurated
+FBbt:00005100	tract	skos:exactMatch	UBERON:0001018	HumanCurated
+FBbt:00005105	nerve	skos:exactMatch	UBERON:0001021	HumanCurated
+FBbt:00005106	neuron	skos:exactMatch	CL:0000540	HumanCurated
+FBbt:00005123	motor neuron	skos:exactMatch	CL:0000100	HumanCurated
+FBbt:00005124	sensory neuron	skos:exactMatch	CL:0000101	HumanCurated
+FBbt:00005125	interneuron	skos:exactMatch	CL:0000099	HumanCurated
+FBbt:00005128	pioneer neuron	skos:exactMatch	CL:0000116	HumanCurated
+FBbt:00005130	neurosecretory neuron	skos:exactMatch	CL:0000381	HumanCurated
+FBbt:00005133	serotonergic neuron	skos:exactMatch	CL:0000403	HumanCurated
+FBbt:00005136	sensory nerve	skos:exactMatch	UBERON:0001027	HumanCurated
+FBbt:00005139	neuropil	skos:exactMatch	UBERON:0002606	HumanCurated
+FBbt:00005144	glial cell	skos:exactMatch	CL:0000125	HumanCurated
+FBbt:00005145	glioblast	skos:exactMatch	CL:0000340	HumanCurated
+FBbt:00005146	neuroblast	skos:exactMatch	CL:0000338	HumanCurated
+FBbt:00005147	neuroglioblast	skos:exactMatch	CL:0000468	HumanCurated
+FBbt:00005148	neuroepidermoblast	skos:exactMatch	CL:0000405	HumanCurated
+FBbt:00005149	ganglion mother cell	skos:exactMatch	CL:0000469	HumanCurated
+FBbt:00005155	sense organ	skos:exactMatch	UBERON:0000020	HumanCurated
+FBbt:00005157	chemosensory sensory organ	skos:exactMatch	UBERON:0000005	HumanCurated
+FBbt:00005158	olfactory sensory organ	skos:exactMatch	UBERON:0002268	HumanCurated
+FBbt:00005159	gustatory sensory organ	skos:exactMatch	UBERON:0003212	HumanCurated
+FBbt:00005162	photoreceptor	skos:exactMatch	UBERON:0000970	HumanCurated
+FBbt:00005168	external sensory organ	skos:exactMatch	UBERON:6005168	HumanCurated
+FBbt:00005169	trichogen cell	skos:exactMatch	CL:0000374	HumanCurated
+FBbt:00005171	tormogen cell	skos:exactMatch	CL:0000372	HumanCurated
+FBbt:00005177	chaeta	skos:exactMatch	UBERON:6005177	HumanCurated
+FBbt:00005215	chordotonal organ	skos:exactMatch	UBERON:0001038	HumanCurated
+FBbt:00005219	scolopale cell	skos:exactMatch	CL:0000382	HumanCurated
+FBbt:00005221	scolopidial ligament cell	skos:exactMatch	CL:0000407	HumanCurated
+FBbt:00005317	gastrula embryo	skos:exactMatch	UBERON:0004734	HumanCurated
+FBbt:00005333	late embryo	skos:exactMatch	UBERON:0000323	HumanCurated
+FBbt:00005338	second instar larva	skos:exactMatch	UBERON:0018382	HumanCurated
+FBbt:00005378	wing margin	skos:exactMatch	UBERON:6005378	HumanCurated
+FBbt:00005379	foregut	skos:exactMatch	UBERON:0001041	HumanCurated
+FBbt:00005380	pharynx	skos:exactMatch	UBERON:0006562	HumanCurated
+FBbt:00005382	salivary gland	skos:exactMatch	UBERON:0001044	HumanCurated
+FBbt:00005383	midgut	skos:exactMatch	UBERON:0001045	HumanCurated
+FBbt:00005384	hindgut	skos:exactMatch	UBERON:0001046	HumanCurated
+FBbt:00005386	glomerulus	skos:exactMatch	UBERON:0001047	HumanCurated
+FBbt:00005393	embryonic/larval integumentary system	skos:exactMatch	UBERON:6005393	HumanCurated
+FBbt:00005396	adult integumentary system	skos:exactMatch	UBERON:6005396	HumanCurated
+FBbt:00005412	gamete	skos:exactMatch	CL:0000300	HumanCurated
+FBbt:00005413	anlage in statu nascendi	skos:exactMatch	UBERON:6005413	HumanCurated
+FBbt:00005425	visual anlage in statu nascendi	skos:exactMatch	UBERON:6005425	HumanCurated
+FBbt:00005426	anlage	skos:exactMatch	UBERON:0007688	HumanCurated
+FBbt:00005427	ectoderm anlage	skos:exactMatch	UBERON:6005427	HumanCurated
+FBbt:00005428	dorsal ectoderm anlage	skos:exactMatch	UBERON:6005428	HumanCurated
+FBbt:00005434	visual anlage	skos:exactMatch	UBERON:6005434	HumanCurated
+FBbt:00005436	trunk mesoderm anlage	skos:exactMatch	UBERON:6005436	HumanCurated
+FBbt:00005439	clypeo-labral anlage	skos:exactMatch	UBERON:6005439	HumanCurated
+FBbt:00005461	circulatory system primordium	skos:exactMatch	UBERON:6005461	HumanCurated
+FBbt:00005467	lymph gland primordium	skos:exactMatch	UBERON:6005467	HumanCurated
+FBbt:00005495	primordium	skos:exactMatch	UBERON:0001048	HumanCurated
+FBbt:00005514	clypeo-labral disc primordium	skos:exactMatch	UBERON:6005514	HumanCurated
+FBbt:00005526	dorsal epidermis primordium	skos:exactMatch	UBERON:6005526	HumanCurated
+FBbt:00005533	ventral epidermis primordium	skos:exactMatch	UBERON:6005533	HumanCurated
+FBbt:00005538	clypeo-labral primordium	skos:exactMatch	UBERON:6005538	HumanCurated
+FBbt:00005541	cardiogenic mesoderm	skos:exactMatch	UBERON:6005541	HumanCurated
+FBbt:00005558	ventral ectoderm	skos:exactMatch	UBERON:6005558	HumanCurated
+FBbt:00005569	presumptive embryonic/larval tracheal system	skos:exactMatch	UBERON:6005569	HumanCurated
+FBbt:00005756	rectum	skos:exactMatch	UBERON:0006866	HumanCurated
+FBbt:00005757	neurohemal organ	skos:exactMatch	UBERON:0001053	HumanCurated
+FBbt:00005786	Malpighian tubule	skos:exactMatch	UBERON:0001054	HumanCurated
+FBbt:00005797	Malpighian tubule Type II cell	skos:exactMatch	CL:1000155	HumanCurated
+FBbt:00005799	corpus cardiacum	skos:exactMatch	UBERON:0001056	HumanCurated
+FBbt:00005800	corpus allatum	skos:exactMatch	UBERON:0001057	HumanCurated
+FBbt:00005801	mushroom body	skos:exactMatch	UBERON:0001058	HumanCurated
+FBbt:00005802	pars intercerebralis	skos:exactMatch	UBERON:0001059	HumanCurated
+FBbt:00005805	Bolwig organ	skos:exactMatch	UBERON:6005805	HumanCurated
+FBbt:00005811	articulation	skos:exactMatch	UBERON:0004905	HumanCurated
+FBbt:00005812	myotube	skos:exactMatch	CL:0002372	HumanCurated
+FBbt:00005830	Bolwig organ primordium	skos:exactMatch	UBERON:6005830	HumanCurated
+FBbt:00005831	dorsal imaginal tissue	skos:exactMatch	UBERON:6005831	HumanCurated
+FBbt:00005835	extraembryonic structure	skos:exactMatch	UBERON:0000478	HumanCurated
+FBbt:00005913	arista lateral	skos:exactMatch	UBERON:6005913	HumanCurated
+FBbt:00005917	lymph gland derived hemocyte	skos:exactMatch	CL:0000735	HumanCurated
+FBbt:00006011	pharate adult	skos:exactMatch	UBERON:6006011	HumanCurated
+FBbt:00006032	mesothoracic tergum primordium	skos:exactMatch	UBERON:6006032	HumanCurated
+FBbt:00007000	appendage	skos:exactMatch	UBERON:0000026	HumanCurated
+FBbt:00007001	anatomical structure	skos:exactMatch	UBERON:0000061	HumanCurated
+FBbt:00007002	cell	skos:exactMatch	CL:0000000	HumanCurated
+FBbt:00007003	portion of tissue	skos:exactMatch	UBERON:0000479	HumanCurated
+FBbt:00007004	male organism	skos:exactMatch	UBERON:0003101	HumanCurated
+FBbt:00007005	epithelium	skos:exactMatch	UBERON:0000483	HumanCurated
+FBbt:00007006	developing material anatomical entity	skos:exactMatch	UBERON:0005423	HumanCurated
+FBbt:00007009	organism subdivision	skos:exactMatch	UBERON:0000475	HumanCurated
+FBbt:00007010	multi-tissue structure	skos:exactMatch	UBERON:0000481	HumanCurated
+FBbt:00007011	female organism	skos:exactMatch	UBERON:0003100	HumanCurated
+FBbt:00007013	acellular anatomical structure	skos:exactMatch	UBERON:0000476	HumanCurated
+FBbt:00007015	immaterial anatomical entity	skos:exactMatch	UBERON:0000466	HumanCurated
+FBbt:00007016	material anatomical entity	skos:exactMatch	UBERON:0000465	HumanCurated
+FBbt:00007017	anatomical space	skos:exactMatch	UBERON:0000464	HumanCurated
+FBbt:00007018	appendage segment	skos:exactMatch	UBERON:0010758	HumanCurated
+FBbt:00007019	portion of organism substance	skos:exactMatch	UBERON:0000463	HumanCurated
+FBbt:00007020	metatarsus of male prothoracic leg	skos:exactMatch	UBERON:6007020	HumanCurated
+FBbt:00007027	cuboidal/columnar epithelium	skos:exactMatch	UBERON:0000485	HumanCurated
+FBbt:00007045	trunk ectoderm	skos:exactMatch	UBERON:6007045	HumanCurated
+FBbt:00007046	dorsal ectoderm derivative	skos:exactMatch	UBERON:6007046	HumanCurated
+FBbt:00007060	multi-cell-component structure	skos:exactMatch	UBERON:0005162	HumanCurated
+FBbt:00007070	embryonic/larval posterior inferior protocerebrum	skos:exactMatch	UBERON:6007070	HumanCurated
+FBbt:00007091	subperineurial glial sheath	skos:exactMatch	UBERON:0000202	HumanCurated
+FBbt:00007116	presumptive embryonic/larval system	skos:exactMatch	UBERON:6007116	HumanCurated
+FBbt:00007145	adult protocerebrum	skos:exactMatch	UBERON:6007145	HumanCurated
+FBbt:00007149	segment of antenna	skos:exactMatch	UBERON:6007149	HumanCurated
+FBbt:00007150	segment of leg	skos:exactMatch	UBERON:6007150	HumanCurated
+FBbt:00007152	sensillum	skos:exactMatch	UBERON:0002536	HumanCurated
+FBbt:00007229	cell cluster organ	skos:exactMatch	UBERON:0010001	HumanCurated
+FBbt:00007230	compound cell cluster organ	skos:exactMatch	UBERON:0014732	HumanCurated
+FBbt:00007231	external sensillum	skos:exactMatch	UBERON:6007231	HumanCurated
+FBbt:00007232	eo-type sensillum	skos:exactMatch	UBERON:6007232	HumanCurated
+FBbt:00007233	internal sensillum	skos:exactMatch	UBERON:6007233	HumanCurated
+FBbt:00007240	embryonic/larval sensillum	skos:exactMatch	UBERON:6007240	HumanCurated
+FBbt:00007242	embryonic/larval head sensillum	skos:exactMatch	UBERON:6007242	HumanCurated
+FBbt:00007245	cuticular specialization	skos:exactMatch	UBERON:6007245	HumanCurated
+FBbt:00007248	chorionic specialization	skos:exactMatch	UBERON:6007248	HumanCurated
+FBbt:00007276	anatomical group	skos:exactMatch	UBERON:0034923	HumanCurated
+FBbt:00007277	anatomical cluster	skos:exactMatch	UBERON:0000477	HumanCurated
+FBbt:00007278	non-connected functional system	skos:exactMatch	UBERON:0015203	HumanCurated
+FBbt:00007280	embryonic/larval head sense organ	skos:exactMatch	UBERON:6007280	HumanCurated
+FBbt:00007284	region of integument	skos:exactMatch	UBERON:6007284	HumanCurated
+FBbt:00007285	segmental subdivision of integument	skos:exactMatch	UBERON:6007285	HumanCurated
+FBbt:00007288	integumentary specialization	skos:exactMatch	UBERON:6007288	HumanCurated
+FBbt:00007289	tagmatic subdivision of integument	skos:exactMatch	UBERON:6007289	HumanCurated
+FBbt:00007330	organ system subdivision	skos:exactMatch	UBERON:0011216	HumanCurated
+FBbt:00007331	segmental subdivision of organ system	skos:exactMatch	UBERON:6007331	HumanCurated
+FBbt:00007373	internal sense organ	skos:exactMatch	UBERON:6007373	HumanCurated
+FBbt:00007410	tracheal lumen	skos:exactMatch	UBERON:0006832	HumanCurated
+FBbt:00007424	epithelial furrow	skos:exactMatch	UBERON:6007424	HumanCurated
+FBbt:00007474	epithelial tube	skos:exactMatch	UBERON:0003914	HumanCurated
+FBbt:00007692	sensory system	skos:exactMatch	UBERON:0001032	HumanCurated
+FBbt:00016022	abdominal histoblast primordium	skos:exactMatch	UBERON:6016022	HumanCurated
+FBbt:00017021	abdominal histoblast anlage	skos:exactMatch	UBERON:6017021	HumanCurated
+FBbt:00025990	ectodermal derivative	skos:exactMatch	UBERON:0004121	HumanCurated
+FBbt:00025991	anterior ectoderm derivative	skos:exactMatch	UBERON:6025991	HumanCurated
+FBbt:00025993	ventral ectoderm derivative	skos:exactMatch	UBERON:6025993	HumanCurated
+FBbt:00025998	mesodermal derivative	skos:exactMatch	UBERON:0004120	HumanCurated
+FBbt:00026000	trunk mesoderm derivative	skos:exactMatch	UBERON:6026000	HumanCurated
+FBbt:00026002	visceral mesoderm derivative	skos:exactMatch	UBERON:6026002	HumanCurated
+FBbt:00040003	non-connected developing system	skos:exactMatch	UBERON:6040003	HumanCurated
+FBbt:00040005	synaptic neuropil	skos:exactMatch	UBERON:6040005	HumanCurated
+FBbt:00040007	synaptic neuropil domain	skos:exactMatch	UBERON:6040007	HumanCurated
+FBbt:00041000	synaptic neuropil block	skos:exactMatch	UBERON:6041000	HumanCurated
+FBbt:00047153	anus	skos:exactMatch	UBERON:0001245	HumanCurated
+FBbt:00057001	anterior-posterior subdivision of organism	skos:exactMatch	UBERON:6057001	HumanCurated
+FBbt:00057012	female germline cell	skos:exactMatch	CL:0000025	HumanCurated
+FBbt:00058291	dorsal vessel	skos:exactMatch	UBERON:0015231	HumanCurated
+FBbt:00100152	row	skos:exactMatch	UBERON:0034926	HumanCurated
+FBbt:00100153	sensillum row	skos:exactMatch	UBERON:6100153	HumanCurated
+FBbt:00100313	multicellular structure	skos:exactMatch	UBERON:0010000	HumanCurated
+FBbt:00100314	duct	skos:exactMatch	UBERON:0000058	HumanCurated
+FBbt:00100315	gut section	skos:exactMatch	UBERON:0004921	HumanCurated
+FBbt:00100316	diverticulum of gut	skos:exactMatch	UBERON:0009854	HumanCurated
+FBbt:00100317	gland	skos:exactMatch	UBERON:0002530	HumanCurated
+FBbt:00110636	adult cerebral ganglion	skos:exactMatch	UBERON:6110636	HumanCurated
+FBbt:00110746	presumptive prothoracic metatarsus	skos:exactMatch	UBERON:6110746	HumanCurated
+FBbt:00110811	presumptive arista	skos:exactMatch	UBERON:6110811	HumanCurated
+FBbt:10000000	anatomical entity	skos:exactMatch	UBERON:0001062	HumanCurated

--- a/src/scripts/sssom2xrefs.awk
+++ b/src/scripts/sssom2xrefs.awk
@@ -1,0 +1,39 @@
+# Generate a OWL file of cross-references from a SSSOM TSV file.
+# Warning: This script assumes a valid SSSOM TSV file.
+
+# Minimal OWL boilerplate
+BEGIN {
+  FS = "\t";
+  print "<?xml version=\"1.0\"?>";
+  print "<rdf:RDF xmlns=\"http://www.w3.org/2002/07/owl#\"";
+  print "  xml:base=\"http://www.w3.org/2002/07/owl\"";
+  print "  xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"";
+  print "  xmlns:oboInOwl=\"http://www.geneontology.org/formats/oboInOwl#\">";
+  print "  <Ontology rdf:about=\"http://purl.obolibrary.org/obo/cl/components/mappings.owl\"/>";
+}
+
+END {
+  print "</rdf:RDF>";
+}
+
+# Find the column containing the object ID
+# (We do not need to do that for the subject ID, as the SSSOM
+#  specification says the subject_id is always the first column)
+/^subject_id/ {
+  for ( i = 1; i < NF; i++ ) {
+    if ( $i == "object_id" ) {
+      object_index = i;
+    }
+  }  
+}
+
+# We only generate cross-references for "exact" mappings
+/skos:exactMatch/ {
+  split($object_index, object, ":");
+  # Only process mappings where the object term belongs to Uberon
+  if ( object[1] == "CL" ) {
+    print "  <Class rdf:about=\"http://purl.obolibrary.org/obo/CL_"object[2]"\">";
+    print "    <oboInOwl:hasDbXref rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">"$1"</oboInOwl:hasDbXref>";
+    print "  </Class>";
+  }
+}


### PR DESCRIPTION
Currently, mappings between CL and FBbt are managed the “classical way”, as cross-references stored on the CL side (though some of them also used to be stored on the FBbt side).

This PR switches from the “classical way” to FBbt-maintained mappings in the SSSOM format. To do that, it:

* removes all FBbt cross-references from the -edit file;
* imports a new dedicated `mappings.owl` component;
* updates the Makefile to automatically download the SSSOM file from FBbt and generate the `mappings.owl` component.

This is exactly the same approach as the one already in use in Uberon.

The initial plan was to have those mapping components managed directly by the ODK (to avoid duplication of code across repositories), but since we don’t have yet a roadmap in the ODK for that, I’d rather accept _some_ duplication for now instead of letting the CL/FBbt mappings go without updates.