### PR TITLE
Obsolete 'primary pigment cell'.

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -9485,21 +9485,21 @@ SubClassOf(obo:CL_0000726 obo:CL_0000605)
 # Class: obo:CL_0000727 (obsolete primary pigment cell)
 
 AnnotationAssertion(obo:IAO_0000233 obo:CL_0000727 "https://github.com/obophenotype/cell-ontology/issues/1930")
-AnnotationAssertion(rdfs:comment obo:CL_0000727 "Obsoleted  as this level of precision is deemed unnecessary for CL. Consider using either the more general CL:0001658 or, if you need to refer to primary pigment cells specifically, a term from a taxon-specific ontology such as FBbt:00004231.")
+AnnotationAssertion(rdfs:comment obo:CL_0000727 "Obsoleted as this level of precision is deemed unnecessary for CL. Consider using either the more general CL:0001658 or, if you need to refer to primary pigment cells specifically, a term from a taxon-specific ontology such as FBbt:00004231.")
 AnnotationAssertion(rdfs:label obo:CL_0000727 "obsolete primary pigment cell")
 AnnotationAssertion(owl:deprecated obo:CL_0000727 "true"^^xsd:boolean)
 
 # Class: obo:CL_0000728 (obsolete secondary pigment cell)
 
 AnnotationAssertion(obo:IAO_0000233 obo:CL_0000728 "https://github.com/obophenotype/cell-ontology/issues/1930")
-AnnotationAssertion(rdfs:comment obo:CL_0000728 "Obsoleted  as this level of precision is deemed unnecessary for CL. Consider using either the more general CL:0001658 or, if you need to refer to secondary pigment cells specifically, a term from a taxon-specific ontology such as FBbt:00004232.")
+AnnotationAssertion(rdfs:comment obo:CL_0000728 "Obsoleted as this level of precision is deemed unnecessary for CL. Consider using either the more general CL:0001658 or, if you need to refer to secondary pigment cells specifically, a term from a taxon-specific ontology such as FBbt:00004232.")
 AnnotationAssertion(rdfs:label obo:CL_0000728 "obsolete secondary pigment cell")
 AnnotationAssertion(owl:deprecated obo:CL_0000728 "true"^^xsd:boolean)
 
 # Class: obo:CL_0000729 (obsolete tertiary pigment cell)
 
 AnnotationAssertion(obo:IAO_0000233 obo:CL_0000729 "https://github.com/obophenotype/cell-ontology/issues/1930")
-AnnotationAssertion(rdfs:comment obo:CL_0000729 "Obsoleted  as this level of precision is deemed unnecessary for CL. Consider using either the more general CL:0001658 or, if you need to refer to tertiary pigment cells specifically, a term from a taxon-specific ontology such as FBbt:00004233.")
+AnnotationAssertion(rdfs:comment obo:CL_0000729 "Obsoleted as this level of precision is deemed unnecessary for CL. Consider using either the more general CL:0001658 or, if you need to refer to tertiary pigment cells specifically, a term from a taxon-specific ontology such as FBbt:00004233.")
 AnnotationAssertion(rdfs:label obo:CL_0000729 "obsolete tertiary pigment cell")
 AnnotationAssertion(owl:deprecated obo:CL_0000729 "true"^^xsd:boolean)
 

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -9484,21 +9484,21 @@ SubClassOf(obo:CL_0000726 obo:CL_0000605)
 
 # Class: obo:CL_0000727 (obsolete primary pigment cell)
 
-AnnotationAssertion(oboInOwl:seeAlso obo:CL_0000727 "https://github.com/obophenotype/cell-ontology/issues/1930")
+AnnotationAssertion(obo:IAO_0000233 obo:CL_0000727 "https://github.com/obophenotype/cell-ontology/issues/1930")
 AnnotationAssertion(rdfs:comment obo:CL_0000727 "Obsoleted  as this level of precision is deemed unnecessary for CL. Consider using either the more general CL:0001658 or, if you need to refer to primary pigment cells specifically, a term from a taxon-specific ontology such as FBbt:00004231.")
 AnnotationAssertion(rdfs:label obo:CL_0000727 "obsolete primary pigment cell")
 AnnotationAssertion(owl:deprecated obo:CL_0000727 "true"^^xsd:boolean)
 
 # Class: obo:CL_0000728 (obsolete secondary pigment cell)
 
-AnnotationAssertion(oboInOwl:seeAlso obo:CL_0000728 "https://github.com/obophenotype/cell-ontology/issues/1930")
+AnnotationAssertion(obo:IAO_0000233 obo:CL_0000728 "https://github.com/obophenotype/cell-ontology/issues/1930")
 AnnotationAssertion(rdfs:comment obo:CL_0000728 "Obsoleted  as this level of precision is deemed unnecessary for CL. Consider using either the more general CL:0001658 or, if you need to refer to secondary pigment cells specifically, a term from a taxon-specific ontology such as FBbt:00004232.")
 AnnotationAssertion(rdfs:label obo:CL_0000728 "obsolete secondary pigment cell")
 AnnotationAssertion(owl:deprecated obo:CL_0000728 "true"^^xsd:boolean)
 
 # Class: obo:CL_0000729 (obsolete tertiary pigment cell)
 
