### PR TITLE
Revise textual definition and links to GO terms - ciliated columnar cell of tracheobronchial tree

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -15156,14 +15156,16 @@ SubClassOf(obo:CL_0002144 obo:CL_0002653)
 
 # Class: obo:CL_0002145 (ciliated columnar cell of tracheobronchial tree)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "ISBN:0517223651") obo:IAO_0000115 obo:CL_0002145 "A ciliated columnar cell found in the trachea and bronchus. Vary from low to tall columnar; possesses up to 300 cilia at its surface, interspersed with long irregular microvilli with the cilia varying in length from about 6um in the trachea to about 4um in the terminal bronchioles; driving force of the ciliary current in the bronchial tree.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "PMID:28400610") obo:IAO_0000115 obo:CL_0002145 "A multi-ciliated epithelial cell located in the trachea and bronchi, characterized by a columnar shape and motile cilia on its apical surface. These cilia facilitate mucociliary clearance by moving mucus and trapped particles toward the pharynx.")
 AnnotationAssertion(terms:contributor obo:CL_0002145 <https://orcid.org/0000-0003-1980-3228>)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002145 "2010-08-24T03:38:29Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0002145 "FMA:70542")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref <https://doi.org/10.1016/B978-032304048-8.50071-2>) Annotation(oboInOwl:hasDbXref "PMID:25386990") rdfs:comment obo:CL_0002145 "These cells possess numerous cilia on their surface, typically ranging from 200 to 300 per cell. The cilia vary in length, measuring between 6 to 7 μm in the upper airways (trachea) and becoming shorter, around 4 μm, in the smaller airways (terminal bronchioles). These cells form a two-layered 'coat' in the airway: the lower 'sol' layer is watery, allowing the cilia to beat in coordinated waves, while the upper 'gel' layer is thick and sticky, trapping inhaled particles.")
 AnnotationAssertion(rdfs:label obo:CL_0002145 "ciliated columnar cell of tracheobronchial tree")
 SubClassOf(obo:CL_0002145 obo:CL_0002202)
 SubClassOf(obo:CL_0002145 obo:CL_0005012)
 SubClassOf(obo:CL_0002145 obo:CL_4030034)
+SubClassOf(obo:CL_0002145 ObjectSomeValuesFrom(obo:BFO_0000051 obo:GO_0031514))
 SubClassOf(obo:CL_0002145 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0002209))
 
 # Class: obo:CL_0002146 (clear cell of eccrine sweat gland)


### PR DESCRIPTION
-Updated textual definition and added references
-A link to GO term has been added
-Revised the extended description and added references - information has been extracted from CxG LLM-driven definition