### PR TITLE
Fix typo in text definition of CL:4030030 'peripheral blood lymphocyte'

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -28956,7 +28956,7 @@ EquivalentClasses(obo:CL_4030029 ObjectIntersectionOf(obo:CL_0000542 ObjectSomeV
 
 # Class: obo:CL_4030030 (peripheral blood lymphocyte)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref <https://orcid.org/0000-0001-9990-8331>) Annotation(oboInOwl:hasDbXref <https://orcid.org/0000-0003-2534-198X>) Annotation(oboInOwl:hasDbXref <https://sciencing.com/what-peripheral-blood-4672930.html>) Annotation(oboInOwl:hasDbXref "PMID:31092833"^^xsd:string) obo:IAO_0000115 obo:CL_4030030 "A blood lymphocte located in the flowing, circulating blood of the body."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref <https://orcid.org/0000-0001-9990-8331>) Annotation(oboInOwl:hasDbXref <https://orcid.org/0000-0003-2534-198X>) Annotation(oboInOwl:hasDbXref <https://sciencing.com/what-peripheral-blood-4672930.html>) Annotation(oboInOwl:hasDbXref "PMID:31092833"^^xsd:string) obo:IAO_0000115 obo:CL_4030030 "A blood lymphocyte located in the flowing, circulating blood of the body."^^xsd:string)
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4030030 <https://orcid.org/0000-0002-1773-2692>)
 AnnotationAssertion(<http://purl.org/dc/terms/date> obo:CL_4030030 "2022-11-14T10:08:14Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:seeAlso obo:CL_4030030 <https://github.com/obophenotype/cell-ontology/pull/1725>)


### PR DESCRIPTION
Origin: https://github.com/obophenotype/cell-ontology/pull/1725
lymphocte --> lymphocyte 