### PR TITLE
Addresses #2012 Edit 'dentate gyrus of hippocampal formation granule cell'

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -29059,7 +29059,7 @@ EquivalentClasses(obo:CL_2000088 ObjectIntersectionOf(obo:CL_0000118 ObjectSomeV
 
 # Class: obo:CL_2000089 (dentate gyrus granule cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:TermGenie") Annotation(oboInOwl:hasDbXref "PMID:17765709") obo:IAO_0000115 obo:CL_2000089 "A granule cell that has soma location in the dentate gyrus cell layer of the hippocampal formation and has an elliptical cell body and characteristic cone-shaped tree of spiny apical dendrites. The branches extend throughout the molecular layer and the distal tips of the dendritic tree end just at the hippocampal fissure or at the ventricular surface. The dentate gyrus of hippocampal formation granule cell is the principal cell type of the dentate gyrus.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:TermGenie") Annotation(oboInOwl:hasDbXref "PMID:17765709") obo:IAO_0000115 obo:CL_2000089 "A granule cell that has soma location in the dentate gyrus cell layer of the hippocampal formation and has an elliptical cell body and characteristic cone-shaped tree of spiny apical dendrites. The branches extend throughout the molecular layer and the distal tips of the dendritic tree end just at the hippocampal fissure or at the ventricular surface. The dentate gyrus granule cell is the principal cell type of the dentate gyrus.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_2000089 <https://www.wikidata.org/entity/Q35563349>)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_2000089 "2015-02-23T05:48:23Z")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_2000089 "dentate gyrus of hippocampal formation granule cell")

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -29057,15 +29057,16 @@ AnnotationAssertion(oboInOwl:id obo:CL_2000088 "CL:2000088")
 AnnotationAssertion(rdfs:label obo:CL_2000088 "Ammon's horn basket cell")
 EquivalentClasses(obo:CL_2000088 ObjectIntersectionOf(obo:CL_0000118 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001954)))
 
-# Class: obo:CL_2000089 (dentate gyrus of hippocampal formation granule cell)
+# Class: obo:CL_2000089 (dentate gyrus granule cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:TermGenie") obo:IAO_0000115 obo:CL_2000089 "The principal cell type of the dentate gyrus.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:TermGenie") Annotation(oboInOwl:hasDbXref "PMID:17765709") obo:IAO_0000115 obo:CL_2000089 "A granule cell that has soma location in the dentate gyrus cell layer of the hippocampal formation and has an elliptical cell body and characteristic cone-shaped tree of spiny apical dendrites. The branches extend throughout the molecular layer and the distal tips of the dendritic tree end just at the hippocampal fissure or at the ventricular surface. The dentate gyrus of hippocampal formation granule cell is the principal cell type of the dentate gyrus.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_2000089 <https://www.wikidata.org/entity/Q35563349>)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_2000089 "2015-02-23T05:48:23Z")
+AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_2000089 "dentate gyrus of hippocampal formation granule cell")
 AnnotationAssertion(oboInOwl:id obo:CL_2000089 "CL:2000089")
-AnnotationAssertion(rdfs:comment obo:CL_2000089 "The granule cell has a characteristic cone-shaped tree of spiny apical dendrites.")
-AnnotationAssertion(rdfs:label obo:CL_2000089 "dentate gyrus of hippocampal formation granule cell")
-EquivalentClasses(obo:CL_2000089 ObjectIntersectionOf(obo:CL_0000120 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001885)))
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:17765709") rdfs:comment obo:CL_2000089 "As far as can be determined, all dentate granule cells appear to project to CA3 and the axon trajectory is partially correlated with the position of the parent cell body.")
+AnnotationAssertion(rdfs:label obo:CL_2000089 "dentate gyrus granule cell")
+EquivalentClasses(obo:CL_2000089 ObjectIntersectionOf(obo:CL_0001033 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0005381)))
 
 # Class: obo:CL_2000090 (dentate gyrus of hippocampal formation stellate cell)
 


### PR DESCRIPTION
Addresses https://github.com/obophenotype/cell-ontology/issues/2012#issuecomment-1633906422:

- edits to 'dentate gyrus granule cell' (formerly labeled as 'dentate gyrus of hippocampal formation granule cell')