### PR TITLE
Replace only_in_taxon by in_taxon.

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -3445,7 +3445,7 @@ AnnotationAssertion(oboInOwl:inSubset obo:CL_0000000 ubprop:_upper_level)
 AnnotationAssertion(rdfs:comment obo:CL_0000000 "The definition of cell is intended to represent all cells, and thus a cell is defined as a material entity and not an anatomical structure, which implies that it is part of an organism (or the entirety of one).")
 AnnotationAssertion(rdfs:label obo:CL_0000000 "cell")
 SubClassOf(obo:CL_0000000 obo:UBERON_0000061)
-SubClassOf(obo:CL_0000000 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_131567))
+SubClassOf(obo:CL_0000000 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_131567))
 
 # Class: obo:CL_0000001 (primary cultured cell)
 
@@ -3665,7 +3665,7 @@ AnnotationAssertion(oboInOwl:hasRelatedSynonym obo:CL_0000023 "oogonium")
 AnnotationAssertion(rdfs:label obo:CL_0000023 "oocyte")
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000023 obo:CL_0000021)
 SubClassOf(obo:CL_0000023 ObjectSomeValuesFrom(obo:RO_0000056 obo:GO_0007143))
-SubClassOf(obo:CL_0000023 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_33208))
+SubClassOf(obo:CL_0000023 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_33208))
 
 # Class: obo:CL_0000024 (oogonial cell)
 
@@ -3739,7 +3739,7 @@ AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000031 "FMA:70563")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000031 "neuroblast")
 AnnotationAssertion(rdfs:label obo:CL_0000031 "neuroblast (sensu Vertebrata)")
 SubClassOf(obo:CL_0000031 obo:CL_0000055)
-SubClassOf(obo:CL_0000031 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_7742))
+SubClassOf(obo:CL_0000031 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_7742))
 
 # Class: obo:CL_0000032 (neuroplacodal cell)
 
@@ -4653,7 +4653,7 @@ EquivalentClasses(obo:CL_0000122 ObjectIntersectionOf(obo:CL_0000117 ObjectSomeV
 
 AnnotationAssertion(rdfs:label obo:CL_0000123 "neuron associated cell (sensu Vertebrata)")
 SubClassOf(obo:CL_0000123 obo:CL_0000095)
-SubClassOf(obo:CL_0000123 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_7742))
+SubClassOf(obo:CL_0000123 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_7742))
 SubClassOf(obo:CL_0000123 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000333))
 
 # Class: obo:CL_0000124 (obsolete glial cell (sensu Nematoda and Protostomia))
@@ -4736,7 +4736,7 @@ SubClassOf(obo:CL_0000129 ObjectSomeValuesFrom(obo:RO_0002202 ObjectIntersection
 
 AnnotationAssertion(rdfs:label obo:CL_0000130 "neuron associated cell (sensu Nematoda and Protostomia)")
 SubClassOf(obo:CL_0000130 obo:CL_0000095)
-SubClassOf(obo:CL_0000130 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_33317))
+SubClassOf(obo:CL_0000130 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_33317))
 
 # Class: obo:CL_0000131 (gut endothelial cell)
 
@@ -5862,7 +5862,7 @@ AnnotationAssertion(owl:deprecated obo:CL_0000254 "true"^^xsd:boolean)
 
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000255 "MESH:D005057")
 AnnotationAssertion(rdfs:label obo:CL_0000255 "eukaryotic cell")
-EquivalentClasses(obo:CL_0000255 ObjectIntersectionOf(obo:CL_0000000 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_2759)))
+EquivalentClasses(obo:CL_0000255 ObjectIntersectionOf(obo:CL_0000000 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_2759)))
 DisjointClasses(obo:CL_0000255 obo:CL_0000520)
 
 # Class: obo:CL_0000256 (uric acid accumulating cell)
@@ -5873,7 +5873,7 @@ SubClassOf(obo:CL_0000256 obo:CL_0000325)
 # Class: obo:CL_0000257 (Eumycetozoan cell)
 
 AnnotationAssertion(rdfs:label obo:CL_0000257 "Eumycetozoan cell")
