### PR TITLE
Reduce words on "merge-term" issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/g_merge-term.md
+++ b/.github/ISSUE_TEMPLATE/g_merge-term.md
@@ -1,6 +1,6 @@
 ---
 name: Merge two terms
-about: Obsolete or deprecate an existing CL term and merge with another CL term. *Note - please use the "Obsolete term" template if you would like to obsolete a term without replacing it with another existing CL term.
+about: Obsolete an existing CL term and merge with another CL term. *Note - please use the "Obsolete term" template if you would like to obsolete a term without replacing it with another CL term.
 title: "[Merge]"
 labels: merge
 


### PR DESCRIPTION
Fixes #2295

Checking the settings on the issue templates, I found that the number of characters in the issue description was above the limit.

![Screenshot 2024-03-01 at 18 19 03](https://github.com/obophenotype/cell-ontology/assets/2208124/45a38065-0468-41a4-a0fb-8482b6ff9502)
