### PR TITLE
Building the ZFA mapping set must depend on 'all_robot_plugins'.

### DIFF
--- a/src/ontology/cl.Makefile
+++ b/src/ontology/cl.Makefile
@@ -138,7 +138,7 @@ $(MAPPINGDIR)/fbbt.sssom.tsv: .FORCE
 # ZFA does contain oboInOwl:treat-xrefs-as-... annotations, but here
 # it's easier to ignore them, as this automatically filters out all the
 # xrefs that point to anything else than CL.
-$(MAPPINGDIR)/zfa.sssom.tsv: .FORCE
+$(MAPPINGDIR)/zfa.sssom.tsv: .FORCE | all_robot_plugins
 	$(ROBOT) sssom:xref-extract -I http://purl.obolibrary.org/obo/zfa.owl \
 		                    --mapping-file $@ -v --drop-duplicates \
 		                    --ignore-treat-xrefs \


### PR DESCRIPTION
The rule that extracts the cross-references from the local mirror of ZFA to build the ZFA-to-CL mapping set is using the SSSOM plugin, so we must make sure the plugin is ready to use (in `$(TMPDIR)/plugins`) before we reach that rule. The normal way to do that is to depend on the 'all_robot_plugins' target, which takes care of installing all plugins.

This was missed when preparing #2361 because running the entire pipeline causes the plugins to be installed anyway before we reach the zfa.sssom.tsv rule. But this may not be the case when trying to build individual products.