### PR TITLE
Add gogoeditdiff trigger

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -70,6 +70,7 @@ jobs:
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
       - uses: actions/checkout@v3
+        if: steps.check.outputs.triggered == 'true'
         with:
           ref: master
       - name: Classify ontology
@@ -96,6 +97,7 @@ jobs:
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
       - uses: actions/checkout@v3
+        if: steps.check.outputs.triggered == 'true'
       - name: Download master classification
         if: steps.check.outputs.triggered == 'true'
         uses: actions/download-artifact@v2

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -14,15 +14,25 @@ jobs:
     runs-on: ubuntu-latest
     container: obolibrary/odklite:v1.3.0
     steps:
+      - uses: khan/pull-request-comment-trigger@v1.1.0
+        id: check
+        with:
+          trigger: '#gogoeditdiff'
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
       - uses: actions/checkout@v3
+        if: steps.check.outputs.triggered == 'true'
       # Checks-out main branch under "main" directory
       - uses: actions/checkout@v3
+        if: steps.check.outputs.triggered == 'true'
         with:
           ref: master
           path: master
       - name: Diff classification
+        if: steps.check.outputs.triggered == 'true'
         run: export ROBOT_JAVA_ARGS=-Xmx6G; robot diff --labels True --left master/src/ontology/cl-edit.owl --left-catalog master/src/ontology/catalog-v001.xml --right src/ontology/cl-edit.owl --right-catalog src/ontology/catalog-v001.xml -f markdown -o edit-diff.md
       - name: Upload diff
+        if: steps.check.outputs.triggered == 'true'
         uses: actions/upload-artifact@v2
         with:
           name: edit-diff.md
@@ -31,10 +41,19 @@ jobs:
     runs-on: ubuntu-latest
     container: obolibrary/odklite:v1.3.0
     steps:
+      - uses: khan/pull-request-comment-trigger@v1.1.0
+        id: check
+        with:
+          trigger: '#gogoeditdiff'
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
       - uses: actions/checkout@v3
+        if: steps.check.outputs.triggered == 'true'
       - name: Classify ontology
+        if: steps.check.outputs.triggered == 'true'
         run: cd src/ontology; make IMP=FALSE PAT=FALSE MIR=FALSE cl-simple.owl
       - name: Upload PR cl-simple.owl
+        if: steps.check.outputs.triggered == 'true'
         uses: actions/upload-artifact@v2
         with:
           name: cl-simple-pr.owl
@@ -44,12 +63,20 @@ jobs:
     runs-on: ubuntu-latest
     container: obolibrary/odklite:v1.3.0
     steps:
+      - uses: khan/pull-request-comment-trigger@v1.1.0
+        id: check
+        with:
+          trigger: '#gogoeditdiff'
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
       - uses: actions/checkout@v3
         with:
           ref: master
       - name: Classify ontology
+        if: steps.check.outputs.triggered == 'true'
         run: cd src/ontology; make IMP=FALSE PAT=FALSE MIR=FALSE cl-simple.owl
       - name: Upload master cl-simple.owl
+        if: steps.check.outputs.triggered == 'true'
         uses: actions/upload-artifact@v2
         with:
           name: cl-simple-master.owl
@@ -62,20 +89,30 @@ jobs:
     runs-on: ubuntu-latest
     container: obolibrary/odklite:v1.3.0
     steps:
+      - uses: khan/pull-request-comment-trigger@v1.1.0
+        id: check
+        with:
+          trigger: '#gogoeditdiff'
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
       - uses: actions/checkout@v3
       - name: Download master classification
+        if: steps.check.outputs.triggered == 'true'
         uses: actions/download-artifact@v2
         with:
           name: cl-simple-master.owl
           path: src/ontology/cl-simple-master.owl
       - name: Download PR classification
+        if: steps.check.outputs.triggered == 'true'
         uses: actions/download-artifact@v2
         with:
           name: cl-simple-pr.owl
           path: src/ontology/cl-simple-pr.owl
       - name: Diff classification
+        if: steps.check.outputs.triggered == 'true'
         run: export ROBOT_JAVA_ARGS=-Xmx6G; cd src/ontology; robot diff --labels True --left cl-simple-master.owl/cl-simple.owl --left-catalog catalog-v001.xml --right cl-simple-pr.owl/cl-simple.owl --right-catalog catalog-v001.xml -f markdown -o classification-diff.md
       - name: Upload diff
+        if: steps.check.outputs.triggered == 'true'
         uses: actions/upload-artifact@v2
         with:
           name: classification-diff.md
@@ -84,15 +121,25 @@ jobs:
     needs: [diff_classification, edit_file]
     runs-on: ubuntu-latest
     steps:
