### PR TITLE
Use a dedicated token for the Ontobot workflow.

### DIFF
--- a/.github/workflows/ontobot.yml
+++ b/.github/workflows/ontobot.yml
@@ -50,7 +50,7 @@ jobs:
         id: gh-script-issue
         uses: actions/github-script@v6
         with:
-          # github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ secrets.ONTOBOT_TOKEN }}
           script: |
             const issue_number = context.issue.number
             const repo = context.repo.owner+"/"+context.repo.repo
@@ -60,7 +60,7 @@ jobs:
         id: gh-script-repo
         uses: actions/github-script@v6
         with:
-          # github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ secrets.ONTOBOT_TOKEN }}
           script: |
             const repo = context.repo.owner+"/"+context.repo.repo
             return repo
@@ -87,7 +87,7 @@ jobs:
           ochange process-issue ${{ env.resource }} \
           -r ${{ steps.gh-script-repo.outputs.result }} \
           -n ${{ steps.gh-script-issue.outputs.result }} \
-          -g ${{ secrets.GH_TOKEN }}
+          -g ${{ secrets.ONTOBOT_TOKEN }}
 
       - name: Clean-up
         run: rm -rf robot-plugins
@@ -104,4 +104,4 @@ jobs:
           title: ${{ env.PR_TITLE }}
           base: ${{ github.head_ref }}
           branch: ${{ env.branch-name }}
-          # token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.ONTOBOT_TOKEN }}


### PR DESCRIPTION
This commit updates the ontobot workflow to make it use a dedicated token (`ONTOBOT_TOKEN`), rather than the default `GITHUB_TOKEN`.

This should ensures that PRs created by the bot can trigger other workflows, notably the CI workflow.

(This is merely the same thing as what was [already done on Uberon](https://github.com/obophenotype/uberon/pull/3225), for the same reasons.)