### PR TITLE
Add an ID range for KGCL-mediated changes.

### DIFF
--- a/src/ontology/cl-idranges.owl
+++ b/src/ontology/cl-idranges.owl
@@ -486,3 +486,9 @@ Datatype: idrange:71
         allocatedto: "Caroline Eastwood"
     EquivalentTo:
         xsd:integer[>4052000, <= 4059999]
+
+Datatype: idrange:72
+    Annotations:
+        allocatedto: "KGCL"
+    EquivalentTo:
+        xsd:integer[>4060000, <= 4069999]


### PR DESCRIPTION
This commit adds a new ID range intended for classes created by Ontobot using the KGCL language.

This will allow editors to command the creation of new classes directly from within a GitHub ticket, without having to explicitly specify the ID of the class to be created:

```
create class AUTOID:1 'my new class'
create edge AUTOID:1 rdfs:subClassOf CL:9999
create exact synonym 'my synonym' for AUTOID:1
```

The ROBOT KGCL plugin would then automatically create the new class using an ID picked from within the "KGCL" range.