### PR TITLE
remove "not" in CL

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -3939,9 +3939,9 @@ SubClassOf(obo:CL_0000085 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_7742
 
 # Class: obo:CL_0000086 (germ line stem cell (sensu Nematoda and Protostomia))
 
+AnnotationAssertion(obo:RO_0002161 obo:CL_0000086 obo:NCBITaxon_33511)
 AnnotationAssertion(rdfs:label obo:CL_0000086 "germ line stem cell (sensu Nematoda and Protostomia)"^^xsd:string)
 SubClassOf(obo:CL_0000086 obo:CL_0000014)
-SubClassOf(obo:CL_0000086 ObjectAllValuesFrom(obo:RO_0002162 ObjectComplementOf(obo:NCBITaxon_33511)))
 
 # Class: obo:CL_0000087 (male germ line stem cell (sensu Nematoda and Protostomia))
 
@@ -4363,9 +4363,9 @@ SubClassOf(obo:CL_0000129 ObjectSomeValuesFrom(obo:RO_0002202 ObjectIntersection
 
 # Class: obo:CL_0000130 (neuron associated cell (sensu Nematoda and Protostomia))
 
+AnnotationAssertion(obo:RO_0002161 obo:CL_0000130 obo:NCBITaxon_33511)
 AnnotationAssertion(rdfs:label obo:CL_0000130 "neuron associated cell (sensu Nematoda and Protostomia)"^^xsd:string)
 SubClassOf(obo:CL_0000130 obo:CL_0000095)
-SubClassOf(obo:CL_0000130 ObjectAllValuesFrom(obo:RO_0002162 ObjectComplementOf(obo:NCBITaxon_33511)))
 
 # Class: obo:CL_0000131 (gut endothelial cell)
 
@@ -6070,10 +6070,10 @@ AnnotationAssertion(owl:deprecated obo:CL_0000337 "true"^^xsd:boolean)
 
 # Class: obo:CL_0000338 (neuroblast (sensu Nematoda and Protostomia))
 
+AnnotationAssertion(obo:RO_0002161 obo:CL_0000338 obo:NCBITaxon_33511)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000338 "neuroblast"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000338 "neuroblast (sensu Nematoda and Protostomia)"^^xsd:string)
 SubClassOf(obo:CL_0000338 obo:CL_0000047)
-SubClassOf(obo:CL_0000338 ObjectAllValuesFrom(obo:RO_0002162 ObjectComplementOf(obo:NCBITaxon_33511)))
 
 # Class: obo:CL_0000339 (glioblast (sensu Vertebrata))
 
@@ -6087,16 +6087,16 @@ SubClassOf(obo:CL_0000339 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_7742
 
 # Class: obo:CL_0000340 (glioblast (sensu Nematoda and Protostomia))
 
+AnnotationAssertion(obo:RO_0002161 obo:CL_0000340 obo:NCBITaxon_33511)
 AnnotationAssertion(rdfs:label obo:CL_0000340 "glioblast (sensu Nematoda and Protostomia)"^^xsd:string)
 SubClassOf(obo:CL_0000340 obo:CL_0000030)
 SubClassOf(obo:CL_0000340 obo:CL_0000130)
-SubClassOf(obo:CL_0000340 ObjectAllValuesFrom(obo:RO_0002162 ObjectComplementOf(obo:NCBITaxon_33511)))
 
 # Class: obo:CL_0000341 (pigment cell (sensu Nematoda and Protostomia))
 
+AnnotationAssertion(obo:RO_0002161 obo:CL_0000341 obo:NCBITaxon_33511)
 AnnotationAssertion(rdfs:label obo:CL_0000341 "pigment cell (sensu Nematoda and Protostomia)"^^xsd:string)
 SubClassOf(obo:CL_0000341 obo:CL_0000147)
-SubClassOf(obo:CL_0000341 ObjectAllValuesFrom(obo:RO_0002162 ObjectComplementOf(obo:NCBITaxon_33511)))
 
 # Class: obo:CL_0000342 (pigment cell (sensu Vertebrata))
 
@@ -6322,10 +6322,10 @@ AnnotationAssertion(owl:deprecated obo:CL_0000370 "true"^^xsd:boolean)
 # Class: obo:CL_0000371 (protoplast)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "ISBN:08199377X"^^xsd:string) obo:IAO_0000115 obo:CL_0000371 "The cell protoplasm after removal of the cell wall."^^xsd:string)
+AnnotationAssertion(obo:RO_0002161 obo:CL_0000371 obo:NCBITaxon_33208)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000371 "MESH:D011523"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000371 "protoplast"^^xsd:string)
 SubClassOf(obo:CL_0000371 obo:CL_0000578)
-SubClassOf(obo:CL_0000371 ObjectSomeValuesFrom(obo:RO_0002162 ObjectComplementOf(obo:NCBITaxon_33208)))
 
 # Class: obo:CL_0000372 (tormogen cell)
 
@@ -6406,9 +6406,9 @@ SubClassOf(obo:CL_0000384 obo:CL_0000630)
 
 # Class: obo:CL_0000385 (prohemocyte (sensu Nematoda and Protostomia))
 
+AnnotationAssertion(obo:RO_0002161 obo:CL_0000385 obo:NCBITaxon_33511)
 AnnotationAssertion(rdfs:label obo:CL_0000385 "prohemocyte (sensu Nematoda and Protostomia)"^^xsd:string)
 SubClassOf(obo:CL_0000385 obo:CL_0000390)
-SubClassOf(obo:CL_0000385 ObjectAllValuesFrom(obo:RO_0002162 ObjectComplementOf(obo:NCBITaxon_33511)))
 
 # Class: obo:CL_0000386 (attachment cell)
 
@@ -6441,9 +6441,9 @@ SubClassOf(obo:CL_0000389 obo:CL_0000658)
 
 # Class: obo:CL_0000390 (blood cell (sensu Nematoda and Protostomia))
 
+AnnotationAssertion(obo:RO_0002161 obo:CL_0000390 obo:NCBITaxon_33511)
 AnnotationAssertion(rdfs:label obo:CL_0000390 "blood cell (sensu Nematoda and Protostomia)"^^xsd:string)
 SubClassOf(obo:CL_0000390 obo:CL_0000081)
-SubClassOf(obo:CL_0000390 ObjectAllValuesFrom(obo:RO_0002162 ObjectComplementOf(obo:NCBITaxon_33511)))
 
 # Class: obo:CL_0000391 (podocyte (sensu Diptera))
 
@@ -6997,10 +6997,10 @@ EquivalentClasses(obo:CL_0000467 ObjectIntersectionOf(obo:CL_0000151 ObjectSomeV
 
 # Class: obo:CL_0000468 (neuroglioblast (sensu Nematoda and Protostomia))
 
+AnnotationAssertion(obo:RO_0002161 obo:CL_0000468 obo:NCBITaxon_33511)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000468 "neuroglioblast")
 AnnotationAssertion(rdfs:label obo:CL_0000468 "neuroglioblast (sensu Nematoda and Protostomia)"^^xsd:string)
 SubClassOf(obo:CL_0000468 obo:CL_0000047)
-SubClassOf(obo:CL_0000468 ObjectAllValuesFrom(obo:RO_0002162 ObjectComplementOf(obo:NCBITaxon_33511)))
 
 # Class: obo:CL_0000469 (ganglion mother cell)
 
@@ -7398,16 +7398,16 @@ SubClassOf(obo:CL_0000518 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_7742
 # Class: obo:CL_0000519 (phagocyte (sensu Nematoda and Protostomia))
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm"^^xsd:string) obo:IAO_0000115 obo:CL_0000519 "A phagocyte from organisms in the Nematoda or Protostomia clades."^^xsd:string)
+AnnotationAssertion(obo:RO_0002161 obo:CL_0000519 obo:NCBITaxon_33511)
 AnnotationAssertion(rdfs:label obo:CL_0000519 "phagocyte (sensu Nematoda and Protostomia)"^^xsd:string)
 SubClassOf(obo:CL_0000519 obo:CL_0000234)
-SubClassOf(obo:CL_0000519 ObjectAllValuesFrom(obo:RO_0002162 ObjectComplementOf(obo:NCBITaxon_33511)))
 
 # Class: obo:CL_0000520 (prokaryotic cell)
 
+AnnotationAssertion(obo:RO_0002161 obo:CL_0000520 obo:NCBITaxon_2759)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000520 "MESH:D011387"^^xsd:string)
 AnnotationAssertion(rdfs:label obo:CL_0000520 "prokaryotic cell"^^xsd:string)
 SubClassOf(obo:CL_0000520 obo:CL_0000003)
-SubClassOf(obo:CL_0000520 ObjectAllValuesFrom(obo:RO_0002162 ObjectComplementOf(obo:NCBITaxon_2759)))
 
 # Class: obo:CL_0000521 (fungal cell)
 
@@ -12860,7 +12860,7 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add"^^xsd:string) Annotat
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_0001068 <https://orcid.org/0000-0001-9990-8331>)
 AnnotationAssertion(<http://purl.org/dc/terms/date> obo:CL_0001068 "2017-01-30T20:54:12Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:CL_0001068 "ILC1")
-EquivalentClasses(obo:CL_0001068 ObjectIntersectionOf(obo:CL_0001067 ObjectComplementOf(ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0001909))))
+SubClassOf(obo:CL_0001068 obo:CL_0001067)
 
 # Class: obo:CL_0001069 (group 2 innate lymphoid cell)
 
@@ -17158,7 +17158,6 @@ AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0002371 "FMA:72300"^^xsd:string)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0002371 "WBbt:0008378"^^xsd:string)
 AnnotationAssertion(oboInOwl:inSubset obo:CL_0002371 <http://purl.obolibrary.org/obo/ubprop#_upper_level>)
 AnnotationAssertion(rdfs:label obo:CL_0002371 "somatic cell"^^xsd:string)
-EquivalentClasses(obo:CL_0002371 ObjectIntersectionOf(obo:CL_0000003 ObjectComplementOf(obo:CL_0000039)))
 SubClassOf(obo:CL_0002371 obo:CL_0000003)
 
 # Class: obo:CL_0002372 (myotube)


### PR DESCRIPTION
Fixes #1693
Changed taxon restrictions to annotation never_in_taxon - @matentzn not sure if CL pipelines deal with expansion of this or is that uberon specific? Removed some equiv classes
PS sorry for asking so many reviewers - thought it might be something that everyone on the reviewer list might want to go through :) 

PS I love how the automated diff in simple file vs unreasoned show how the "not" is not being used by a reasoner :D 