### PR TITLE
2023-03-16 imports refresh

### DIFF
--- a/src/patterns/definitions.owl
+++ b/src/patterns/definitions.owl
@@ -1,4 +1,4 @@
-Prefix(:=<urn:unnamed:ontology#ont1>)
+Prefix(:=<http://purl.obolibrary.org/obo/cl/patterns/definitions.owl#>)
 Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
 Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)
 Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
@@ -7,8 +7,9 @@ Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
 
 
 Ontology(<http://purl.obolibrary.org/obo/cl/patterns/definitions.owl>
-<http://purl.obolibrary.org/obo/cl/releases/2023-03-15/patterns/definitions.owl>
-Annotation(owl:versionInfo "2023-03-15"^^xsd:string)
+<http://purl.obolibrary.org/obo/cl/releases/2023-03-16/patterns/definitions.owl>
+Annotation(owl:versionInfo "2023-03-16")
+
 
 
 )


### PR DESCRIPTION
[Yesterday's refresh](https://github.com/obophenotype/cell-ontology/pull/1890) was made using an outdated version of ODK. This refresh was made with the latest ODK.

FYI @matentzn.