### PR TITLE
Add Jorstad paper as a reference to cortical neuron CL terms

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -3412,7 +3412,7 @@ AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000000 "XAO:0003012")
 AnnotationAssertion(oboInOwl:inSubset obo:CL_0000000 <http://purl.obolibrary.org/obo/ubprop#_upper_level>)
 AnnotationAssertion(rdfs:comment obo:CL_0000000 "The definition of cell is intended to represent all cells, and thus a cell is defined as a material entity and not an anatomical structure, which implies that it is part of an organism (or the entirety of one).")
 AnnotationAssertion(rdfs:label obo:CL_0000000 "cell")
-SubClassOf(obo:CL_0000000 obo:CL_0010005)
+SubClassOf(obo:CL_0000000 obo:UBERON_0000061)
 SubClassOf(obo:CL_0000000 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_131567))
 
 # Class: obo:CL_0000001 (primary cultured cell)
@@ -31176,7 +31176,7 @@ EquivalentClasses(obo:CL_4030067 ObjectIntersectionOf(obo:CL_4023012 ObjectSomeV
 
 # Class: obo:CL_4030068 (L6 intratelencephalic projecting Car3 glutamatergic neuron)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1101/2022.11.30.518285") Annotation(oboInOwl:hasDbXref "PMID:34004146") Annotation(oboInOwl:hasDbXref "PMID:37824655") obo:IAO_0000115 obo:CL_4030068 "An intratelencephalic-projecting glutamatergic neuron with a soma found in cortical layer 6 that expresses Car3.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:34004146") Annotation(oboInOwl:hasDbXref "PMID:37824655") Annotation(oboInOwl:hasDbXref "doi:10.1101/2022.11.30.518285") obo:IAO_0000115 obo:CL_4030068 "An intratelencephalic-projecting glutamatergic neuron with a soma found in cortical layer 6 that expresses Car3.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4030068 <https://orcid.org/0000-0003-4389-9821>)
 AnnotationAssertion(<http://purl.org/dc/terms/date> obo:CL_4030068 "2023-11-23T09:16:14Z"^^xsd:dateTime)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref <https://orcid.org/0000-0003-4389-9821>) Annotation(oboInOwl:hasSynonymType obo:OMO_0003000) oboInOwl:hasExactSynonym obo:CL_4030068 "L6 IT Car3 glutamatergic neuron")

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -3412,7 +3412,7 @@ AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000000 "XAO:0003012")
 AnnotationAssertion(oboInOwl:inSubset obo:CL_0000000 <http://purl.obolibrary.org/obo/ubprop#_upper_level>)
 AnnotationAssertion(rdfs:comment obo:CL_0000000 "The definition of cell is intended to represent all cells, and thus a cell is defined as a material entity and not an anatomical structure, which implies that it is part of an organism (or the entirety of one).")
 AnnotationAssertion(rdfs:label obo:CL_0000000 "cell")
-SubClassOf(obo:CL_0000000 obo:UBERON_0000061)
+SubClassOf(obo:CL_0000000 obo:CL_0010005)
 SubClassOf(obo:CL_0000000 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_131567))
 
 # Class: obo:CL_0000001 (primary cultured cell)
@@ -29143,7 +29143,7 @@ SubClassOf(obo:CL_4023010 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000005460))
 # Class: obo:CL_4023011 (lamp5 GABAergic cortical interneuron)
 
 AnnotationAssertion(obo:IAO_0000028 obo:CL_4023011 "Lamp5 cortical interneuron")
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30382198") obo:IAO_0000115 obo:CL_4023011 "A GABAergic neuron located in the cerebral cortex that expresses Lamp5")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30382198") Annotation(oboInOwl:hasDbXref "PMID:37824655") obo:IAO_0000115 obo:CL_4023011 "A GABAergic neuron located in the cerebral cortex that expresses Lamp5")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4023011 <https://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023011 "ILX:0770149")
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023011 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
@@ -29188,7 +29188,7 @@ SubClassOf(obo:CL_4023014 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_P32648))
 # Class: obo:CL_4023015 (sncg GABAergic cortical interneuron)
 
 AnnotationAssertion(obo:IAO_0000028 obo:CL_4023015 "sncg cortical interneuron")
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:33186530") obo:IAO_0000115 obo:CL_4023015 "A GABAergic neuron located in the cerebral cortex that expresses Gamma-synuclein")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:33186530") Annotation(oboInOwl:hasDbXref "PMID:37824655") obo:IAO_0000115 obo:CL_4023015 "A GABAergic neuron located in the cerebral cortex that expresses Gamma-synuclein")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4023015 <https://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023015 "ILX:0770150")
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023015 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
@@ -29198,7 +29198,7 @@ EquivalentClasses(obo:CL_4023015 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeV
 # Class: obo:CL_4023016 (vip GABAergic cortical interneuron)
 
 AnnotationAssertion(obo:IAO_0000028 obo:CL_4023016 "vip cortical interneuron")
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:33186530") obo:IAO_0000115 obo:CL_4023016 "A GABAergic neuron located in the cerebral cortex that expresses vasoactive intestinal polypeptide")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:33186530") Annotation(oboInOwl:hasDbXref "PMID:37824655") obo:IAO_0000115 obo:CL_4023016 "A GABAergic neuron located in the cerebral cortex that expresses vasoactive intestinal polypeptide")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4023016 <https://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023016 "ILX:0770151")
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023016 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
@@ -29208,7 +29208,7 @@ EquivalentClasses(obo:CL_4023016 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeV
 # Class: obo:CL_4023017 (sst GABAergic cortical interneuron)
 
 AnnotationAssertion(obo:IAO_0000028 obo:CL_4023017 "sst cortical interneuron")
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:27477017") obo:IAO_0000115 obo:CL_4023017 "A GABAergic neuron located in the cerebral cortex that expresses somatostatin (sst)")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:27477017") Annotation(oboInOwl:hasDbXref "PMID:37824655") obo:IAO_0000115 obo:CL_4023017 "A GABAergic neuron located in the cerebral cortex that expresses somatostatin (sst)")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4023017 <https://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023017 "ILX:0770152")
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023017 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
@@ -29218,7 +29218,7 @@ EquivalentClasses(obo:CL_4023017 ObjectIntersectionOf(obo:CL_0000099 ObjectSomeV
 # Class: obo:CL_4023018 (pvalb GABAergic cortical interneuron)
 
 AnnotationAssertion(obo:IAO_0000028 obo:CL_4023018 "pvalb cortical interneuron")
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:27477017") obo:IAO_0000115 obo:CL_4023018 "A GABAergic interneuron located in the cerebral cortex that expresses Parvalbumin.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:27477017") Annotation(oboInOwl:hasDbXref "PMID:37824655") obo:IAO_0000115 obo:CL_4023018 "A GABAergic interneuron located in the cerebral cortex that expresses Parvalbumin.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4023018 <https://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023018 "ILX:0770154")
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023018 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
@@ -29442,7 +29442,7 @@ SubClassOf(obo:CL_4023036 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000013502))
 # Class: obo:CL_4023038 (L6b glutamatergic cortical neuron)
 
 AnnotationAssertion(obo:IAO_0000028 obo:CL_4023038 "L6b glut")
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "DOI:10.1101/2020.10.19.34312") Annotation(oboInOwl:hasDbXref "PMID:30382198") obo:IAO_0000115 obo:CL_4023038 "A glutamatergic neuron with a soma found in cortical layer 6b. They are transcriptomically related to corticothalamic-projecting neurons but have differential projections to the thalamus or anterior cingulate.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "DOI:10.1101/2020.10.19.34312") Annotation(oboInOwl:hasDbXref "PMID:30382198") Annotation(oboInOwl:hasDbXref "PMID:37824655") obo:IAO_0000115 obo:CL_4023038 "A glutamatergic neuron with a soma found in cortical layer 6b. They are transcriptomically related to corticothalamic-projecting neurons but have differential projections to the thalamus or anterior cingulate.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4023038 <https://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023038 "ILX:0770163")
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023038 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
@@ -29469,10 +29469,10 @@ SubClassOf(obo:CL_4023040 obo:CL_4023008)
 # Class: obo:CL_4023041 (L5 extratelencephalic projecting glutamatergic cortical neuron)
 
 AnnotationAssertion(obo:IAO_0000028 obo:CL_4023041 "L5 ET glut")
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "DOI:10.1101/2020.10.19.343129") obo:IAO_0000115 obo:CL_4023041 "A glutamatergic neuron, with a soma found in the deeper portion of L5, that has long-range axonal projections including deep subcortical targets outside of the telencephalon and, in some cases, the spinal cord. While the L5 ET neuron projections are not limited to ET targets, they are clearly differentiated from the neuron subclasses whose projections are constrained to intratelencephalic (IT) targets.  L5 ET neurons are generally the largest excitatory cortical neurons, typically having a thick apical dendrite with a prominent dendritic tuft in layer 1 and displaying burst-firing physiological characteristics.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:34616075") Annotation(oboInOwl:hasDbXref "PMID:37824655") obo:IAO_0000115 obo:CL_4023041 "A glutamatergic neuron, with a soma found in the deeper portion of L5, that has long-range axonal projections including deep subcortical targets outside of the telencephalon and, in some cases, the spinal cord. While the L5 ET neuron projections are not limited to ET targets, they are clearly differentiated from the neuron subclasses whose projections are constrained to intratelencephalic (IT) targets.  L5 ET neurons are generally the largest excitatory cortical neurons, typically having a thick apical dendrite with a prominent dendritic tuft in layer 1 and displaying burst-firing physiological characteristics.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4023041 <https://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "DOI:10.1016/j.neuron.2005.08.030") oboInOwl:hasBroadSynonym obo:CL_4023041 "subcerebral projection (SCPN) neuron")
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "DOI:10.1016/j.cell.2019.09.023") Annotation(rdfs:comment "pyramidal tract-like is used because, unlike pyramidal tract neurons in the motor cortex, neurons in the structures like the auditory cortex do not project to the spinal cord.") oboInOwl:hasExactSynonym obo:CL_4023041 "Pyramidal tract-like (PT-l)")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:31626774") Annotation(rdfs:comment "pyramidal tract-like is used because, unlike pyramidal tract neurons in the motor cortex, neurons in the structures like the auditory cortex do not project to the spinal cord.") oboInOwl:hasExactSynonym obo:CL_4023041 "Pyramidal tract-like (PT-l)")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "DOI:10.3389/fncel.2011.00001") oboInOwl:hasExactSynonym obo:CL_4023041 "burst-firing layer 5 neuron")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "DOI:10.3389/fncel.2015.00233") oboInOwl:hasExactSynonym obo:CL_4023041 "thick-tufted layer 5 (TTL5) pyramidal neuron")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "DOI:10.1038/nrn3469") oboInOwl:hasNarrowSynonym obo:CL_4023041 "pyramidal tract (PT) neuron")
@@ -29485,9 +29485,9 @@ SubClassOf(obo:CL_4023041 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0070015))
 # Class: obo:CL_4023042 (L6 corticothalamic-projecting glutamatergic cortical neuron)
 
 AnnotationAssertion(obo:IAO_0000028 obo:CL_4023042 "L6 CT glut")
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "DOI:10.1101/2020.10.19.343129") obo:IAO_0000115 obo:CL_4023042 "A corticothalamic-projecting neuron with a soma found in cortical layer 6.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:34616075") Annotation(oboInOwl:hasDbXref "PMID:37824655") obo:IAO_0000115 obo:CL_4023042 "A corticothalamic-projecting neuron with a soma found in cortical layer 6.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4023042 <https://orcid.org/0000-0001-7258-9596>)
-AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4023042 "L6 CT")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:28625486") Annotation(oboInOwl:hasDbXref "PMID:34616075") oboInOwl:hasExactSynonym obo:CL_4023042 "L6 CT")
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023042 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(rdfs:label obo:CL_4023042 "L6 corticothalamic-projecting glutamatergic cortical neuron")
 EquivalentClasses(obo:CL_4023042 ObjectIntersectionOf(obo:CL_4023013 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0005395)))
