### PR TITLE
Obsolete 'primary neuron' and related terms.

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -5683,7 +5683,6 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "VHOG:0001484") oboInOwl:hasEx
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000247 "Rohon-Beard cell")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "VHOG:0001484") oboInOwl:hasRelatedSynonym obo:CL_0000247 "RB neuron")
 AnnotationAssertion(rdfs:label obo:CL_0000247 "Rohon-Beard neuron")
-SubClassOf(obo:CL_0000247 obo:CL_0000531)
 SubClassOf(obo:CL_0000247 obo:CL_4023168)
 
 # Class: obo:CL_0000248 (obsolete microsporocyte)
@@ -7744,44 +7743,52 @@ SubClassOf(obo:CL_0000528 obo:CL_0000540)
 AnnotationAssertion(rdfs:label obo:CL_0000529 "pigmented epithelial cell")
 SubClassOf(obo:CL_0000529 obo:CL_0000710)
 
-# Class: obo:CL_0000530 (primary neuron)
+# Class: obo:CL_0000530 (obsolete primary neuron)
 
-AnnotationAssertion(rdfs:label obo:CL_0000530 "primary neuron")
-SubClassOf(obo:CL_0000530 obo:CL_0000540)
+AnnotationAssertion(obo:IAO_0000233 obo:CL_0000530 "https://github.com/obophenotype/cell-ontology/issues/1931")
+AnnotationAssertion(rdfs:comment obo:CL_0000530 "Obsoleted for lack of a consensual meaning for such a term in CL. If needed, consider a term from a taxon-specific ontology.")
+AnnotationAssertion(rdfs:label obo:CL_0000530 "obsolete primary neuron")
+AnnotationAssertion(owl:deprecated obo:CL_0000530 "true"^^xsd:boolean)
 
-# Class: obo:CL_0000531 (primary sensory neuron)
+# Class: obo:CL_0000531 (obsolete primary sensory neuron)
 
-AnnotationAssertion(rdfs:label obo:CL_0000531 "primary sensory neuron")
-EquivalentClasses(obo:CL_0000531 ObjectIntersectionOf(obo:CL_0000101 obo:CL_0000530))
+AnnotationAssertion(obo:IAO_0000233 obo:CL_0000531 "https://github.com/obophenotype/cell-ontology/issues/1931")
+AnnotationAssertion(rdfs:comment obo:CL_0000531 "Obsoleted for lack of a consensual meaning for such a term in CL. If needed, consider a term from a taxon-specific ontology.")
+AnnotationAssertion(rdfs:label obo:CL_0000531 "obsolete primary sensory neuron")
+AnnotationAssertion(owl:deprecated obo:CL_0000531 "true"^^xsd:boolean)
 
 # Class: obo:CL_0000532 (CAP motoneuron)
 
 AnnotationAssertion(rdfs:label obo:CL_0000532 "CAP motoneuron")
-SubClassOf(obo:CL_0000532 obo:CL_0000533)
+SubClassOf(obo:CL_0000532 obo:CL_0000100)
 
-# Class: obo:CL_0000533 (primary motor neuron)
+# Class: obo:CL_0000533 (obsolete primary motor neuron)
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000533 "FMA:83619")
-AnnotationAssertion(rdfs:label obo:CL_0000533 "primary motor neuron")
-SubClassOf(obo:CL_0000533 obo:CL_0000100)
-SubClassOf(obo:CL_0000533 obo:CL_0000530)
+AnnotationAssertion(obo:IAO_0000233 obo:CL_0000533 "https://github.com/obophenotype/cell-ontology/issues/1931")
+AnnotationAssertion(rdfs:comment obo:CL_0000533 "Obsoleted for lack of a consensual meaning for such a term in CL. If needed, consider a term from a taxon-specific ontology.")
+AnnotationAssertion(rdfs:label obo:CL_0000533 "obsolete primary motor neuron")
+AnnotationAssertion(owl:deprecated obo:CL_0000533 "true"^^xsd:boolean)
 
-# Class: obo:CL_0000534 (primary interneuron)
+# Class: obo:CL_0000534 (obsolete primary interneuron)
 
-AnnotationAssertion(rdfs:label obo:CL_0000534 "primary interneuron")
-SubClassOf(obo:CL_0000534 obo:CL_0000099)
-SubClassOf(obo:CL_0000534 obo:CL_0000530)
+AnnotationAssertion(obo:IAO_0000233 obo:CL_0000534 "https://github.com/obophenotype/cell-ontology/issues/1931")
+AnnotationAssertion(rdfs:comment obo:CL_0000534 "Obsoleted for lack of a consensual meaning for such a term in CL. If needed, consider a term from a taxon-specific ontology.")
+AnnotationAssertion(rdfs:label obo:CL_0000534 "obsolete primary interneuron")
+AnnotationAssertion(owl:deprecated obo:CL_0000534 "true"^^xsd:boolean)
 
-# Class: obo:CL_0000535 (secondary neuron)
+# Class: obo:CL_0000535 (obsolete secondary neuron)
 
-AnnotationAssertion(rdfs:label obo:CL_0000535 "secondary neuron")
-SubClassOf(obo:CL_0000535 obo:CL_0000540)
+AnnotationAssertion(obo:IAO_0000233 obo:CL_0000535 "https://github.com/obophenotype/cell-ontology/issues/1931")
+AnnotationAssertion(rdfs:comment obo:CL_0000535 "Obsoleted for lack of a consensual meaning for such a term in CL. If needed, consider a term from a taxon-specific ontology.")
+AnnotationAssertion(rdfs:label obo:CL_0000535 "obsolete secondary neuron")
+AnnotationAssertion(owl:deprecated obo:CL_0000535 "true"^^xsd:boolean)
 
-# Class: obo:CL_0000536 (secondary motor neuron)
+# Class: obo:CL_0000536 (obsolete secondary motor neuron)
 
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000536 "FMA:83620")
-AnnotationAssertion(rdfs:label obo:CL_0000536 "secondary motor neuron")
-EquivalentClasses(obo:CL_0000536 ObjectIntersectionOf(obo:CL_0000100 obo:CL_0000535))
+AnnotationAssertion(obo:IAO_0000233 obo:CL_0000536 "https://github.com/obophenotype/cell-ontology/issues/1931")
+AnnotationAssertion(rdfs:comment obo:CL_0000536 "Obsoleted for lack of a consensual meaning for such a term in CL. If needed, consider a term from a taxon-specific ontology.")
+AnnotationAssertion(rdfs:label obo:CL_0000536 "obsolete secondary motor neuron")
+AnnotationAssertion(owl:deprecated obo:CL_0000536 "true"^^xsd:boolean)
 
 # Class: obo:CL_0000537 (obsolete antipodal cell)
 


### PR DESCRIPTION
Obsolete 'primary neuron' and its generic subclasses 'primary motor neuron', 'primary sensory neuron', and 'primary interneuron'. Subclasses corresponding to precise neurons ('CAP motoneuron' and 'Rohon-Beard neuron') are re-classified so that they do not depend on those terms.

Likewise for 'secondary neuron'.

closes #1931