### PR TITLE
Addresses #2148 Edit text definition of 'L2/3 intratelencephalic projecting glutamatergic neuron of the primary motor cortex'

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -29749,7 +29749,7 @@ SubClassOf(obo:CL_4023046 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001384
 # Class: obo:CL_4023047 (L2/3 intratelencephalic projecting glutamatergic neuron of the primary motor cortex)
 
 AnnotationAssertion(obo:IAO_0000028 obo:CL_4023047 "L2/3 IT glut MOp")
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "DOI:10.1101/2020.10.19.343129") obo:IAO_0000115 obo:CL_4023047 "An intratelencephalic-projecting glutamatergic neuron with a soma found in cortical layer 2/3.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "DOI:10.1101/2020.10.19.343129") obo:IAO_0000115 obo:CL_4023047 "An intratelencephalic-projecting glutamatergic neuron with a soma found in cortical layer 2/3 of the primary motor cortex.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4023047 <https://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4023047 "L2/3 IT M1")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4023047 "L2/3 IT MOp")


### PR DESCRIPTION
Addresses #2148 Edit text definition of 'L2/3 intratelencephalic projecting glutamatergic neuron of the primary motor cortex' so it is aligned with logical definition.