### PR TITLE
1960-Make 'CNS interneuron' taxon-neutral

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -6806,8 +6806,6 @@ AnnotationAssertion(owl:deprecated obo:CL_0000401 "true"^^xsd:boolean)
 
 AnnotationAssertion(rdfs:label obo:CL_0000402 "CNS interneuron")
 EquivalentClasses(obo:CL_0000402 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001017)))
-SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000402 obo:CL_0000099)
-SubClassOf(obo:CL_0000402 obo:CL_0000117)
 
 # Class: obo:CL_0000403 (obo:CL_0000403)
 

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -6804,6 +6804,8 @@ AnnotationAssertion(owl:deprecated obo:CL_0000401 "true"^^xsd:boolean)
 
 # Class: obo:CL_0000402 (CNS interneuron)
 
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1016/B978-0-12-817424-1.00001-X") obo:IAO_0000115 obo:CL_0000402 "An interneuron that has its cell body in a central nervous system.")
+AnnotationAssertion(rdfs:comment obo:CL_0000402 "Interneurons are commonly described as being only found in the central nervous system. However, in CL we define 'interneuron' more broady as any neuron that is neither a motor neuron nor a sensory neuron, regardless of its location, so we need this term to refer strictly to interneurons of the central nervous system.")
 AnnotationAssertion(rdfs:label obo:CL_0000402 "CNS interneuron")
 EquivalentClasses(obo:CL_0000402 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001017)))
 

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -6805,7 +6805,7 @@ AnnotationAssertion(owl:deprecated obo:CL_0000401 "true"^^xsd:boolean)
 # Class: obo:CL_0000402 (CNS interneuron)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1016/B978-0-12-817424-1.00001-X") obo:IAO_0000115 obo:CL_0000402 "An interneuron that has its cell body in a central nervous system.")
-AnnotationAssertion(rdfs:comment obo:CL_0000402 "Interneurons are commonly described as being only found in the central nervous system. However, in CL we define 'interneuron' more broady as any neuron that is neither a motor neuron nor a sensory neuron, regardless of its location, so we need this term to refer strictly to interneurons of the central nervous system.")
+AnnotationAssertion(rdfs:comment obo:CL_0000402 "Interneurons are commonly described as being only found in the central nervous system. However, in CL we define 'interneuron' more broadly as any neuron that is neither a motor neuron nor a sensory neuron, regardless of its location, so we need this term to refer strictly to interneurons of the central nervous system.")
 AnnotationAssertion(rdfs:label obo:CL_0000402 "CNS interneuron")
 EquivalentClasses(obo:CL_0000402 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001017)))
 


### PR DESCRIPTION
This PR fixes #1960 by implementing the first proposed solution, that is by making [CNS interneuron](http://purl.obolibrary.org/obo/CL_0000402) truly taxon-neutral by removing the classification as a [CNS neuron (sensu Vertebrata)](http://purl.obolibrary.org/obo/CL_0000117).

A rudimentary text definition is also added, along with a comment explaining the difference with the parental [interneuron](http://purl.obolibrary.org/obo/CL_0000099).