### PR TITLE
Make 'primary neuron' teleost-specific.

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -7821,7 +7821,6 @@ SubClassOf(obo:CL_0000532 obo:CL_0000533)
 # Class: obo:CL_0000533 (primary motor neuron (sensu Teleostei))
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:1842357") obo:IAO_0000115 obo:CL_0000533 "A primary neuron (sensu Teleostei) that has a motor function.")
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000533 "FMA:83619")
 AnnotationAssertion(rdfs:label obo:CL_0000533 "primary motor neuron (sensu Teleostei)")
 SubClassOf(obo:CL_0000533 obo:CL_0000100)
 SubClassOf(obo:CL_0000533 obo:CL_0000530)
@@ -7843,7 +7842,6 @@ SubClassOf(Annotation(obo:IAO_0000233 "https://github.com/obophenotype/cell-onto
 # Class: obo:CL_0000536 (secondary motor neuron (sensu Teleostei))
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:1842357") obo:IAO_0000115 obo:CL_0000536 "A secondary neuron (sensu Teleostei) that has a motor function.")
-AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000536 "FMA:83620")
 AnnotationAssertion(rdfs:label obo:CL_0000536 "secondary motor neuron (sensu Teleostei)")
 EquivalentClasses(obo:CL_0000536 ObjectIntersectionOf(obo:CL_0000100 obo:CL_0000535))
 

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -7800,14 +7800,17 @@ SubClassOf(obo:CL_0000528 obo:CL_0000540)
 AnnotationAssertion(rdfs:label obo:CL_0000529 "pigmented epithelial cell")
 SubClassOf(obo:CL_0000529 obo:CL_0000710)
 
-# Class: obo:CL_0000530 (primary neuron)
+# Class: obo:CL_0000530 (primary neuron (sensu Teleostei))
 
-AnnotationAssertion(rdfs:label obo:CL_0000530 "primary neuron")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:1842357") Annotation(oboInOwl:hasDbXref "doi:10.1242/dev.108.1.121") obo:IAO_0000115 obo:CL_0000530 "A neuron that develops during the early segmentation stages in teleosts, before the neural tube is formed.")
+AnnotationAssertion(rdfs:label obo:CL_0000530 "primary neuron (sensu Teleostei)")
 SubClassOf(obo:CL_0000530 obo:CL_0000540)
+SubClassOf(Annotation(obo:IAO_0000233 "https://github.com/obophenotype/cell-ontology/pull/1950") obo:CL_0000530 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_32443))
 
-# Class: obo:CL_0000531 (primary sensory neuron)
+# Class: obo:CL_0000531 (primary sensory neuron (sensu Teleostei))
 
-AnnotationAssertion(rdfs:label obo:CL_0000531 "primary sensory neuron")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:1842357") obo:IAO_0000115 obo:CL_0000531 "A primary neuron (sensu Teleostei) that has a sensory function.")
+AnnotationAssertion(rdfs:label obo:CL_0000531 "primary sensory neuron (sensu Teleostei)")
 EquivalentClasses(obo:CL_0000531 ObjectIntersectionOf(obo:CL_0000101 obo:CL_0000530))
 
 # Class: obo:CL_0000532 (CAP motoneuron)
@@ -7815,28 +7818,33 @@ EquivalentClasses(obo:CL_0000531 ObjectIntersectionOf(obo:CL_0000101 obo:CL_0000
 AnnotationAssertion(rdfs:label obo:CL_0000532 "CAP motoneuron")
 SubClassOf(obo:CL_0000532 obo:CL_0000533)
 
-# Class: obo:CL_0000533 (primary motor neuron)
+# Class: obo:CL_0000533 (primary motor neuron (sensu Teleostei))
 
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:1842357") obo:IAO_0000115 obo:CL_0000533 "A primary neuron (sensu Teleostei) that has a motor function.")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000533 "FMA:83619")
-AnnotationAssertion(rdfs:label obo:CL_0000533 "primary motor neuron")
+AnnotationAssertion(rdfs:label obo:CL_0000533 "primary motor neuron (sensu Teleostei)")
 SubClassOf(obo:CL_0000533 obo:CL_0000100)
 SubClassOf(obo:CL_0000533 obo:CL_0000530)
 
-# Class: obo:CL_0000534 (primary interneuron)
+# Class: obo:CL_0000534 (primary interneuron (sensu Teleostei))
 
-AnnotationAssertion(rdfs:label obo:CL_0000534 "primary interneuron")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:1842357") obo:IAO_0000115 obo:CL_0000534 "A primary neuron (sensu Teleostei) that is neither a sensory neuron or a motor neuron.")
+AnnotationAssertion(rdfs:label obo:CL_0000534 "primary interneuron (sensu Teleostei)")
 SubClassOf(obo:CL_0000534 obo:CL_0000099)
 SubClassOf(obo:CL_0000534 obo:CL_0000530)
 
-# Class: obo:CL_0000535 (secondary neuron)
+# Class: obo:CL_0000535 (secondary neuron (sensu Teleostei))
 
-AnnotationAssertion(rdfs:label obo:CL_0000535 "secondary neuron")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:1842357") Annotation(oboInOwl:hasDbXref "doi:10.1242/dev.108.1.121") obo:IAO_0000115 obo:CL_0000535 "A neuron of teleosts that develops later than a primary neuron, typically during the larval stages.")
+AnnotationAssertion(rdfs:label obo:CL_0000535 "secondary neuron (sensu Teleostei)")
 SubClassOf(obo:CL_0000535 obo:CL_0000540)
+SubClassOf(Annotation(obo:IAO_0000233 "https://github.com/obophenotype/cell-ontology/pull/1950") obo:CL_0000535 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_32443))
 
-# Class: obo:CL_0000536 (secondary motor neuron)
+# Class: obo:CL_0000536 (secondary motor neuron (sensu Teleostei))
 
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:1842357") obo:IAO_0000115 obo:CL_0000536 "A secondary neuron (sensu Teleostei) that has a motor function.")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000536 "FMA:83620")
-AnnotationAssertion(rdfs:label obo:CL_0000536 "secondary motor neuron")
+AnnotationAssertion(rdfs:label obo:CL_0000536 "secondary motor neuron (sensu Teleostei)")
 EquivalentClasses(obo:CL_0000536 ObjectIntersectionOf(obo:CL_0000100 obo:CL_0000535))
 
 # Class: obo:CL_0000537 (obsolete antipodal cell)


### PR DESCRIPTION
[Primary neuron](http://purl.obolibrary.org/obo/CL_0000530) (and related terms, including [secondary neuron](http://purl.obolibrary.org/obo/CL_0000535)) was supposed to be obsoleted for lack of a consensus on its intended meaning, but the term may be in used to represent fish cells (following the merging of the TAO into CL).

So instead, we keep the terms but restrict them to teleosts.

This PR adds the necessary taxon restrictions, updates the labels accordingly, and adds minimal definitions.

closes #1931 
supersedes #1950