### PR TITLE
Add taxon restriction to `epidermal cell (sensu Arthropoda)`.

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -6795,12 +6795,13 @@ EquivalentClasses(obo:CL_0000460 ObjectIntersectionOf(obo:CL_0000151 ObjectSomeV
 AnnotationAssertion(rdfs:label obo:CL_0000462 "adepithelial cell"^^xsd:string)
 SubClassOf(obo:CL_0000462 obo:CL_0000680)
 
-# Class: obo:CL_0000463 (epidermal cell (sensu arthropoda))
+# Class: obo:CL_0000463 (epidermal cell (sensu Arthropoda))
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "FlyBase:ds"^^xsd:string) Annotation(oboInOwl:hasDbXref "ISBN:ISBN:978-0801481253"^^xsd:string) obo:IAO_0000115 obo:CL_0000463 "An epidermal cell that secretes chitinous cuticle from its apical side."^^xsd:string)
 AnnotationAssertion(rdfs:comment obo:CL_0000463 "While insect epidermis is generally columnar/cuboidal, there are certainly well studied cases where it is not (e.g.- Rhodnius prolixus when starved). So it would be safer to add this as a differentium for particular species where this is known. -DSJ."^^xsd:string)
-AnnotationAssertion(rdfs:label obo:CL_0000463 "epidermal cell (sensu arthropoda)"^^xsd:string)
+AnnotationAssertion(rdfs:label obo:CL_0000463 "epidermal cell (sensu Arthropoda)"^^xsd:string)
 SubClassOf(obo:CL_0000463 obo:CL_0000362)
+SubClassOf(obo:CL_0000463 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_6656))
 SubClassOf(obo:CL_0000463 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000464))
 
 # Class: obo:CL_0000464 (epidermoblast)


### PR DESCRIPTION
The term `epidermal cell (sensu Arthropoda)` is intended to refer to arthropod cells only, so this PR makes that explicit with the appropriate taxon restriction.

The label is also changed from `... (sensu arthropoda)` to `... (sensu Arthropoda)`, for consistency with other terms with similar "sensu" qualifications (taxons in "sensu"-type expressions are always capitalized).

closes #342