@@ -29496,7 +29496,7 @@ SubClassOf(obo:CL_4023042 ObjectSomeValuesFrom(obo:RO_0013001 obo:UBERON_0010225
 # Class: obo:CL_4023043 (L5/6 near-projecting glutamatergic neuron of the primary motor cortex)
 
 AnnotationAssertion(obo:IAO_0000028 obo:CL_4023043 "L5/6 NP glut MOp")
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "DOI:10.1101/2020.10.19.343129") Annotation(oboInOwl:hasDbXref "PMID:31209381") obo:IAO_0000115 obo:CL_4023043 "A near-projecting glutamatergic neuron with a soma found in layer 5/6 of the primary motor cortex.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:31209381") Annotation(oboInOwl:hasDbXref "PMID:34616075") obo:IAO_0000115 obo:CL_4023043 "A near-projecting glutamatergic neuron with a soma found in layer 5/6 of the primary motor cortex.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4023043 <https://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023043 "ILX:0770161")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4023043 "L5/6 NP M1")
@@ -29546,10 +29546,10 @@ SubClassOf(obo:CL_4023046 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001384
 # Class: obo:CL_4023047 (L2/3 intratelencephalic projecting glutamatergic neuron of the primary motor cortex)
 
 AnnotationAssertion(obo:IAO_0000028 obo:CL_4023047 "L2/3 IT glut MOp")
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "DOI:10.1101/2020.10.19.343129") obo:IAO_0000115 obo:CL_4023047 "An intratelencephalic-projecting glutamatergic neuron with a soma found in cortical layer 2/3 of the primary motor cortex.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:34616075") obo:IAO_0000115 obo:CL_4023047 "An intratelencephalic-projecting glutamatergic neuron with a soma found in cortical layer 2/3 of the primary motor cortex.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4023047 <https://orcid.org/0000-0001-7258-9596>)
-AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4023047 "L2/3 IT M1")
-AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4023047 "L2/3 IT MOp")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:34616075") oboInOwl:hasExactSynonym obo:CL_4023047 "L2/3 IT M1")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:34616075") oboInOwl:hasExactSynonym obo:CL_4023047 "L2/3 IT MOp")
 AnnotationAssertion(oboInOwl:inSubset obo:CL_4023047 <http://purl.obolibrary.org/obo/cl#BDS_subset>)
 AnnotationAssertion(rdfs:label obo:CL_4023047 "L2/3 intratelencephalic projecting glutamatergic neuron of the primary motor cortex")
 EquivalentClasses(obo:CL_4023047 ObjectIntersectionOf(obo:CL_4030059 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001384)))
