### PR TITLE
Obsolete clade-specific germ line stem cell terms

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -4136,42 +4136,53 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000084 obo:CL_0000542
 SubClassOf(obo:CL_0000084 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000827))
 DisjointClasses(obo:CL_0000084 obo:CL_0000945)
 
-# Class: obo:CL_0000085 (germ line stem cell (sensu Vertebrata))
+# Class: obo:CL_0000085 (obsolete germ line stem cell (sensu Vertebrata))
 
-AnnotationAssertion(rdfs:label obo:CL_0000085 "germ line stem cell (sensu Vertebrata)")
-SubClassOf(obo:CL_0000085 obo:CL_0000014)
-SubClassOf(obo:CL_0000085 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_7742))
+AnnotationAssertion(obo:IAO_0000233 obo:CL_0000085 "https://github.com/obophenotype/cell-ontology/issues/1935")
+AnnotationAssertion(obo:IAO_0100001 obo:CL_0000085 obo:CL_0000014)
+AnnotationAssertion(rdfs:comment obo:CL_0000085 "Obsoleted as there is no need for a term specific for vertebrates.")
+AnnotationAssertion(rdfs:label obo:CL_0000085 "obsolete germ line stem cell (sensu Vertebrata)")
+AnnotationAssertion(owl:deprecated obo:CL_0000085 "true"^^xsd:boolean)
 
-# Class: obo:CL_0000086 (germ line stem cell (sensu Nematoda and Protostomia))
+# Class: obo:CL_0000086 (obsolete germ line stem cell (sensu Nematoda and Protostomia))
 
-AnnotationAssertion(obo:RO_0002161 obo:CL_0000086 obo:NCBITaxon_33511)
-AnnotationAssertion(rdfs:label obo:CL_0000086 "germ line stem cell (sensu Nematoda and Protostomia)")
-SubClassOf(obo:CL_0000086 obo:CL_0000014)
+AnnotationAssertion(obo:IAO_0000233 obo:CL_0000086 "https://github.com/obophenotype/cell-ontology/issues/1935")
+AnnotationAssertion(obo:IAO_0100001 obo:CL_0000086 obo:CL_0000014)
+AnnotationAssertion(rdfs:comment obo:CL_0000086 "Obsoleted as there is no need for a term specific for nematods and protostomes.")
+AnnotationAssertion(rdfs:label obo:CL_0000086 "obsolete germ line stem cell (sensu Nematoda and Protostomia)")
+AnnotationAssertion(owl:deprecated obo:CL_0000086 "true"^^xsd:boolean)
 
-# Class: obo:CL_0000087 (male germ line stem cell (sensu Nematoda and Protostomia))
+# Class: obo:CL_0000087 (obsolete male germ line stem cell (sensu Nematoda and Protostomia))
 
-AnnotationAssertion(rdfs:label obo:CL_0000087 "male germ line stem cell (sensu Nematoda and Protostomia)")
-SubClassOf(obo:CL_0000087 obo:CL_0000016)
-SubClassOf(obo:CL_0000087 obo:CL_0000086)
+AnnotationAssertion(obo:IAO_0000233 obo:CL_0000087 "https://github.com/obophenotype/cell-ontology/issues/1935")
+AnnotationAssertion(obo:IAO_0100001 obo:CL_0000087 obo:CL_0000016)
+AnnotationAssertion(rdfs:comment obo:CL_0000087 "Obsoleted as there is no need for a term specific for nematods and protostomes.")
+AnnotationAssertion(rdfs:label obo:CL_0000087 "obsolete male germ line stem cell (sensu Nematoda and Protostomia)")
+AnnotationAssertion(owl:deprecated obo:CL_0000087 "true"^^xsd:boolean)
 
-# Class: obo:CL_0000088 (female germ line stem cell (sensu Nematoda and Protostomia))
+# Class: obo:CL_0000088 (obsolete female germ line stem cell (sensu Nematoda and Protostomia))
 
-AnnotationAssertion(rdfs:label obo:CL_0000088 "female germ line stem cell (sensu Nematoda and Protostomia)")
-SubClassOf(obo:CL_0000088 obo:CL_0000022)
-SubClassOf(obo:CL_0000088 obo:CL_0000086)
+AnnotationAssertion(obo:IAO_0000233 obo:CL_0000088 "https://github.com/obophenotype/cell-ontology/issues/1935")
+AnnotationAssertion(obo:IAO_0100001 obo:CL_0000088 obo:CL_0000022)
+AnnotationAssertion(rdfs:comment obo:CL_0000088 "Obsoleted as there is no need for a term specific for nematods and protostomes.")
+AnnotationAssertion(rdfs:label obo:CL_0000088 "obsolete female germ line stem cell (sensu Nematoda and Protostomia)")
+AnnotationAssertion(owl:deprecated obo:CL_0000088 "true"^^xsd:boolean)
 
