### PR TITLE
Fixes #2212 class hierarchy 'peritubular capillary endothelial cell'

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -27096,6 +27096,7 @@ AnnotationAssertion(rdfs:label obo:CL_1001033 "peritubular capillary endothelial
 EquivalentClasses(obo:CL_1001033 ObjectIntersectionOf(obo:CL_1000892 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0005272)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_1001033 obo:CL_1000892)
 SubClassOf(obo:CL_1001033 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0005272))
+SubClassOf(obo:CL_1001033 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0012441))
 
 # Class: obo:CL_1001036 (vasa recta cell)
 


### PR DESCRIPTION
Fixes #2212 class hierarchy 'peritubular capillary endothelial cell'