### PR TITLE
Change telocyte and lymphoblast subclass to seperate subclass

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -24558,7 +24558,8 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:20367664") oboInOwl:hasR
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:31311805") oboInOwl:hasRelatedSynonym obo:CL_0017004 "interstitial neuron")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref <https://doi.org/10.1016/B978-0-12-818561-2.00001-1>) rdfs:comment obo:CL_0017004 "Telocytes manage to develop complex networks in almost all organs of the human body. Although staining positively for vimentin antibody, some uncertainty still persists over the mesenchymal origin of these cells.")
 AnnotationAssertion(rdfs:label obo:CL_0017004 "telocyte")
-SubClassOf(obo:CL_0017004 ObjectIntersectionOf(obo:CL_0002320 ObjectSomeValuesFrom(obo:BFO_0000051 obo:GO_0120327)))
+SubClassOf(obo:CL_0017004 obo:CL_0002320)
+SubClassOf(obo:CL_0017004 ObjectSomeValuesFrom(obo:BFO_0000051 obo:GO_0120327))
 
 # Class: obo:CL_0017005 (lymphoblast)
 
@@ -24569,7 +24570,8 @@ AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0017005 "BTO:0000772")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0017005 "EFO:0000572")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0017005 "FMA:83030")
 AnnotationAssertion(rdfs:label obo:CL_0017005 "lymphoblast")
-SubClassOf(obo:CL_0017005 ObjectIntersectionOf(obo:CL_0000542 ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0046649)))
+SubClassOf(obo:CL_0017005 obo:CL_0000542)
+SubClassOf(obo:CL_0017005 ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0046649))
 
 # Class: obo:CL_0017006 (B-lymphoblast)
 


### PR DESCRIPTION
Fixes #2086

Previously was intersection, making them orphany 
note: not 100% sure about implication, but I think this is correct?
Either way, should probably have explicit parentage 
thoughts @aleixpuigb and/or @bvarner-ebi?

Thanks 