### PR TITLE
File clean up fix for generic_coverage.py

### DIFF
--- a/src/scripts/generic_coverage.py
+++ b/src/scripts/generic_coverage.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+
 import argparse
 import csv
 from collections import defaultdict
@@ -256,6 +257,10 @@ def modify_docker_script(input_file, _output_file):
         f.writelines(lines)
 
 
+def clean_up():
+    os.remove("test.ttl")
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -329,8 +334,6 @@ if __name__ == "__main__":
     cl_rel = Graph().parse("../ontology/test.ttl", format="ttl")
     cl = cl_base + cl_rel
 
-    cl.serialize("ontology.owl", format="turtle")
-
     term_dict = {}
     with open(file_name, mode="r", encoding="utf-8-sig", newline="") as csvfile:
         reader = csv.DictReader(csvfile)
@@ -368,3 +371,4 @@ if __name__ == "__main__":
             write = csv.writer(file)
             write.writerows(result)
     print(f"{file_name} has {report_str} coverage over {scope}")
+    clean_up()

--- a/src/scripts/generic_coverage.py
+++ b/src/scripts/generic_coverage.py
@@ -257,10 +257,6 @@ def modify_docker_script(input_file, _output_file):
         f.writelines(lines)
 
 
-def clean_up():
-    os.remove("test.ttl")
-
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -313,7 +309,7 @@ if __name__ == "__main__":
         "--ontology-file",
         "cl-full.owl",
         "--output-file",
-        "test.ttl",
+        "tmp/test.ttl",
         "--output-subclasses",
         "true",
         "false",
@@ -331,7 +327,7 @@ if __name__ == "__main__":
     run_command(relation_graph_command, working_directory)
 
     cl_base = Graph().parse("../ontology/cl-full.owl", format="xml")
-    cl_rel = Graph().parse("../ontology/test.ttl", format="ttl")
+    cl_rel = Graph().parse("../ontology/tmp/test.ttl", format="ttl")
     cl = cl_base + cl_rel
 
     term_dict = {}
@@ -371,4 +367,3 @@ if __name__ == "__main__":
             write = csv.writer(file)
             write.writerows(result)
     print(f"{file_name} has {report_str} coverage over {scope}")
-    clean_up()


### PR DESCRIPTION
Files generated during coverage calculation are causing issues in certain commits. @bvarner-ebi has requested that we address these files within the script.