-EquivalentClasses(obo:CL_0000257 ObjectIntersectionOf(obo:CL_0000000 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_142796)))
+EquivalentClasses(obo:CL_0000257 ObjectIntersectionOf(obo:CL_0000000 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_142796)))
 SubClassOf(obo:CL_0000257 obo:CL_0000255)
 
 # Class: obo:CL_0000258 (obsolete fiber tracheid)
@@ -6449,7 +6449,7 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:1295739") obo:IAO_000011
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000338 "neuroblast")
 AnnotationAssertion(rdfs:label obo:CL_0000338 "neuroblast (sensu Nematoda and Protostomia)")
 SubClassOf(obo:CL_0000338 obo:CL_0000047)
-SubClassOf(obo:CL_0000338 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_33317))
+SubClassOf(obo:CL_0000338 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_33317))
 
 # Class: obo:CL_0000339 (glioblast (sensu Vertebrata))
 
@@ -6459,7 +6459,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000339 "spongioblast")
 AnnotationAssertion(rdfs:label obo:CL_0000339 "glioblast (sensu Vertebrata)")
 SubClassOf(obo:CL_0000339 obo:CL_0000030)
 SubClassOf(obo:CL_0000339 obo:CL_0000123)
-SubClassOf(obo:CL_0000339 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_7742))
+SubClassOf(obo:CL_0000339 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_7742))
 
 # Class: obo:CL_0000340 (glioblast (sensu Nematoda and Protostomia))
 
@@ -6479,7 +6479,7 @@ SubClassOf(obo:CL_0000341 obo:CL_0000147)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "ISBN:0721662544") obo:IAO_0000115 obo:CL_0000342 "Any animal cell containing pigment granules.")
 AnnotationAssertion(rdfs:label obo:CL_0000342 "pigment cell (sensu Vertebrata)")
 SubClassOf(obo:CL_0000342 obo:CL_0000147)
-SubClassOf(obo:CL_0000342 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_7742))
+SubClassOf(obo:CL_0000342 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_7742))
 
 # Class: obo:CL_0000343 (visual pigment cell (sensu Vertebrata))
 
@@ -6652,7 +6652,7 @@ AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000365 "BTO:0000854")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000365 "EHDAA2:0004546")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000365 "FMA:72395")
 AnnotationAssertion(rdfs:label obo:CL_0000365 "animal zygote")
-EquivalentClasses(obo:CL_0000365 ObjectIntersectionOf(obo:CL_0010017 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_33208)))
+EquivalentClasses(obo:CL_0000365 ObjectIntersectionOf(obo:CL_0010017 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_33208)))
 SubClassOf(obo:CL_0000365 obo:CL_0000007)
 SubClassOf(obo:CL_0000365 obo:CL_0010017)
 
@@ -6713,7 +6713,7 @@ SubClassOf(obo:CL_0000372 obo:CL_0000463)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1016/j.cub.2022.01.045") obo:IAO_0000115 obo:CL_0000373 "A progenitor cell found in the larval epidermis of insects and that gives rise to the adult abdominal epidermis.")
 AnnotationAssertion(rdfs:label obo:CL_0000373 "histoblast")
 SubClassOf(obo:CL_0000373 obo:CL_0011026)
-SubClassOf(obo:CL_0000373 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_50557))
+SubClassOf(obo:CL_0000373 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_50557))
 
 # Class: obo:CL_0000374 (trichogen cell)
 
@@ -6802,7 +6802,7 @@ SubClassOf(obo:CL_0000386 obo:CL_0000630)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1016/B978-012369493-5.50008-0") obo:IAO_0000115 obo:CL_0000387 "A blood cell of the circulatory system of arthropods.")
 AnnotationAssertion(rdfs:label obo:CL_0000387 "hemocyte (sensu Arthropoda)")
 SubClassOf(obo:CL_0000387 obo:CL_0000390)
-SubClassOf(obo:CL_0000387 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_6656))
+SubClassOf(obo:CL_0000387 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_6656))
 SubClassOf(obo:CL_0000387 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000385))
 
 # Class: obo:CL_0000388 (tendon cell)
