### PR TITLE
Addresses #427 obsolete 'acid secreting cell' and edit 'parietal cell'

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -4965,11 +4965,12 @@ AnnotationAssertion(rdfs:label obo:CL_0000160 "goblet cell")
 SubClassOf(obo:CL_0000160 obo:CL_0000150)
 SubClassOf(obo:CL_0000160 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0070254))
 
-# Class: obo:CL_0000161 (acid secreting cell)
+# Class: obo:CL_0000161 (obsolete acid secreting cell)
 
-AnnotationAssertion(rdfs:label obo:CL_0000161 "acid secreting cell")
-EquivalentClasses(obo:CL_0000161 ObjectIntersectionOf(obo:CL_0000151 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0046717)))
-SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000161 obo:CL_0000151)
+AnnotationAssertion(oboInOwl:consider obo:CL_0000161 obo:CL_0000162)
+AnnotationAssertion(rdfs:comment obo:CL_0000161 "https://github.com/obophenotype/cell-ontology/issues/427")
+AnnotationAssertion(rdfs:label obo:CL_0000161 "obsolete acid secreting cell")
+AnnotationAssertion(owl:deprecated obo:CL_0000161 "true"^^xsd:boolean)
 
 # Class: obo:CL_0000162 (parietal cell)
 
@@ -4979,8 +4980,9 @@ AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000162 "FMA:62901")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000162 "oxyntic cell")
 AnnotationAssertion(rdfs:label obo:CL_0000162 "parietal cell")
 SubClassOf(obo:CL_0000162 obo:CL_0000150)
-SubClassOf(obo:CL_0000162 obo:CL_0000161)
+SubClassOf(obo:CL_0000162 obo:CL_0000151)
 SubClassOf(obo:CL_0000162 obo:CL_0002178)
+SubClassOf(obo:CL_0000162 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0046717))
 
 # Class: obo:CL_0000163 (endocrine cell)
 


### PR DESCRIPTION
Addresses #427 obsolete 'acid secreting cell' and edit 'parietal cell'