+      - uses: khan/pull-request-comment-trigger@v1.1.0
+        id: check
+        with:
+          trigger: '#gogoeditdiff'
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
       - uses: actions/checkout@v3
+        if: steps.check.outputs.triggered == 'true'
       - name: Download reasoned diff
+        if: steps.check.outputs.triggered == 'true'
         uses: actions/download-artifact@v2
         with:
           name: classification-diff.md
           path: classification-diff.md
       - name: Prepare reasoned comment
+        if: steps.check.outputs.triggered == 'true'
         run: "echo \"<details>\n <summary> Here's a diff of how these changes impact the classified ontology (on -simple file): </summary> \n\" >comment.md; cat classification-diff.md/classification-diff.md >>comment.md"
       - name: Post reasoned comment
+        if: steps.check.outputs.triggered == 'true'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         uses: NejcZdovc/comment-pr@v1.1.1
@@ -100,14 +147,18 @@ jobs:
           file: "../../comment.md"
           identifier: "REASONED"
       - uses: actions/checkout@v3
+        if: steps.check.outputs.triggered == 'true'
       - name: Download edit diff
+        if: steps.check.outputs.triggered == 'true'
         uses: actions/download-artifact@v2
         with:
           name: edit-diff.md
           path: edit-diff.md
       - name: Prepare edit file comment
+        if: steps.check.outputs.triggered == 'true'
         run: "echo \"<details>\n <summary> Here's a diff of your edit file (unreasoned) </summary> \n\" >edit-comment.md; cat edit-diff.md/edit-diff.md >>edit-comment.md"
       - name: Post comment
+        if: steps.check.outputs.triggered == 'true'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         uses: NejcZdovc/comment-pr@v1.1.1

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Fourth Monday of month, 10am PT/1pm ET (CL & Uberon)
 
 Diehl,A.D., Meehan,T.F., Bradford,Y.M., Brush,M.H., Dahdul,W.M., Dougall,D.S., He,Y., Osumi-Sutherland,D., Ruttenberg,A., Sarntivijai,S., et al. (2016) The Cell Ontology 2016: enhanced content, modularization, and ontology interoperability. J. Biomed. Semantics, 7, 44.
 
+## GitHub Actions Triggers
+
+To trigger an automated human readable diff, add the following tag to a comment in your pull request: #gogoeditdiff
+
 ## Applications
 
 CL is used in a number of applications including: 

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -2658,7 +2658,6 @@ Declaration(Class(obo:CL_4023030))
 Declaration(Class(obo:CL_4023031))
 Declaration(Class(obo:CL_4023034))
 Declaration(Class(obo:CL_4023036))
-Declaration(Class(obo:CL_4023037))
 Declaration(Class(obo:CL_4023038))
 Declaration(Class(obo:CL_4023040))
 Declaration(Class(obo:CL_4023041))
@@ -27714,12 +27713,6 @@ SubClassOf(obo:CL_4023036 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0070011))
 SubClassOf(obo:CL_4023036 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000956))
 SubClassOf(obo:CL_4023036 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534))
 SubClassOf(obo:CL_4023036 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000013502))
-
-# Class: obo:CL_4023037 (test)
-
-AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4023037 <http://orcid.org/0000-0001-7258-9596>)
-AnnotationAssertion(rdfs:label obo:CL_4023037 "test")
-SubClassOf(obo:CL_4023037 obo:CL_0000540)
 
 # Class: obo:CL_4023038 (L6b glutamatergic cortical neuron)
 

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -2658,6 +2658,7 @@ Declaration(Class(obo:CL_4023030))
 Declaration(Class(obo:CL_4023031))
 Declaration(Class(obo:CL_4023034))
 Declaration(Class(obo:CL_4023036))
+Declaration(Class(obo:CL_4023037))
 Declaration(Class(obo:CL_4023038))
 Declaration(Class(obo:CL_4023040))
 Declaration(Class(obo:CL_4023041))
@@ -27713,6 +27714,12 @@ SubClassOf(obo:CL_4023036 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0070011))
 SubClassOf(obo:CL_4023036 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000956))
 SubClassOf(obo:CL_4023036 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534))
 SubClassOf(obo:CL_4023036 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000013502))
+
+# Class: obo:CL_4023037 (test)
+
+AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4023037 <http://orcid.org/0000-0001-7258-9596>)
+AnnotationAssertion(rdfs:label obo:CL_4023037 "test")
+SubClassOf(obo:CL_4023037 obo:CL_0000540)
 
 # Class: obo:CL_4023038 (L6b glutamatergic cortical neuron)
 


### PR DESCRIPTION
#gogoeditdiff

This PR makes it so that the tag #gogoeditdiff needs to be on a comment for the automated diff to run
trial on CL to ensure social side of this works and all before full implementation in ODK