### PR TITLE
Cycling stromal cell ID update (multiple with same ID)

### DIFF
--- a/src/patterns/definitions.owl
+++ b/src/patterns/definitions.owl
@@ -45,11 +45,11 @@ Declaration(Class(<http://purl.obolibrary.org/obo/CL_4033079>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CL_4033080>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CL_4033081>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CL_4033082>))
-Declaration(Class(<http://purl.obolibrary.org/obo/CL_4047001>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CL_4047002>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CL_4047003>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CL_4047004>))
 Declaration(Class(<http://purl.obolibrary.org/obo/CL_4047005>))
+Declaration(Class(<http://purl.obolibrary.org/obo/CL_4047010>))
 Declaration(Class(<http://purl.obolibrary.org/obo/GO_0022402>))
 Declaration(Class(<http://purl.obolibrary.org/obo/PATO_0002354>))
 Declaration(ObjectProperty(<http://purl.obolibrary.org/obo/RO_0000056>))
@@ -201,15 +201,6 @@ AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#has
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CL_4033082> "cycling basal cell")
 EquivalentClasses(<http://purl.obolibrary.org/obo/CL_4033082> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/CL_0000646> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000056> <http://purl.obolibrary.org/obo/GO_0022402>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000086> <http://purl.obolibrary.org/obo/PATO_0002354>)))
 
-# Class: <http://purl.obolibrary.org/obo/CL_4047001> (cycling stromal cell)
-
-AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "PMID:34497389") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CL_4047001> "A(n) stromal cell that is cycling.")
-AnnotationAssertion(<http://purl.org/dc/terms/contributor> <http://purl.obolibrary.org/obo/CL_4047001> <https://orcid.org/0009-0005-7919-4905>)
-AnnotationAssertion(<http://purl.org/dc/terms/date> <http://purl.obolibrary.org/obo/CL_4047001> "2024-07-19T09:14:23Z")
-AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "PMID:34497389") <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/CL_4047001> "proliferating stromal cell")
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CL_4047001> "cycling stromal cell")
-EquivalentClasses(<http://purl.obolibrary.org/obo/CL_4047001> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/CL_0000499> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000056> <http://purl.obolibrary.org/obo/GO_0022402>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000086> <http://purl.obolibrary.org/obo/PATO_0002354>)))
-
 # Class: <http://purl.obolibrary.org/obo/CL_4047002> (cycling glial cell)
 
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "PMID:34497389") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CL_4047002> "A(n) glial cell that is cycling.")
@@ -245,6 +236,15 @@ AnnotationAssertion(<http://purl.org/dc/terms/date> <http://purl.obolibrary.org/
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "PMID:34497389") <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/CL_4047005> "proliferating neuroblast (sensu Vertebrata)")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CL_4047005> "cycling neuroblast (sensu Vertebrata)")
 EquivalentClasses(<http://purl.obolibrary.org/obo/CL_4047005> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/CL_0000031> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000056> <http://purl.obolibrary.org/obo/GO_0022402>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000086> <http://purl.obolibrary.org/obo/PATO_0002354>)))
+
+# Class: <http://purl.obolibrary.org/obo/CL_4047010> (cycling stromal cell)
+
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "PMID:34497389") <http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/CL_4047010> "A(n) stromal cell that is cycling.")
+AnnotationAssertion(<http://purl.org/dc/terms/contributor> <http://purl.obolibrary.org/obo/CL_4047010> <https://orcid.org/0009-0005-7919-4905>)
+AnnotationAssertion(<http://purl.org/dc/terms/date> <http://purl.obolibrary.org/obo/CL_4047010> "2024-07-19T09:14:23Z")
+AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "PMID:34497389") <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/CL_4047010> "proliferating stromal cell")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/CL_4047010> "cycling stromal cell")
+EquivalentClasses(<http://purl.obolibrary.org/obo/CL_4047010> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/CL_0000499> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000056> <http://purl.obolibrary.org/obo/GO_0022402>) ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000086> <http://purl.obolibrary.org/obo/PATO_0002354>)))
 
 
 )


### PR DESCRIPTION
Cycling stromal cell and liver resident natural killer cell shared the same ID CL:4047001. Updating on the liver resident NK branch causes incorrect split with definitions and attributes from stromal cell being listed under liver resident NK cell. Created this branch to update cycling stromal cell to CL:4047010 as liver resident NK cell doesnt exist in master yet, will then update liver resident NK cell branch from master which should resolve the conflicts on that branch.