@@ -7093,7 +7093,7 @@ AnnotationAssertion(rdfs:comment obo:CL_0000429 "This term does not encompass al
 AnnotationAssertion(rdfs:label obo:CL_0000429 "imaginal disc cell")
 SubClassOf(obo:CL_0000429 obo:CL_0000146)
 SubClassOf(obo:CL_0000429 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0000939))
-SubClassOf(obo:CL_0000429 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_50557))
+SubClassOf(obo:CL_0000429 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_50557))
 
 # Class: obo:CL_0000430 (xanthophore cell)
 
@@ -7187,7 +7187,7 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1016/B978-012369493-5.
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1016/j.devcel.2005.08.012") oboInOwl:hasBroadSynonym obo:CL_0000441 "somatic stem cell")
 AnnotationAssertion(rdfs:label obo:CL_0000441 "follicle stem cell (sensu Arthropoda)")
 SubClassOf(obo:CL_0000441 obo:CL_0000036)
-SubClassOf(Annotation(obo:IAO_0000233 "https://github.com/obophenotype/cell-ontology/issues/1943") obo:CL_0000441 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_6656))
+SubClassOf(Annotation(obo:IAO_0000233 "https://github.com/obophenotype/cell-ontology/issues/1943") obo:CL_0000441 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_6656))
 
 # Class: obo:CL_0000442 (follicular dendritic cell)
 
@@ -7360,7 +7360,7 @@ AnnotationAssertion(owl:deprecated obo:CL_0000461 "true"^^xsd:boolean)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1016/S0925-4773(97)00654-0") obo:IAO_0000115 obo:CL_0000462 "A cell of mesodermal origin that is closely associated with the epithelium of an imaginal disc. It is a precursor of some of the insect's adult muscles.")
 AnnotationAssertion(rdfs:label obo:CL_0000462 "adepithelial cell")
 SubClassOf(obo:CL_0000462 obo:CL_0000680)
-SubClassOf(obo:CL_0000462 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_50557))
+SubClassOf(obo:CL_0000462 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_50557))
 
 # Class: obo:CL_0000463 (epidermal cell (sensu Arthropoda))
 
@@ -7368,7 +7368,7 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "FlyBase:ds") Annotation(oboIn
 AnnotationAssertion(rdfs:comment obo:CL_0000463 "While insect epidermis is generally columnar/cuboidal, there are certainly well studied cases where it is not (e.g.- Rhodnius prolixus when starved). So it would be safer to add this as a differentium for particular species where this is known. -DSJ.")
 AnnotationAssertion(rdfs:label obo:CL_0000463 "epidermal cell (sensu Arthropoda)")
 SubClassOf(obo:CL_0000463 obo:CL_0000362)
-SubClassOf(obo:CL_0000463 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_6656))
+SubClassOf(obo:CL_0000463 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_6656))
 SubClassOf(obo:CL_0000463 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000464))
 
 # Class: obo:CL_0000464 (epidermoblast)
@@ -7384,7 +7384,7 @@ SubClassOf(obo:CL_0000464 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000114))
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1007/BF00360522") obo:IAO_0000115 obo:CL_0000465 "A precursor of the cells that form the dorsal vessel of arthropods.")
 AnnotationAssertion(rdfs:label obo:CL_0000465 "cardioblast (sensu Arthropoda)")
 SubClassOf(obo:CL_0000465 obo:CL_0010021)
-SubClassOf(obo:CL_0000465 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_6656))
+SubClassOf(obo:CL_0000465 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_6656))
 
 # Class: obo:CL_0000466 (obo:CL_0000466)
 
@@ -7410,7 +7410,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000468 "neuro-glioblast")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000468 "neuroglioblast")
 AnnotationAssertion(rdfs:label obo:CL_0000468 "neuroglioblast (sensu Nematoda and Protostomia)")
 SubClassOf(obo:CL_0000468 obo:CL_0000047)
-SubClassOf(obo:CL_0000468 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_33317))
+SubClassOf(obo:CL_0000468 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_33317))
 
 # Class: obo:CL_0000469 (ganglion mother cell)
 