-# Class: obo:CL_0000089 (male germ line stem cell (sensu Vertebrata))
+# Class: obo:CL_0000089 (obsolete male germ line stem cell (sensu Vertebrata))
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:19948499") oboInOwl:hasExactSynonym obo:CL_0000089 "spermatogonial stem cell")
-AnnotationAssertion(rdfs:label obo:CL_0000089 "male germ line stem cell (sensu Vertebrata)")
-SubClassOf(obo:CL_0000089 obo:CL_0000016)
-SubClassOf(obo:CL_0000089 obo:CL_0000085)
+AnnotationAssertion(obo:IAO_0000233 obo:CL_0000089 "https://github.com/obophenotype/cell-ontology/issues/1935")
+AnnotationAssertion(obo:IAO_0100001 obo:CL_0000089 obo:CL_0000016)
+AnnotationAssertion(rdfs:comment obo:CL_0000089 "Obsoleted as there is no need for a term specific for vertebrates.")
+AnnotationAssertion(rdfs:label obo:CL_0000089 "obsolete male germ line stem cell (sensu Vertebrata)")
+AnnotationAssertion(owl:deprecated obo:CL_0000089 "true"^^xsd:boolean)
 
-# Class: obo:CL_0000090 (female germ line stem cell (sensu Vertebrata))
+# Class: obo:CL_0000090 (obsolete female germ line stem cell (sensu Vertebrata))
 
-AnnotationAssertion(rdfs:label obo:CL_0000090 "female germ line stem cell (sensu Vertebrata)")
-SubClassOf(obo:CL_0000090 obo:CL_0000022)
-SubClassOf(obo:CL_0000090 obo:CL_0000085)
+AnnotationAssertion(obo:IAO_0000233 obo:CL_0000090 "https://github.com/obophenotype/cell-ontology/issues/1935")
+AnnotationAssertion(obo:IAO_0100001 obo:CL_0000090 obo:CL_0000022)
+AnnotationAssertion(rdfs:comment obo:CL_0000090 "Obsoleted as there is no need for a term specific for vertebrates.")
+AnnotationAssertion(rdfs:label obo:CL_0000090 "obsolete female germ line stem cell (sensu Vertebrata)")
+AnnotationAssertion(owl:deprecated obo:CL_0000090 "true"^^xsd:boolean)
 
 # Class: obo:CL_0000091 (Kupffer cell)
 

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -3390,6 +3390,7 @@ AnnotationAssertion(owl:deprecated obo:CL_0000013 "true"^^xsd:boolean)
 
 # Class: obo:CL_0000014 (germ line stem cell)
 
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1016/j.stem.2012.05.016") obo:IAO_0000115 obo:CL_0000014 "A stem cell that is the precursor of gametes.")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000014 "germline stem cell")
 AnnotationAssertion(rdfs:label obo:CL_0000014 "germ line stem cell")
 EquivalentClasses(obo:CL_0000014 ObjectIntersectionOf(obo:CL_0000039 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0017145)))
@@ -3410,6 +3411,7 @@ SubClassOf(obo:CL_0000015 ObjectSomeValuesFrom(obo:RO_0002216 obo:GO_0007283))
 
 # Class: obo:CL_0000016 (male germ line stem cell)
 
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1016/j.stem.2012.05.016") obo:IAO_0000115 obo:CL_0000016 "A stem cell that is the precursor of male gametes.")
 AnnotationAssertion(rdfs:label obo:CL_0000016 "male germ line stem cell")
 SubClassOf(obo:CL_0000016 obo:CL_0000014)
 SubClassOf(obo:CL_0000016 obo:CL_0000015)
@@ -3483,6 +3485,7 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000021 obo:CL_0000586
 
 # Class: obo:CL_0000022 (female germ line stem cell)
 
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1016/j.stem.2012.05.016") obo:IAO_0000115 obo:CL_0000022 "A stem cell that is the precursor of female gametes.")
 AnnotationAssertion(rdfs:label obo:CL_0000022 "female germ line stem cell")
 EquivalentClasses(obo:CL_0000022 ObjectIntersectionOf(obo:CL_0000021 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0017145)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000022 obo:CL_0000014)


### PR DESCRIPTION
This PR obsoletes the vertebrate- and protostome-specific variants of _germ line stem cell_, as well as their female and male subclasses. Those cells do not differ enough across clades to justify having separate classes for them.

A minimal definition is also added to the corresponding clade-neutral terms.

closes #1935 