### PR TITLE
Define 'follicle stem cell' and restrict it to arthropods.

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -7089,10 +7089,13 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000440 "melanotroph")
 AnnotationAssertion(rdfs:label obo:CL_0000440 "melanocyte stimulating hormone secreting cell")
 EquivalentClasses(obo:CL_0000440 ObjectIntersectionOf(obo:CL_0000151 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0036160)))
 
-# Class: obo:CL_0000441 (follicle stem cell)
+# Class: obo:CL_0000441 (follicle stem cell (sensu Arthropoda))
 
-AnnotationAssertion(rdfs:label obo:CL_0000441 "follicle stem cell")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1016/B978-012369493-5.50005-5") Annotation(oboInOwl:hasDbXref "doi:10.1242/dev.121.11.3797") obo:IAO_0000115 obo:CL_0000441 "A stem cell that gives rise to the follicle cells that surround the oocyte in female arthropods.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1016/j.devcel.2005.08.012") oboInOwl:hasBroadSynonym obo:CL_0000441 "somatic stem cell")
+AnnotationAssertion(rdfs:label obo:CL_0000441 "follicle stem cell (sensu Arthropoda)")
 SubClassOf(obo:CL_0000441 obo:CL_0000036)
+SubClassOf(Annotation(obo:IAO_0000233 "https://github.com/obophenotype/cell-ontology/issues/1943") obo:CL_0000441 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_6656))
 
 # Class: obo:CL_0000442 (follicular dendritic cell)
 


### PR DESCRIPTION
Follicle cells in insects (and _probably_ more largely in arthropods, though evidence about that is hard to find) all derive from clearly identified "follicle stem cells", but that does not seem to be the case for the follicular epithelial cells found e.g. in vertebrates.

So we restrict the term [follicle stem cell](http://purl.obolibrary.org/obo/CL_0000441) to arthropods. We also rename it to make the taxon restriction clear, and ensure people don’t use the term thinking it refers to the stem cells of hair follicles (which are similarly named but are completely unrelated).

closes #1943 