### PR TITLE
mappings: Allow the use of semapv:crossSpeciesExactMatch.

### DIFF
--- a/src/scripts/sssom2xrefs.awk
+++ b/src/scripts/sssom2xrefs.awk
@@ -28,7 +28,7 @@ END {
 }
 
 # We only generate cross-references for "exact" mappings
-/skos:exactMatch/ {
+/(skos:exactMatch|semapv:crossSpeciesExactMatch)/ {
   split($object_index, object, ":");
   # Only process mappings where the object term belongs to Uberon
   if ( object[1] == "CL" ) {


### PR DESCRIPTION
FlyBase will now provide its mapping set with `semapv:crossSpecies*Match` relations. This commit updates the SSSOM-processing AWK script to accept `semapv:crossSpeciesExactMatch` predicates in addition to the former `skos:exactMatch`.