### PR TITLE
Re-classify 'R7 photoreceptor cell' as part of an ommatidium.

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -9494,8 +9494,8 @@ SubClassOf(obo:CL_0000706 obo:CL_0000627)
 
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000707 "R7 cell")
 AnnotationAssertion(rdfs:label obo:CL_0000707 "R7 photoreceptor cell")
-SubClassOf(obo:CL_0000707 obo:CL_0000287)
 SubClassOf(obo:CL_0000707 obo:CL_0000494)
+SubClassOf(obo:CL_0000707 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0000971))
 
 # Class: obo:CL_0000708 (leptomeningeal cell)
 


### PR DESCRIPTION
The `R7 photoreceptor cell` is explicitly classified as an `eye photoreceptor cell`. This is imprecise as `eye photoreceptor cell` refers to photoreceptors in any type of eye, while R7 photoreceptors are found in compound eyes.

This PR classifies `R7 photoreceptor cell` as being part of some `ommatidium` (as the other R1, R2, ... R8 photoreceptor cells). This automatically classifies it as a `compound eye photoreceptor cell`, as it should be.

(Found while working on #2342)