### PR TITLE
Addresses #1627 Update a_adding_term_cellxgene.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/a_adding_term_cellxgene.md
+++ b/.github/ISSUE_TEMPLATE/a_adding_term_cellxgene.md
@@ -3,7 +3,7 @@ name: Add term (cellxgene)
 about: New term suggestion for CL via cellxgene
 title: "[NTR-cxg]"
 assignees: bvarner-ebi
-labels: 'new term request', 'cellxgene'
+labels: new term request, cellxgene
 ---
 
 Note - please check that the term does not already exist (check OLS: https://www.ebi.ac.uk/ols/ontologies/cl)


### PR DESCRIPTION
Template was not appearing in GitHub. It may have to do with the quotes I used in the label values. [h_typos_bugs.md](https://github.com/obophenotype/cell-ontology/files/8917596/h_typos_bugs.md) is a template that uses multiple labels with no quotes, so I updated a_adding_term_cellxgene.md to match the format.
 