@@ -7478,7 +7478,7 @@ AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000477 "ovarian follicle ce
 AnnotationAssertion(rdfs:label obo:CL_0000477 "follicle cell of egg chamber")
 SubClassOf(obo:CL_0000477 obo:CL_0000500)
 SubClassOf(obo:CL_0000477 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0000992))
-SubClassOf(Annotation(oboInOwl:source <https://github.com/obophenotype/cell-ontology/issues/589>) obo:CL_0000477 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_50557))
+SubClassOf(Annotation(oboInOwl:source <https://github.com/obophenotype/cell-ontology/issues/589>) obo:CL_0000477 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_50557))
 SubClassOf(obo:CL_0000477 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000441))
 
 # Class: obo:CL_0000478 (oxytocin stimulating hormone secreting cell)
@@ -7555,7 +7555,7 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:bf") Annotation(oboInOwl:
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:24397521") Annotation(oboInOwl:hasDbXref "PMID:34208190") rdfs:comment obo:CL_0000487 "Oenocytes are highly variable in size, shape, cluster formation and anatomical location. In adults, oenocytes tend to be smaller but more numerous than in larvae. While oenocytes have been found in arachnids and crustaceans, they have been most abundantly described in insects.")
 AnnotationAssertion(rdfs:label obo:CL_0000487 "oenocyte")
 SubClassOf(obo:CL_0000487 obo:CL_0000151)
-SubClassOf(obo:CL_0000487 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_6656))
+SubClassOf(obo:CL_0000487 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_6656))
 
 # Class: obo:CL_0000488 (visible light photoreceptor cell)
 
@@ -7802,7 +7802,7 @@ SubClassOf(obo:CL_0000517 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000235))
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") obo:IAO_0000115 obo:CL_0000518 "A phagocyte in vertebrates that is able to phagocytosis.")
 AnnotationAssertion(rdfs:label obo:CL_0000518 "phagocyte (sensu Vertebrata)")
 SubClassOf(obo:CL_0000518 obo:CL_0000234)
-SubClassOf(obo:CL_0000518 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_7742))
+SubClassOf(obo:CL_0000518 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_7742))
 
 # Class: obo:CL_0000519 (phagocyte (sensu Nematoda and Protostomia))
 
@@ -7821,7 +7821,7 @@ SubClassOf(obo:CL_0000520 obo:CL_0000000)
 # Class: obo:CL_0000521 (fungal cell)
 
 AnnotationAssertion(rdfs:label obo:CL_0000521 "fungal cell")
-EquivalentClasses(obo:CL_0000521 ObjectIntersectionOf(obo:CL_0000000 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_4751)))
+EquivalentClasses(obo:CL_0000521 ObjectIntersectionOf(obo:CL_0000000 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_4751)))
 SubClassOf(obo:CL_0000521 obo:CL_0000255)
 
 # Class: obo:CL_0000522 (obsolete spore)
@@ -7889,7 +7889,7 @@ SubClassOf(obo:CL_0000529 obo:CL_0000710)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:1842357") Annotation(oboInOwl:hasDbXref "doi:10.1242/dev.108.1.121") obo:IAO_0000115 obo:CL_0000530 "A neuron that develops during the early segmentation stages in teleosts, before the neural tube is formed.")
 AnnotationAssertion(rdfs:label obo:CL_0000530 "primary neuron (sensu Teleostei)")
 SubClassOf(obo:CL_0000530 obo:CL_0000540)
-SubClassOf(Annotation(obo:IAO_0000233 "https://github.com/obophenotype/cell-ontology/pull/1950") obo:CL_0000530 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_32443))
+SubClassOf(Annotation(obo:IAO_0000233 "https://github.com/obophenotype/cell-ontology/pull/1950") obo:CL_0000530 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_32443))
 
 # Class: obo:CL_0000531 (primary sensory neuron (sensu Teleostei))
 
@@ -7921,7 +7921,7 @@ SubClassOf(obo:CL_0000534 obo:CL_0000530)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:1842357") Annotation(oboInOwl:hasDbXref "doi:10.1242/dev.108.1.121") obo:IAO_0000115 obo:CL_0000535 "A neuron of teleosts that develops later than a primary neuron, typically during the larval stages.")
 AnnotationAssertion(rdfs:label obo:CL_0000535 "secondary neuron (sensu Teleostei)")
 SubClassOf(obo:CL_0000535 obo:CL_0000540)