-AnnotationAssertion(oboInOwl:seeAlso obo:CL_0000729 "https://github.com/obophenotype/cell-ontology/issues/1930")
+AnnotationAssertion(obo:IAO_0000233 obo:CL_0000729 "https://github.com/obophenotype/cell-ontology/issues/1930")
 AnnotationAssertion(rdfs:comment obo:CL_0000729 "Obsoleted  as this level of precision is deemed unnecessary for CL. Consider using either the more general CL:0001658 or, if you need to refer to tertiary pigment cells specifically, a term from a taxon-specific ontology such as FBbt:00004233.")
 AnnotationAssertion(rdfs:label obo:CL_0000729 "obsolete tertiary pigment cell")
 AnnotationAssertion(owl:deprecated obo:CL_0000729 "true"^^xsd:boolean)

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -9482,23 +9482,26 @@ AnnotationAssertion(rdfs:comment obo:CL_0000726 "Considering obsoleting as somet
 AnnotationAssertion(rdfs:label obo:CL_0000726 "chlamydospore")
 SubClassOf(obo:CL_0000726 obo:CL_0000605)
 
-# Class: obo:CL_0000727 (primary pigment cell)
+# Class: obo:CL_0000727 (obsolete primary pigment cell)
 
-AnnotationAssertion(rdfs:label obo:CL_0000727 "primary pigment cell")
-SubClassOf(obo:CL_0000727 obo:CL_0000548)
-SubClassOf(obo:CL_0000727 obo:CL_0001658)
+AnnotationAssertion(oboInOwl:seeAlso obo:CL_0000727 "https://github.com/obophenotype/cell-ontology/issues/1930")
+AnnotationAssertion(rdfs:comment obo:CL_0000727 "Obsoleted  as this level of precision is deemed unnecessary for CL. Consider using either the more general CL:0001658 or, if you need to refer to primary pigment cells specifically, a term from a taxon-specific ontology such as FBbt:00004231.")
+AnnotationAssertion(rdfs:label obo:CL_0000727 "obsolete primary pigment cell")
+AnnotationAssertion(owl:deprecated obo:CL_0000727 "true"^^xsd:boolean)
 
-# Class: obo:CL_0000728 (secondary pigment cell)
+# Class: obo:CL_0000728 (obsolete secondary pigment cell)
 
-AnnotationAssertion(rdfs:label obo:CL_0000728 "secondary pigment cell")
-SubClassOf(obo:CL_0000728 obo:CL_0000548)
-SubClassOf(obo:CL_0000728 obo:CL_0001658)
+AnnotationAssertion(oboInOwl:seeAlso obo:CL_0000728 "https://github.com/obophenotype/cell-ontology/issues/1930")
+AnnotationAssertion(rdfs:comment obo:CL_0000728 "Obsoleted  as this level of precision is deemed unnecessary for CL. Consider using either the more general CL:0001658 or, if you need to refer to secondary pigment cells specifically, a term from a taxon-specific ontology such as FBbt:00004232.")
+AnnotationAssertion(rdfs:label obo:CL_0000728 "obsolete secondary pigment cell")
+AnnotationAssertion(owl:deprecated obo:CL_0000728 "true"^^xsd:boolean)
 
-# Class: obo:CL_0000729 (tertiary pigment cell)
+# Class: obo:CL_0000729 (obsolete tertiary pigment cell)
 
-AnnotationAssertion(rdfs:label obo:CL_0000729 "tertiary pigment cell")
-SubClassOf(obo:CL_0000729 obo:CL_0000548)
-SubClassOf(obo:CL_0000729 obo:CL_0001658)
+AnnotationAssertion(oboInOwl:seeAlso obo:CL_0000729 "https://github.com/obophenotype/cell-ontology/issues/1930")
+AnnotationAssertion(rdfs:comment obo:CL_0000729 "Obsoleted  as this level of precision is deemed unnecessary for CL. Consider using either the more general CL:0001658 or, if you need to refer to tertiary pigment cells specifically, a term from a taxon-specific ontology such as FBbt:00004233.")
+AnnotationAssertion(rdfs:label obo:CL_0000729 "obsolete tertiary pigment cell")
+AnnotationAssertion(owl:deprecated obo:CL_0000729 "true"^^xsd:boolean)
 
 # Class: obo:CL_0000730 (leading edge cell)
 


### PR DESCRIPTION
The term _primary pigment cell_, which refers to one type of visual pigment cells in protostomes, is deemed to be unnecessary in CL, and is therefore obsoleted. Suggestion is to use either the closest parental term (_visual pigment cell (sensu Nematoda and Protostomia)_) to refer to any kind of visual pigment cell regardless of their exact type, or a more precise term from a taxon-specific ontology such as FBbt.

Likewise for _secondary_ and _tertiary pigment cell_.

closes #1930