### PR TITLE
Revise epithelial cell of cervix classification

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -15232,11 +15232,12 @@ SubClassOf(obo:CL_0002151 obo:CL_0000836)
 
 # Class: obo:CL_0002152 (columnar cell of endocervix)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "ISBN:0721662544") obo:IAO_0000115 obo:CL_0002152 "A columnar cell of the cervix uteri.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "ISBN:0721662544") Annotation(oboInOwl:hasDbXref "doi:/10.1016/j.autneu.2015.04.008") obo:IAO_0000115 obo:CL_0002152 "A simple columnar epithelial cell located in the endocervix.")
 AnnotationAssertion(terms:contributor obo:CL_0002152 <https://orcid.org/0000-0003-1980-3228>)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002152 "2010-08-24T10:47:47Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0002152 "FMA:86486")
 AnnotationAssertion(rdfs:label obo:CL_0002152 "columnar cell of endocervix")
+EquivalentClasses(obo:CL_0002152 ObjectIntersectionOf(obo:CL_0000146 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0012252)))
 SubClassOf(obo:CL_0002152 obo:CL_0002149)
 SubClassOf(obo:CL_0002152 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0000458))
 
@@ -16196,12 +16197,13 @@ SubClassOf(obo:CL_0002243 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000133))
 
 # Class: obo:CL_0002244 (squamous cell of ectocervix)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "http://www.bu.edu/histology/p/19404loa.htm") obo:IAO_0000115 obo:CL_0002244 "A nonstratified squamous cell located in the ectocervix.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "http://www.bu.edu/histology/p/19404loa.htm") Annotation(oboInOwl:hasDbXref "PMID:32644501") Annotation(oboInOwl:hasDbXref "doi:/10.1016/j.autneu.2015.04.008") obo:IAO_0000115 obo:CL_0002244 "A stratified squamous epithelial cell located in the ectocervix.")
 AnnotationAssertion(terms:contributor obo:CL_0002244 <https://orcid.org/0000-0003-1980-3228>)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002244 "2010-09-08T09:12:23Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0002244 "FMA:86483")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0002244 "ectocervical squamous cell")
 AnnotationAssertion(rdfs:label obo:CL_0002244 "squamous cell of ectocervix")
+EquivalentClasses(obo:CL_0002244 ObjectIntersectionOf(obo:CL_0000076 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0012251)))
 SubClassOf(obo:CL_0002244 obo:CL_0000076)
 SubClassOf(obo:CL_0002244 obo:CL_0002149)
 

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -15238,8 +15238,6 @@ AnnotationAssertion(oboInOwl:creation_date obo:CL_0002152 "2010-08-24T10:47:47Z"
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0002152 "FMA:86486")
 AnnotationAssertion(rdfs:label obo:CL_0002152 "columnar cell of endocervix")
 EquivalentClasses(obo:CL_0002152 ObjectIntersectionOf(obo:CL_0000146 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0012252)))
-SubClassOf(obo:CL_0002152 obo:CL_0002149)
-SubClassOf(obo:CL_0002152 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0000458))
 
 # Class: obo:CL_0002153 (corneocyte)
 
@@ -16197,15 +16195,13 @@ SubClassOf(obo:CL_0002243 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000133))
 
 # Class: obo:CL_0002244 (squamous cell of ectocervix)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "http://www.bu.edu/histology/p/19404loa.htm") Annotation(oboInOwl:hasDbXref "PMID:32644501") Annotation(oboInOwl:hasDbXref "doi:/10.1016/j.autneu.2015.04.008") obo:IAO_0000115 obo:CL_0002244 "A stratified squamous epithelial cell located in the ectocervix.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "PMID:32644501") Annotation(oboInOwl:hasDbXref "doi:/10.1016/j.autneu.2015.04.008") Annotation(oboInOwl:hasDbXref "http://www.bu.edu/histology/p/19404loa.htm") obo:IAO_0000115 obo:CL_0002244 "A stratified squamous epithelial cell located in the ectocervix.")
 AnnotationAssertion(terms:contributor obo:CL_0002244 <https://orcid.org/0000-0003-1980-3228>)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002244 "2010-09-08T09:12:23Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0002244 "FMA:86483")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0002244 "ectocervical squamous cell")
 AnnotationAssertion(rdfs:label obo:CL_0002244 "squamous cell of ectocervix")
 EquivalentClasses(obo:CL_0002244 ObjectIntersectionOf(obo:CL_0000076 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0012251)))
-SubClassOf(obo:CL_0002244 obo:CL_0000076)
-SubClassOf(obo:CL_0002244 obo:CL_0002149)
 
 # Class: obo:CL_0002245 (obsolete null lymphocyte)
 

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -15205,7 +15205,7 @@ AnnotationAssertion(terms:contributor obo:CL_0002149 <https://orcid.org/0000-000
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002149 "2010-08-24T10:45:54Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0002149 "FMA:256161")
 AnnotationAssertion(rdfs:label obo:CL_0002149 "epithelial cell of uterus")
-EquivalentClasses(obo:CL_0002149 ObjectIntersectionOf(obo:CL_0000066 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0000995)))
+EquivalentClasses(obo:CL_0002149 ObjectIntersectionOf(obo:CL_0000066 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0006955)))
 SubClassOf(obo:CL_0002149 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000222))
 
 # Class: obo:CL_0002150 (epithelioid macrophage)
@@ -20316,7 +20316,7 @@ AnnotationAssertion(terms:contributor obo:CL_0002656 <https://orcid.org/0000-000
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002656 "2011-07-08T03:54:08Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0002656 "FMA:86489")
 AnnotationAssertion(rdfs:label obo:CL_0002656 "glandular cell of endometrium")
-EquivalentClasses(obo:CL_0002656 ObjectIntersectionOf(obo:CL_0000150 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0001295)))
+EquivalentClasses(obo:CL_0002656 ObjectIntersectionOf(obo:CL_0000150 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0004811)))
 SubClassOf(obo:CL_0002656 obo:CL_0000150)
 
 # Class: obo:CL_0002657 (glandular cell of esophagus)


### PR DESCRIPTION
This is the current classification of epithelial cell of the uterus. columnar cell of endocervix and squamous cell of ectocervix should be classified under the epithelial cell of cervix.

![image](https://github.com/user-attachments/assets/90b095aa-39c3-4052-bca8-7da8de184f6d)

Actions taken:
-logical definitions for squamous cell of ectocervix and columnar cell of endocervix have been updated 
-changed the textual definition of squamous cell of ectocervix and added references 
-changed the textual definition of columnar cell of ectocervix and added references