### PR TITLE
Remove deprecated class from count

### DIFF
--- a/src/sparql/class-count-by-prefix.sparql
+++ b/src/sparql/class-count-by-prefix.sparql
@@ -5,6 +5,8 @@ SELECT ?prefix (COUNT(DISTINCT ?cls) AS ?numberOfClasses) WHERE
 {
   ?cls a owl:Class .
   FILTER (!isBlank(?cls))
+  FILTER NOT EXISTS { ?cls owl:deprecated true }
+  FILTER (?cls != oboInOwl:ObsoleteClass)
   BIND( STRBEFORE(STRAFTER(str(?cls),"http://purl.obolibrary.org/obo/"), "_") AS ?prefix)
 }
 GROUP BY ?prefix


### PR DESCRIPTION
I assume we do not want to count deprecated terms, so adding filters to the sparql
feel free to close if we actually do want to count deprecated terms for some reason 
probably should do this on uberon too
dont know if this is an ODK shipped out sparql (did not find it on dynamic file jinja, but if it is, might want to do this there too. 

Thanks :) 