### PR TITLE
Added branch status warning to diff report

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -203,4 +203,3 @@ jobs:
         with:
           file: "../../edit-comment.md"
           identifier: "UNREASONED"
-          file: "../../warncomment.md"

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -1,13 +1,40 @@
 name: 'Create ROBOT diffs on Pull requests'
 
-on: 
+on:
 
   issue_comment:
         types: [created]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  branch_status:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Check current branch status
+        id: info
+        run: |
+          echo "status=$(git rev-list --left-right --count origin/$DEFAULT_BRANCH...origin/${GITHUB_HEAD_REF} | awk '{print $1}')"
+          echo "status=$(git rev-list --left-right --count origin/$DEFAULT_BRANCH...origin/${GITHUB_HEAD_REF} | awk '{print $1}')" >> $GITHUB_OUTPUT
+      - name: Warn users with a comment
+        if: steps.info.outputs.status >= 1
+        run: echo "Your branch is $STATUS commit/s behind, please update your branch.   " > warncomment.md
+      - name: post comment
+        if: steps.info.outputs.status >= 1
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        uses: NejcZdovc/comment-pr@v1.1.1
+        with:
+          file: "../../warncomment.md"
+      - name: fail
+        if: steps.info.outputs.status >= 1
+        run: |
+          echo "Your branch is $STATUS commit/s behind, please update your branch.   "
+          exit 1
   edit_file:
+    needs: [branch_status]
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     container: obolibrary/odklite:v1.3.0
@@ -41,6 +68,7 @@ jobs:
           name: edit-diff.md
           path: edit-diff.md
   classify_branch:
+    needs: [branch_status]
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     container: obolibrary/odklite:v1.3.0
@@ -68,6 +96,7 @@ jobs:
           path: src/ontology/cl-simple.owl
           retention-days: 1
   classify_main:
+    needs: [branch_status]
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     container: obolibrary/odklite:v1.3.0
@@ -93,9 +122,7 @@ jobs:
           path: src/ontology/cl-simple.owl
           retention-days: 1
   diff_classification:
-    needs:
-      - classify_branch
-      - classify_main
+    needs:  [classify_branch, classify_main]
     runs-on: ubuntu-latest
     container: obolibrary/odklite:v1.3.0
     steps:
@@ -176,4 +203,4 @@ jobs:
         with:
           file: "../../edit-comment.md"
           identifier: "UNREASONED"
-
+          file: "../../warncomment.md"


### PR DESCRIPTION
Fixes #1738 

I have added `branch_status` step at the top. It checks if the current branch is behind compared to master branch, and make a comment to warn user. It fails after the comment process.