### PR TITLE
Update ODK version used in workflows.

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -53,7 +53,7 @@ jobs:
     needs: [branch_status]
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
-    container: obolibrary/odklite:v1.3.0
+    container: obolibrary/odkfull:v1.5
     steps:
       - uses: khan/pull-request-comment-trigger@v1.1.0
         id: check
@@ -87,7 +87,7 @@ jobs:
     needs: [branch_status]
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
-    container: obolibrary/odklite:v1.3.0
+    container: obolibrary/odkfull:v1.5
     steps:
       - uses: khan/pull-request-comment-trigger@v1.1.0
         id: check
@@ -115,7 +115,7 @@ jobs:
     needs: [branch_status]
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
-    container: obolibrary/odklite:v1.3.0
+    container: obolibrary/odkfull:v1.5
     steps:
       - uses: khan/pull-request-comment-trigger@v1.1.0
         id: check
@@ -140,7 +140,7 @@ jobs:
   diff_classification:
     needs:  [classify_branch, classify_main]
     runs-on: ubuntu-latest
-    container: obolibrary/odklite:v1.3.0
+    container: obolibrary/odkfull:v1.5
     steps:
       - uses: khan/pull-request-comment-trigger@v1.1.0
         id: check

--- a/.github/workflows/ontobot.yml
+++ b/.github/workflows/ontobot.yml
@@ -31,7 +31,7 @@ jobs:
     needs: check
     if: needs.check.outputs.phraseExists == 'true'
     runs-on: ${{ matrix.os }}
-    container: obolibrary/odkfull:v1.4.3
+    container: obolibrary/odkfull:v1.5
     strategy:
       matrix:
         python-version: ["3.9"]
@@ -71,11 +71,9 @@ jobs:
           echo "resource=src/ontology/cl-edit.owl" >> $GITHUB_ENV
           echo "branch-name=kgcl_automation_"${{ steps.gh-script-issue.outputs.result }} >> $GITHUB_ENV
       
-      - name: Get jar & enable plugin.
+      - name: Enable KGCL plugin
         run: |
-          mkdir -p robot-plugins
-          wget https://github.com/gouttegd/kgcl-java/releases/download/kgcl-0.2.0/kgcl-robot-plugin-0.2.0.jar -O robot-plugins/kgcl.jar
-          echo "ROBOT_PLUGINS_DIRECTORY=$(pwd)/robot-plugins/" >> "$GITHUB_ENV"
+          echo "ROBOT_PLUGINS_DIRECTORY=/tools/robot-plugins/" >> "$GITHUB_ENV"
 
       - name: Install dependencies
         run: |
@@ -88,9 +86,6 @@ jobs:
           -r ${{ steps.gh-script-repo.outputs.result }} \
           -n ${{ steps.gh-script-issue.outputs.result }} \
           -g ${{ secrets.ONTOBOT_TOKEN }}
-
-      - name: Clean-up
-        run: rm -rf robot-plugins
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5


### PR DESCRIPTION
The `diff` workflow is still using version 1.3.0 of the ODK, but building CL now requires version 1.5 since the preprocessing step is making use of a ROBOT plugin and support for ROBOT plugins was introduced in 1.5. Also, the use of plugins require *odkfull*, not *odklite*.

Similarly, the `ontobot` workflow is still using version 1.4.3 of the ODK, and is manually downloading the KGCL plugin. This works, but the ODK 1.5 already includes the KGCL plugin, so upgrading the workflow to use the latest ODK makes things a bit easier as we can just use the plugin as provided by the ODK.

closes #2367