### PR TITLE
Add IAO:0000233 to the list of allowed annotation properties.

### DIFF
--- a/src/sparql/illegal-annotation-property-violation.sparql
+++ b/src/sparql/illegal-annotation-property-violation.sparql
@@ -7,6 +7,7 @@ SELECT DISTINCT ?term ?annotation WHERE {
     <http://purl.obolibrary.org/obo/IAO_0000116>,
     <http://purl.obolibrary.org/obo/IAO_0000231>,
     <http://purl.obolibrary.org/obo/IAO_0000232>,
+    <http://purl.obolibrary.org/obo/IAO_0000233>,
     <http://purl.obolibrary.org/obo/IAO_0000412>,
     <http://purl.obolibrary.org/obo/IAO_0000589>,
     <http://purl.obolibrary.org/obo/IAO_0000424>,


### PR DESCRIPTION
IAO:0000233 is supposedly the annotation property to use for linking to a bug tracker issue, so it should not be flagged as an “illegal” annotation.

(This is exactly the same change as in obophenotype/uberon#2879.)