### PR TITLE
Adding missing conditional statement to branch-status action

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -11,6 +11,7 @@ env:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   branch_status:
+    if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
       - uses: khan/pull-request-comment-trigger@v1.1.0


### PR DESCRIPTION
```
  issue_comment:
        types: [created]
```
Part checks for comments in both issues and PRs. `if: ${{ github.event.issue.pull_request }}` statement has been added to branch-status to prevent it to be run with issue comments.