### PR TITLE
merge CL:0002294 into CL:0009077

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -16791,6 +16791,7 @@ AnnotationAssertion(oboInOwl:creation_date obo:CL_0002294 "2010-09-13T02:37:23Z"
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0002294 "FMA:72209")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0002294 "subcapsular thymic epithelial cell")
 AnnotationAssertion(rdfs:label obo:CL_0002294 "obsolete type-1 epithelial cell of thymus")
+AnnotationAssertion(owl:deprecated obo:CL_0002294 "true"^^xsd:boolean)
 
 # Class: obo:CL_0002295 (type-6 epithelial cell of thymus)
 

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -3185,7 +3185,7 @@ AnnotationAssertion(rdfs:label obo:IAO_0000115 "definition")
 
 AnnotationAssertion(rdfs:label obo:IAO_0000424 "expand expression to")
 
-# Annotation Property: obo:IAO_0000700 (preferred_root)
+# Annotation Property: obo:IAO_0000700 (has ontology root term)
 
 AnnotationAssertion(rdfs:label obo:IAO_0000700 "preferred_root")
 
@@ -16782,15 +16782,15 @@ AnnotationAssertion(rdfs:label obo:CL_0002293 "epithelial cell of thymus")
 EquivalentClasses(obo:CL_0002293 ObjectIntersectionOf(obo:CL_0002076 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0002370)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0002293 obo:CL_0002076)
 
-# Class: obo:CL_0002294 (type-1 epithelial cell of thymus)
+# Class: obo:CL_0002294 (obsolete type-1 epithelial cell of thymus)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "PMID:9264335") obo:IAO_0000115 obo:CL_0002294 "An epithelial cell with a well defined Golgi apparatus that makes up the continuous layer of cells bordering the thymic tissue beneath the capsule.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "PMID:9264335") obo:IAO_0000115 obo:CL_0002294 "OBSOLETE. An epithelial cell with a well defined Golgi apparatus that makes up the continuous layer of cells bordering the thymic tissue beneath the capsule.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_0002294 <https://orcid.org/0000-0003-1980-3228>)
+AnnotationAssertion(oboInOwl:consider obo:CL_0002294 "CL:0009077")
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002294 "2010-09-13T02:37:23Z")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0002294 "FMA:72209")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0002294 "subcapsular thymic epithelial cell")
-AnnotationAssertion(rdfs:label obo:CL_0002294 "type-1 epithelial cell of thymus")
-SubClassOf(obo:CL_0002294 obo:CL_0002364)
+AnnotationAssertion(rdfs:label obo:CL_0002294 "obsolete type-1 epithelial cell of thymus")
 
 # Class: obo:CL_0002295 (type-6 epithelial cell of thymus)
 
@@ -23528,9 +23528,12 @@ SubClassOf(obo:CL_0009076 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_000384
 
 # Class: obo:CL_0009077 (subcapsular thymic epithelial cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:6209968") obo:IAO_0000115 obo:CL_0009077 "A thymic epithelial cell located within the subcapsular region of the thymus.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:6209968") Annotation(oboInOwl:hasDbXref "PMID:9264335") obo:IAO_0000115 obo:CL_0009077 "A thymic epithelial cell located within the subcapsular region of the thymus. Subcapsular thymic epithelial cells have a well defined Golgi apparatus that makes up the continuous layer of cells bordering the thymic tissue beneath the capsule.")
 AnnotationAssertion(obo:RO_0002175 obo:CL_0009077 obo:NCBITaxon_9606)
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_0009077 <https://orcid.org/0000-0002-2825-0621>)
+AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_0009077 <https://orcid.org/0000-0003-1980-3228>)
+AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0009077 "FMA:72209")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:9264335") oboInOwl:hasExactSynonym obo:CL_0009077 "type-1 epithelial cell of thymus")
 AnnotationAssertion(rdfs:label obo:CL_0009077 "subcapsular thymic epithelial cell")
 SubClassOf(obo:CL_0009077 obo:CL_0002364)
 SubClassOf(obo:CL_0009077 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0006936))


### PR DESCRIPTION
Fixes #2101 
Requires changes in Uberon (changing UBERON:0006936 to use CL:0009077)
My choice of choosing CL:0009077 was due to its use in HRA subset 
I see that there are obsoletion notices now - not sure exact ways of working now so will leave that to @bvarner-ebi 
Also due to obsoletion method, import file is changed - happy for this change to be reverted and fixed at source (Uberon). 
PS could someone help me fix it in [Uberon side please](https://github.com/obophenotype/uberon/issues/3024)? requires import and its a whole thing here. 

Thanks! 