### PR TITLE
Make 'taste receptor cell' taxon-neutral

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -5364,7 +5364,6 @@ AnnotationAssertion(rdfs:label obo:CL_0000209 "taste receptor cell")
 EquivalentClasses(obo:CL_0000209 ObjectIntersectionOf(obo:CL_0000540 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0050912)))
 SubClassOf(obo:CL_0000209 obo:CL_0000098)
 SubClassOf(obo:CL_0000209 obo:CL_0002076)
-SubClassOf(obo:CL_0000209 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0002025))
 
 # Class: obo:CL_0000210 (photoreceptor cell)
 

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -5357,7 +5357,7 @@ SubClassOf(obo:CL_0000208 obo:CL_0000206)
 
 # Class: obo:CL_0000209 (taste receptor cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "ISBN:0618947256") obo:IAO_0000115 obo:CL_0000209 "A cell type found in the spherical or ovoid clusters of receptor cells found mainly in the epithelium of the tongue and constituting the end organs of the sense of taste.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "ISBN:0618947256") obo:IAO_0000115 obo:CL_0000209 "A specialized cell involved in gustatory sensory perception. In vertebrates, it is mainly found in spherical or ovoid clusters of receptors cells in the epithelium of the tongue.")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000209 "FMA:67910")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000209 "taste bud cell")
 AnnotationAssertion(rdfs:label obo:CL_0000209 "taste receptor cell")


### PR DESCRIPTION
This PR implements the first solution discussed in #1961: it makes [taste receptor cell](http://purl.obolibrary.org/obo/CL_0000209) taxon-neutral by removing the reference to the [stratum basale of epidermis](http://purl.obolibrary.org/obo/UBERON_0002025).