@@ -29593,7 +29593,7 @@ SubClassOf(obo:CL_4023050 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0070019))
 
 # Class: obo:CL_4023051 (vascular leptomeningeal cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:27284195") Annotation(oboInOwl:hasDbXref "PMID:29443965") Annotation(oboInOwl:hasDbXref "PMID:30096314") obo:IAO_0000115 obo:CL_4023051 "A type of mesothelial fibroblast that is derived from the neural crest, is localized on blood vessels, and is a key component of the pia and arachnoid membranes surrounding the brain.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:27284195") Annotation(oboInOwl:hasDbXref "PMID:29443965") Annotation(oboInOwl:hasDbXref "PMID:30096314") Annotation(oboInOwl:hasDbXref "PMID:37824655") obo:IAO_0000115 obo:CL_4023051 "A type of mesothelial fibroblast that is derived from the neural crest, is localized on blood vessels, and is a key component of the pia and arachnoid membranes surrounding the brain.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4023051 <https://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_4023051 "ILX:0770143")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4023051 "VLMC")
@@ -29892,7 +29892,7 @@ SubClassOf(obo:CL_4023081 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0070021))
 
 # Class: obo:CL_4023083 (chandelier cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:15378039") Annotation(oboInOwl:hasDbXref "PMID:27199673") obo:IAO_0000115 obo:CL_4023083 "A GABAergic interneuron that selectively innervates the axon initial segment of pyramidal cells. Their local axonal clusters are formed by high-frequency branching at shallow angles, often ramifying around, above or below their somata with a high bouton density. The characteristic terminal portions of the axon form short vertical rows of boutons, resembling the candlesticks and candles of a chandelier. Chandelier cells can be multipolar or bitufted.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:15378039") Annotation(oboInOwl:hasDbXref "PMID:27199673") Annotation(oboInOwl:hasDbXref "PMID:37824655") obo:IAO_0000115 obo:CL_4023083 "A GABAergic interneuron that selectively innervates the axon initial segment of pyramidal cells. Their local axonal clusters are formed by high-frequency branching at shallow angles, often ramifying around, above or below their somata with a high bouton density. The characteristic terminal portions of the axon form short vertical rows of boutons, resembling the candlesticks and candles of a chandelier. Chandelier cells can be multipolar or bitufted.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4023083 <https://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:27199673") Annotation(oboInOwl:hasDbXref "PMID:33862423") oboInOwl:hasBroadSynonym obo:CL_4023083 "axo-axonic cell")
 AnnotationAssertion(Annotation(obo:IAO_0000116 "Interlex cross reference refers specifically to Markram 2015 rat chandelier cell.") oboInOwl:hasDbXref obo:CL_4023083 "ILX:0777213")