-SubClassOf(Annotation(obo:IAO_0000233 "https://github.com/obophenotype/cell-ontology/pull/1950") obo:CL_0000535 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_32443))
+SubClassOf(Annotation(obo:IAO_0000233 "https://github.com/obophenotype/cell-ontology/pull/1950") obo:CL_0000535 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_32443))
 
 # Class: obo:CL_0000536 (secondary motor neuron (sensu Teleostei))
 
@@ -9645,7 +9645,7 @@ SubClassOf(obo:CL_0000721 obo:CL_0000718)
 
 AnnotationAssertion(rdfs:label obo:CL_0000722 "cystoblast")
 SubClassOf(obo:CL_0000722 obo:CL_0000586)
-SubClassOf(obo:CL_0000722 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_6656))
+SubClassOf(obo:CL_0000722 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_6656))
 
 # Class: obo:CL_0000723 (somatic stem cell)
 
@@ -9768,7 +9768,7 @@ AnnotationAssertion(rdfs:label obo:CL_0000738 "leukocyte")
 EquivalentClasses(obo:CL_0000738 ObjectIntersectionOf(obo:CL_0000988 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0002505) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0001667)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000738 obo:CL_0000988)
 SubClassOf(obo:CL_0000738 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0002405))
-SubClassOf(obo:CL_0000738 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_7742))
+SubClassOf(obo:CL_0000738 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_7742))
 SubClassOf(obo:CL_0000738 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000037))
 
 # Class: obo:CL_0000739 (obo:CL_0000739)
@@ -9888,7 +9888,7 @@ SubClassOf(obo:CL_0000751 obo:CL_0000749)
 SubClassOf(obo:CL_0000751 ObjectSomeValuesFrom(obo:RO_0002102 obo:UBERON_0008925))
 SubClassOf(obo:CL_0000751 ObjectSomeValuesFrom(obo:RO_0002102 obo:UBERON_0008926))
 SubClassOf(obo:CL_0000751 ObjectSomeValuesFrom(obo:RO_0002103 obo:CL_0000604))
-SubClassOf(obo:CL_0000751 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_40674))
+SubClassOf(obo:CL_0000751 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_40674))
 
 # Class: obo:CL_0000752 (cone retinal bipolar cell)
 
@@ -13084,7 +13084,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0001046 "memory CCR4-positiv
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0001046 "memory CCR4-positive regulatory T-lymphocyte")
 AnnotationAssertion(rdfs:comment obo:CL_0001046 "This cell type is compatible with the HIPC Lyoplate markers for 'memory CCR4+ Treg'.  The definition is valid for human; its applicability for mouse and other species is unknown.")
 AnnotationAssertion(rdfs:label obo:CL_0001046 "memory CCR4-positive regulatory T cell")
-EquivalentClasses(obo:CL_0001046 ObjectIntersectionOf(obo:CL_0002678 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001017) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001200) ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_9606)))
+EquivalentClasses(obo:CL_0001046 ObjectIntersectionOf(obo:CL_0002678 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001017) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001200) ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_9606)))
 SubClassOf(obo:CL_0001046 obo:CL_0002678)
 
 # Class: obo:CL_0001047 (CD4-positive, CD25-positive, CCR4-positive, alpha-beta regulatory T cell)
@@ -13495,7 +13495,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0001203 "CD8-positive, alpha
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0001203 "CD8-positive, alpha-beta memory T-cell, CD45RO-positive")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0001203 "CD8-positive, alpha-beta memory T-lymphocyte, CD45RO-positive")
 AnnotationAssertion(rdfs:label obo:CL_0001203 "CD8-positive, alpha-beta memory T cell, CD45RO-positive")
