### PR TITLE
Fix #2490 make CL:2000062 part_of some `placenta`.

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -28660,7 +28660,7 @@ AnnotationAssertion(oboInOwl:creation_date obo:CL_2000062 "2014-10-07T17:55:56Z"
 AnnotationAssertion(oboInOwl:id obo:CL_2000062 "CL:2000062")
 AnnotationAssertion(rdfs:comment obo:CL_2000062 "http://www.ncbi.nlm.nih.gov/books/NBK53245/")
 AnnotationAssertion(rdfs:label obo:CL_2000062 "placental villus capillary endothelial cell")
-EquivalentClasses(obo:CL_2000062 ObjectIntersectionOf(obo:CL_0002144 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0010005)))
+EquivalentClasses(obo:CL_2000062 ObjectIntersectionOf(obo:CL_0002144 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0001987)))
 
 # Class: obo:CL_2000063 (ovarian fibroblast)
 


### PR DESCRIPTION
The term `placental villus capillary endothelial cell` (CL:2000062) is textually defined as “any capillary endothelial cell that is part of a placenta”, but its logical definition restricts it more specifically to the `placental labyrinth villous`.

But `placental labyrinth villous`, in Uberon, is said not to exist in human (the term is intended to refer to labyrinthine-type placentas, which exist e.g. in rodents but not in human). In effect, this means that CL:2000062 itself, by its logical definition, cannot exist in human.

This was likely not intended (as indicated by the fact CL:2000062 is in fact also explicitly marked as being found in humans).

So here, we amend CL:2000062’s logical definition to align it more closely to its textual definition, by making it part_of some `placenta`.

closes #2490