@@ -30203,7 +30203,7 @@ EquivalentClasses(obo:CL_4023120 ObjectIntersectionOf(obo:CL_0000202 ObjectSomeV
 # Class: obo:CL_4023121 (sst chodl GABAergic cortical interneuron)
 
 AnnotationAssertion(obo:IAO_0000028 obo:CL_4023121 "sst chodl cortical interneuron")
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:15845086") Annotation(oboInOwl:hasDbXref "PMID:31209381") Annotation(oboInOwl:hasDbXref "PMID:33372656") obo:IAO_0000115 obo:CL_4023121 "A sst GABAergic cortical interneuron that also expresses Chodl. These neurons are rare and correspond to the only known cortical interneurons with long-range projection.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:15845086") Annotation(oboInOwl:hasDbXref "PMID:31209381") Annotation(oboInOwl:hasDbXref "PMID:33372656") Annotation(oboInOwl:hasDbXref "PMID:37824655") obo:IAO_0000115 obo:CL_4023121 "A sst GABAergic cortical interneuron that also expresses Chodl. These neurons are rare and correspond to the only known cortical interneurons with long-range projection.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4023121 <https://orcid.org/0000-0001-7258-9596>)
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_4023121 "long-range GABAergic interneuron")
 AnnotationAssertion(rdfs:label obo:CL_4023121 "sst chodl GABAergic cortical interneuron")
@@ -31094,7 +31094,7 @@ EquivalentClasses(obo:CL_4030058 ObjectIntersectionOf(obo:CL_0000235 ObjectSomeV
 
 # Class: obo:CL_4030059 (L2/3 intratelencephalic projecting glutamatergic neuron)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:34004146") Annotation(oboInOwl:hasDbXref "PMID:37292694") obo:IAO_0000115 obo:CL_4030059 "An intratelencephalic-projecting glutamatergic neuron with a soma found in cortical layer 2/3.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:34004146") Annotation(oboInOwl:hasDbXref "PMID:37292694") Annotation(oboInOwl:hasDbXref "PMID:37824655") obo:IAO_0000115 obo:CL_4030059 "An intratelencephalic-projecting glutamatergic neuron with a soma found in cortical layer 2/3.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4030059 <https://orcid.org/0000-0003-4389-9821>)
 AnnotationAssertion(<http://purl.org/dc/terms/date> obo:CL_4030059 "2023-10-10T14:10:21Z"^^xsd:dateTime)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:34004146") Annotation(oboInOwl:hasSynonymType obo:OMO_0003000) oboInOwl:hasRelatedSynonym obo:CL_4030059 "L2/3 IT")
@@ -31130,7 +31130,7 @@ EquivalentClasses(obo:CL_4030062 ObjectIntersectionOf(obo:CL_4023040 ObjectSomeV
 
 # Class: obo:CL_4030063 (L4 intratelencephalic projecting glutamatergic neuron)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:37292694") obo:IAO_0000115 obo:CL_4030063 "An intratelencephalic-projecting glutamatergic neuron with a soma found in cortical layer 4.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:37292694") Annotation(oboInOwl:hasDbXref "PMID:37824655") obo:IAO_0000115 obo:CL_4030063 "An intratelencephalic-projecting glutamatergic neuron with a soma found in cortical layer 4.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4030063 <https://orcid.org/0000-0003-4389-9821>)
 AnnotationAssertion(<http://purl.org/dc/terms/date> obo:CL_4030063 "2023-10-10T14:11:25Z"^^xsd:dateTime)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:37292694") Annotation(oboInOwl:hasSynonymType obo:OMO_0003000) oboInOwl:hasRelatedSynonym obo:CL_4030063 "L4 IT")
@@ -31139,7 +31139,7 @@ EquivalentClasses(obo:CL_4030063 ObjectIntersectionOf(obo:CL_4023040 ObjectSomeV
 
 # Class: obo:CL_4030064 (L5 intratelencephalic projecting glutamatergic neuron)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:37292694") Annotation(oboInOwl:hasDbXref "PMID:37609206") obo:IAO_0000115 obo:CL_4030064 "An intratelencephalic-projecting glutamatergic neuron with a soma found in cortical layer 5.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:37292694") Annotation(oboInOwl:hasDbXref "PMID:37609206") Annotation(oboInOwl:hasDbXref "PMID:37824655") obo:IAO_0000115 obo:CL_4030064 "An intratelencephalic-projecting glutamatergic neuron with a soma found in cortical layer 5.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4030064 <https://orcid.org/0000-0003-4389-9821>)
 AnnotationAssertion(<http://purl.org/dc/terms/date> obo:CL_4030064 "2023-10-10T14:11:59Z"^^xsd:dateTime)
 AnnotationAssertion(Annotation(oboInOwl:SynonymTypeProperty obo:OMO_0003000) Annotation(oboInOwl:hasDbXref "PMID:37292694") oboInOwl:hasRelatedSynonym obo:CL_4030064 "L5 IT")
@@ -31148,7 +31148,7 @@ EquivalentClasses(obo:CL_4030064 ObjectIntersectionOf(obo:CL_4023040 ObjectSomeV
 
 # Class: obo:CL_4030065 (L6 intratelencephalic projecting glutamatergic neuron)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:37292694") Annotation(oboInOwl:hasDbXref "PMID:37609206") obo:IAO_0000115 obo:CL_4030065 "An intratelencephalic-projecting glutamatergic neuron with a soma found in cortical layer 6.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:37292694") Annotation(oboInOwl:hasDbXref "PMID:37609206") Annotation(oboInOwl:hasDbXref "PMID:37824655") obo:IAO_0000115 obo:CL_4030065 "An intratelencephalic-projecting glutamatergic neuron with a soma found in cortical layer 6.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4030065 <https://orcid.org/0000-0003-4389-9821>)
 AnnotationAssertion(<http://purl.org/dc/terms/date> obo:CL_4030065 "2023-10-10T14:12:23Z"^^xsd:dateTime)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:37292694") Annotation(oboInOwl:hasSynonymType obo:OMO_0003000) oboInOwl:hasRelatedSynonym obo:CL_4030065 "L6 IT")
@@ -31167,7 +31167,7 @@ SubClassOf(Annotation(oboInOwl:hasDbXref "PMID:9374839") obo:CL_4030066 ObjectSo
 
 # Class: obo:CL_4030067 (L5/6 near-projecting glutamatergic neuron)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:34004146") Annotation(oboInOwl:hasDbXref "PMID:37292694") obo:IAO_0000115 obo:CL_4030067 "A near-projecting glutamatergic neuron with a soma found in cortical layer 5/6.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:34004146") Annotation(oboInOwl:hasDbXref "PMID:37292694") Annotation(oboInOwl:hasDbXref "PMID:37824655") obo:IAO_0000115 obo:CL_4030067 "A near-projecting glutamatergic neuron with a soma found in cortical layer 5/6.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4030067 <https://orcid.org/0000-0003-4389-9821>)
 AnnotationAssertion(<http://purl.org/dc/terms/date> obo:CL_4030067 "2023-11-17T11:35:06Z"^^xsd:dateTime)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:34004146") Annotation(oboInOwl:hasSynonymType obo:OMO_0003000) oboInOwl:hasRelatedSynonym obo:CL_4030067 "L5/6 NP")
@@ -31176,7 +31176,7 @@ EquivalentClasses(obo:CL_4030067 ObjectIntersectionOf(obo:CL_4023012 ObjectSomeV
 
 # Class: obo:CL_4030068 (L6 intratelencephalic projecting Car3 glutamatergic neuron)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1016/j.cell.2021.04.021") Annotation(oboInOwl:hasDbXref "doi:10.1101/2022.11.06.515349") Annotation(oboInOwl:hasDbXref "doi:10.1101/2022.11.30.518285") obo:IAO_0000115 obo:CL_4030068 "An intratelencephalic-projecting glutamatergic neuron with a soma found in cortical layer 6 that expresses Car3.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1101/2022.11.30.518285") Annotation(oboInOwl:hasDbXref "PMID:34004146") Annotation(oboInOwl:hasDbXref "PMID:37824655") obo:IAO_0000115 obo:CL_4030068 "An intratelencephalic-projecting glutamatergic neuron with a soma found in cortical layer 6 that expresses Car3.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4030068 <https://orcid.org/0000-0003-4389-9821>)
 AnnotationAssertion(<http://purl.org/dc/terms/date> obo:CL_4030068 "2023-11-23T09:16:14Z"^^xsd:dateTime)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref <https://orcid.org/0000-0003-4389-9821>) Annotation(oboInOwl:hasSynonymType obo:OMO_0003000) oboInOwl:hasExactSynonym obo:CL_4030068 "L6 IT Car3 glutamatergic neuron")
@@ -32040,7 +32040,7 @@ SubClassOf(obo:CL_4042007 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001950
 
 # Class: obo:CL_4042008 (fibrous astrocyte)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:19279265") Annotation(oboInOwl:hasDbXref "PMID:22144298") Annotation(oboInOwl:hasDbXref "PMID:28280934") Annotation(oboInOwl:hasDbXref "PMID:31435019") Annotation(oboInOwl:hasDbXref "PMID:34616062") obo:IAO_0000115 obo:CL_4042008 "A cell type located in the first layer of the neocortex with radial protrusions extending transversely into the deeper cortex layers, herby facilitating communication across neurons, astrocytes, capillaries, meninges and cerebrospinal fluid through contact with neurons, pia mater and capillaries.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:19279265") Annotation(oboInOwl:hasDbXref "PMID:22144298") Annotation(oboInOwl:hasDbXref "PMID:28280934") Annotation(oboInOwl:hasDbXref "PMID:31435019") Annotation(oboInOwl:hasDbXref "PMID:34616062") Annotation(oboInOwl:hasDbXref "PMID:37824655") obo:IAO_0000115 obo:CL_4042008 "A cell type located in the first layer of the neocortex with radial protrusions extending transversely into the deeper cortex layers, herby facilitating communication across neurons, astrocytes, capillaries, meninges and cerebrospinal fluid through contact with neurons, pia mater and capillaries.")
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> obo:CL_4042008 <https://orcid.org/0000-0002-0098-8958>)
 AnnotationAssertion(<http://purl.org/dc/terms/date> obo:CL_4042008 "2024-04-08T16:29:28Z"^^xsd:dateTime)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:28280934") rdfs:comment obo:CL_4042008 "In humans, a fibrous astrocyte diameter is circa 182 µm. In rodents, a fibrous astrocyte diameter is circa 85 µm.")


### PR DESCRIPTION
Fixes #2337

- Adds Jorstad paper as a reference to cortical neurons.
- Substitutes references doi ID for PMID:
doi:10.1016/j.cell.2021.04.021 → PMID:34004146
doi:10.1101/2022.11.06.515349 → PMID:37824655