### PR TITLE
Addresses #1780 text definition typo in 'anterior lateral line neuromast mantle cell'

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -28125,7 +28125,7 @@ EquivalentClasses(obo:CL_2000034 ObjectIntersectionOf(obo:CL_0000856 ObjectSomeV
 
 # Class: obo:CL_2000035 (anterior lateral line neuromast mantle cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:TermGenie"^^xsd:string) obo:IAO_0000115 obo:CL_2000035 "Any neuromast mantle cell that is part of a anterior lateral line."^^xsd:string)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:TermGenie"^^xsd:string) obo:IAO_0000115 obo:CL_2000035 "Any neuromast mantle cell that is part of an anterior lateral line."^^xsd:string)
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_2000035 <https://www.wikidata.org/entity/Q35563349>)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_2000035 "2014-06-25T03:44:44Z"^^xsd:string)
 AnnotationAssertion(oboInOwl:id obo:CL_2000035 "CL:2000035"^^xsd:string)


### PR DESCRIPTION
Resolves #1780 text definition typo in 'anterior lateral line neuromast mantle cell'