### PR TITLE
Trigger with comment added to branch-status

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -5,33 +5,48 @@ on:
   issue_comment:
         types: [created]
 
+env:
+  DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   branch_status:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: khan/pull-request-comment-trigger@v1.1.0
+        id: check
         with:
+          trigger: '#gogoeditdiff'
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      - uses: xt0rted/pull-request-comment-branch@v1
+        id: comment-branch
+      # Checks-out current branch
+      - uses: actions/checkout@v3
+        if: steps.check.outputs.triggered == 'true'
+        with:
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
           fetch-depth: 0
       - name: Check current branch status
+        if: steps.check.outputs.triggered == 'true'
         id: info
         run: |
-          echo "status=$(git rev-list --left-right --count origin/$DEFAULT_BRANCH...origin/${GITHUB_HEAD_REF} | awk '{print $1}')"
-          echo "status=$(git rev-list --left-right --count origin/$DEFAULT_BRANCH...origin/${GITHUB_HEAD_REF} | awk '{print $1}')" >> $GITHUB_OUTPUT
+          echo "status=$(git rev-list --left-right --count origin/$DEFAULT_BRANCH...origin/`git branch --show-current` | awk '{print $1}')"
+          echo "status=$(git rev-list --left-right --count origin/$DEFAULT_BRANCH...origin/`git branch --show-current` | awk '{print $1}')" >> $GITHUB_OUTPUT
       - name: Warn users with a comment
         if: steps.info.outputs.status >= 1
-        run: echo "Your branch is $STATUS commit/s behind, please update your branch.   " > warncomment.md
+        run: echo "Your branch is ${{ steps.info.outputs.status }} commit/s behind, please update your branch.   " > warncomment.md
       - name: post comment
-        if: steps.info.outputs.status >= 1
+        if: steps.info.outputs.status >= 1 && steps.check.outputs.triggered == 'true'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         uses: NejcZdovc/comment-pr@v1.1.1
         with:
           file: "../../warncomment.md"
       - name: fail
-        if: steps.info.outputs.status >= 1
+        if: steps.info.outputs.status >= 1 && steps.check.outputs.triggered == 'true'
         run: |
-          echo "Your branch is $STATUS commit/s behind, please update your branch.   "
+          echo "Your branch is ${{ steps.info.outputs.status }} commit/s behind, please update your branch.   "
           exit 1
   edit_file:
     needs: [branch_status]


### PR DESCRIPTION
Comment trigger was missing from the branch-status part of the action. Branch-status part is now triggered with comments.