-EquivalentClasses(obo:CL_0001203 ObjectIntersectionOf(obo:CL_0000909 ObjectSomeValuesFrom(obo:CL_4030046 obo:PR_000001380) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001017) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001869) ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_9606) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0043379) ObjectSomeValuesFrom(obo:RO_0015015 obo:PR_000001307) ObjectSomeValuesFrom(obo:RO_0015015 obo:PR_000001381)))
+EquivalentClasses(obo:CL_0001203 ObjectIntersectionOf(obo:CL_0000909 ObjectSomeValuesFrom(obo:CL_4030046 obo:PR_000001380) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001017) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001869) ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_9606) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0043379) ObjectSomeValuesFrom(obo:RO_0015015 obo:PR_000001307) ObjectSomeValuesFrom(obo:RO_0015015 obo:PR_000001381)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0001203 obo:CL_0000909)
 SubClassOf(obo:CL_0001203 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000906))
 
@@ -13506,7 +13506,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0001204 "CD4-positive, alpha
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0001204 "CD4-positive, alpha-beta memory T-cell, CD45RO-positive")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0001204 "CD4-positive, alpha-beta memory T-lymphocyte, CD45RO-positive")
 AnnotationAssertion(rdfs:label obo:CL_0001204 "CD4-positive, alpha-beta memory T cell, CD45RO-positive")
-EquivalentClasses(obo:CL_0001204 ObjectIntersectionOf(obo:CL_0000897 ObjectSomeValuesFrom(obo:CL_4030046 obo:PR_000001380) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001017) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001869) ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_9606) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0043379) ObjectSomeValuesFrom(obo:RO_0015015 obo:PR_000001307) ObjectSomeValuesFrom(obo:RO_0015015 obo:PR_000001381)))
+EquivalentClasses(obo:CL_0001204 ObjectIntersectionOf(obo:CL_0000897 ObjectSomeValuesFrom(obo:CL_4030046 obo:PR_000001380) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001017) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001869) ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_9606) ObjectSomeValuesFrom(obo:RO_0002353 obo:GO_0043379) ObjectSomeValuesFrom(obo:RO_0015015 obo:PR_000001307) ObjectSomeValuesFrom(obo:RO_0015015 obo:PR_000001381)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0001204 obo:CL_0000897)
 SubClassOf(obo:CL_0001204 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000896))
 
@@ -19057,7 +19057,7 @@ AnnotationAssertion(oboInOwl:creation_date obo:CL_0002520 "2011-02-08T01:34:56Z"
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0002520 "BTO:0004597")
 AnnotationAssertion(rdfs:label obo:CL_0002520 "nephrocyte")
 SubClassOf(obo:CL_0002520 obo:CL_0002522)
-SubClassOf(obo:CL_0002520 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_50557))
+SubClassOf(obo:CL_0002520 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_50557))
 
 # Class: obo:CL_0002521 (subcutaneous adipocyte)
 
@@ -22533,7 +22533,7 @@ AnnotationAssertion(rdfs:label obo:CL_0008032 "rosehip neuron"@en)
 SubClassOf(obo:CL_0008032 obo:CL_0000099)
 SubClassOf(obo:CL_0008032 ObjectIntersectionOf(ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000005110) ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000007785)))
 SubClassOf(obo:CL_0008032 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0005390))
-SubClassOf(obo:CL_0008032 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_9606))
+SubClassOf(obo:CL_0008032 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_9606))
 SubClassOf(obo:CL_0008032 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534))
 SubClassOf(obo:CL_0008032 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000011467))
 
@@ -30825,7 +30825,7 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref <https://orcid.org/0000-0002-7
 AnnotationAssertion(terms:date obo:CL_4030026 "2022-09-07T12:34:20Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:CL_4030026 "BEST4+ intestinal epithelial cell, human")
 SubClassOf(obo:CL_4030026 obo:CL_0000677)
-SubClassOf(obo:CL_4030026 ObjectSomeValuesFrom(obo:RO_0002160 obo:NCBITaxon_9606))
+SubClassOf(obo:CL_4030026 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_9606))
 SubClassOf(obo:CL_4030026 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_Q8NFU0))
 
 # Class: obo:CL_4030027 (GABAergic amacrine cell)


### PR DESCRIPTION
The `only_in_taxon` relation (RO:0002160) represents, in effect, the same thing as its parent `in_taxon` (RO:0002162) and [is slated for obsoletion](https://github.com/oborel/obo-relations/issues/367). So here, we replace all uses of that relationship by RO:0002162.