### PR TITLE
Addresses #1947 NTR tracheobronchial mucus secreting glandular cell

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -2960,6 +2960,7 @@ Declaration(Class(obo:CL_4033033))
 Declaration(Class(obo:CL_4033034))
 Declaration(Class(obo:CL_4033035))
 Declaration(Class(obo:CL_4033036))
+Declaration(Class(obo:CL_4033037))
 Declaration(Class(obo:CL_4040000))
 Declaration(Class(obo:CL_4040001))
 Declaration(Class(obo:CL_4040002))
@@ -31265,6 +31266,16 @@ AnnotationAssertion(<http://purl.org/dc/terms/date> obo:CL_4033036 "2023-04-04T1
 AnnotationAssertion(rdfs:label obo:CL_4033036 "OFFx cell")
 SubClassOf(obo:CL_4033036 obo:CL_0000750)
 SubClassOf(obo:CL_4033036 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0001786))
+
+# Class: obo:CL_4033037 (tracheobronchial mucus secreting glandular cell)
+
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30864819") obo:IAO_0000115 obo:CL_4033037 "A mucus secreting cell of a submucosal gland of the tracheobronchial tree.")
+AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4033037 <https://orcid.org/0000-0001-6677-8489>)
+AnnotationAssertion(<http://purl.org/dc/terms/date> obo:CL_4033037 "2023-04-20T10:55:50Z"^^xsd:dateTime)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30864819") oboInOwl:hasExactSynonym obo:CL_4033037 "mucus secreting cell of tracheobronchial tree submucosal gland")
+AnnotationAssertion(rdfs:label obo:CL_4033037 "tracheobronchial mucus secreting glandular cell")
+EquivalentClasses(obo:CL_4033037 ObjectIntersectionOf(obo:CL_0000319 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0007196) ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_8410077)))
+SubClassOf(obo:CL_4033037 obo:CL_0002202)
 
 # Class: obo:CL_4040000 (glial restricted tripotential precursor cell)
 

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -31267,13 +31267,12 @@ AnnotationAssertion(rdfs:label obo:CL_4033036 "OFFx cell")
 SubClassOf(obo:CL_4033036 obo:CL_0000750)
 SubClassOf(obo:CL_4033036 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0001786))
 
-# Class: obo:CL_4033037 (tracheobronchial mucus secreting glandular cell)
+# Class: obo:CL_4033037 (mucus secreting cell of tracheobronchial tree submucosal gland)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30864819") obo:IAO_0000115 obo:CL_4033037 "A mucus secreting cell of a submucosal gland of the tracheobronchial tree.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4033037 <https://orcid.org/0000-0001-6677-8489>)
 AnnotationAssertion(<http://purl.org/dc/terms/date> obo:CL_4033037 "2023-04-20T10:55:50Z"^^xsd:dateTime)
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30864819") oboInOwl:hasExactSynonym obo:CL_4033037 "mucus secreting cell of tracheobronchial tree submucosal gland")
-AnnotationAssertion(rdfs:label obo:CL_4033037 "tracheobronchial mucus secreting glandular cell")
+AnnotationAssertion(rdfs:label obo:CL_4033037 "mucus secreting cell of tracheobronchial tree submucosal gland")
 EquivalentClasses(obo:CL_4033037 ObjectIntersectionOf(obo:CL_0000319 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0007196) ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_8410077)))
 SubClassOf(obo:CL_4033037 obo:CL_0002202)
 


### PR DESCRIPTION
Closes #1947 NTR tracheobronchial mucus secreting glandular cell.

>I would check that the following terms reason under this new term:
- mucus secreting cell of bronchus submucosal gland
- mucus secreting cell of trachea gland

![image](https://user-images.githubusercontent.com/94959119/233621799-ef25d19a-caf3-43fb-8c97-04451b1ed7bb.png)
![image](https://user-images.githubusercontent.com/94959119/233621867-6a3c01ac-499e-42a5-aa18-f38dec164572.png)
