### PR TITLE
Fixes #2429 merge 'epithelial cell of alveolus of lung'

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -3062,9 +3062,9 @@ Declaration(Class(obo:CL_4042017))
 Declaration(Class(obo:CL_4042018))
 Declaration(Class(obo:CL_4042019))
 Declaration(Class(obo:CL_4042020))
+Declaration(Class(obo:CL_4047006))
 Declaration(Class(obo:CL_4052001))
 Declaration(Class(obo:CL_4052002))
-Declaration(Class(obo:CL_4047006))
 Declaration(Class(obo:CP_0000000))
 Declaration(Class(obo:CP_0000025))
 Declaration(Class(obo:CP_0000027))
@@ -4137,7 +4137,7 @@ EquivalentClasses(obo:CL_0000064 ObjectIntersectionOf(obo:CL_0000000 ObjectSomeV
 
 # Class: obo:CL_0000065 (ependymal cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "JB:jb") Annotation(oboInOwl:hasDbXref "PMID:9550134") Annotation(oboInOwl:hasDbXref "doi:/10.3389/fncel.2021.703951") Annotation(oboInOwl:hasDbXref "https://www.britannica.com/science/ependymal-cell") Annotation(oboInOwl:hasDbXref "PMID:34335193") Annotation(oboInOwl:hasDbXref "PMID:37008045") obo:IAO_0000115 obo:CL_0000065 "A neuroepithelial glial cell, derived from a radial glial cell originating from the neuroectoderm, lines the ventricles of the brain and the central canal of the spinal cord. This cell is characterized by the presence of cilia on its apical surface, which can be motile or non-motile.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "JB:jb") Annotation(oboInOwl:hasDbXref "PMID:34335193") Annotation(oboInOwl:hasDbXref "PMID:37008045") Annotation(oboInOwl:hasDbXref "PMID:9550134") Annotation(oboInOwl:hasDbXref "doi:/10.3389/fncel.2021.703951") Annotation(oboInOwl:hasDbXref "https://www.britannica.com/science/ependymal-cell") obo:IAO_0000115 obo:CL_0000065 "A neuroepithelial glial cell, derived from a radial glial cell originating from the neuroectoderm, lines the ventricles of the brain and the central canal of the spinal cord. This cell is characterized by the presence of cilia on its apical surface, which can be motile or non-motile.")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000065 "BTO:0001724")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000065 "FMA:70550")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.53347/rID-51713") oboInOwl:hasNarrowSynonym obo:CL_0000065 "ependymocyte")
@@ -6341,15 +6341,19 @@ AnnotationAssertion(owl:deprecated obo:CL_0000321 "true"^^xsd:boolean)
 # Class: obo:CL_0000322 (pulmonary alveolar epithelial cell)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "PMID:20054144") Annotation(oboInOwl:hasDbXref "PMID:29463737") obo:IAO_0000115 obo:CL_0000322 "An epithelial cell that lines the peripheral gas exchange region of the lungs of air-breathing vertebrates.")
+AnnotationAssertion(terms:contributor obo:CL_0000322 <https://orcid.org/0000-0001-6677-8489>)
+AnnotationAssertion(terms:date obo:CL_0000322 "2024-09-02T08:27:21Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000322 "BTO:0000395")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000322 "CALOHA:TS-2168")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000322 "FMA:62499")
+AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000322 "MESH:D056809")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000322 "alveolar epithelial cell")
+AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000322 "alveolus of lung epithelial cell")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:32491474") oboInOwl:hasExactSynonym obo:CL_0000322 "pneumocyte")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000322 "pneumonocyte")
+AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000322 "epithelial cell of alveolus of lung")
 AnnotationAssertion(rdfs:label obo:CL_0000322 "pulmonary alveolar epithelial cell")
-SubClassOf(obo:CL_0000322 obo:CL_0000066)
-SubClassOf(obo:CL_0000322 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0004821))
+EquivalentClasses(obo:CL_0000322 ObjectIntersectionOf(obo:CL_0000066 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0004821)))
 
 # Class: obo:CL_0000323 (lysozyme secreting cell)
 
@@ -14285,6 +14289,7 @@ AnnotationAssertion(oboInOwl:hasRelatedSynonym obo:CL_0002063 "TII")
 AnnotationAssertion(oboInOwl:hasRelatedSynonym obo:CL_0002063 "lung type II cell")
 AnnotationAssertion(rdfs:label obo:CL_0002063 "pulmonary alveolar type 2 cell")
 EquivalentClasses(obo:CL_0002063 ObjectIntersectionOf(obo:CL_0000322 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0032940) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0043129)))
+SubClassOf(obo:CL_0002063 obo:CL_0000076)
 SubClassOf(obo:CL_0002063 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_4040003))
 
 # Class: obo:CL_0002064 (pancreatic acinar cell)
@@ -23916,15 +23921,17 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0010002 "umbilical artery ep
 AnnotationAssertion(rdfs:label obo:CL_0010002 "epithelial cell of umbilical artery")
 EquivalentClasses(obo:CL_0010002 ObjectIntersectionOf(obo:CL_0000066 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0001310)))
 
-# Class: obo:CL_0010003 (epithelial cell of alveolus of lung)
+# Class: obo:CL_0010003 (obsolete epithelial cell of alveolus of lung)
 
-AnnotationAssertion(obo:IAO_0000115 obo:CL_0010003 "An epithelial cell that is part_of a alveolus of lung.")
+AnnotationAssertion(obo:IAO_0000115 obo:CL_0010003 "OBSOLETE. An epithelial cell that is part_of a alveolus of lung.")
+AnnotationAssertion(obo:IAO_0000233 obo:CL_0010003 <https://github.com/obophenotype/cell-ontology/issues/2429>)
+AnnotationAssertion(obo:IAO_0100001 obo:CL_0010003 obo:CL_0000322)
 AnnotationAssertion(terms:contributor obo:CL_0010003 <https://orcid.org/0000-0002-6601-2165>)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0010003 "MESH:D056809")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0010003 "alveolus of lung epithelial cell")
-AnnotationAssertion(rdfs:comment obo:CL_0010003 "May be merged with pneumocyte in future")
-AnnotationAssertion(rdfs:label obo:CL_0010003 "epithelial cell of alveolus of lung")
-EquivalentClasses(obo:CL_0010003 ObjectIntersectionOf(obo:CL_0000066 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0002299)))
+AnnotationAssertion(rdfs:comment obo:CL_0010003 "This cell type is exactly the same as 'pulmonary alveolar epithelial cell'.")
+AnnotationAssertion(rdfs:label obo:CL_0010003 "obsolete epithelial cell of alveolus of lung")
+AnnotationAssertion(owl:deprecated obo:CL_0010003 "true"^^xsd:boolean)
 
 # Class: obo:CL_0010004 (mononuclear cell of bone marrow)
 
@@ -32314,6 +32321,17 @@ SubClassOf(obo:CL_4042020 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_000625
 SubClassOf(obo:CL_4042020 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000007479))
 SubClassOf(obo:CL_4042020 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000007489))
 
+# Class: obo:CL_4047006 (fetal artery endothelial cell)
+
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:34497389") obo:IAO_0000115 obo:CL_4047006 "An endothelial cell that lines an artery in the fetal circulatory system.")
+AnnotationAssertion(terms:contributor obo:CL_4047006 <https://orcid.org/0009-0005-7919-4905>)
+AnnotationAssertion(terms:date obo:CL_4047006 "2024-08-16T13:52:25Z"^^xsd:dateTime)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:34497389") oboInOwl:hasExactSynonym obo:CL_4047006 "endothelial cell of fetal artery")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:34497389") oboInOwl:hasExactSynonym obo:CL_4047006 "fetal arterial EC")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:34497389") oboInOwl:hasExactSynonym obo:CL_4047006 "fetal artery EC")
+AnnotationAssertion(rdfs:label obo:CL_4047006 "fetal artery endothelial cell")
+SubClassOf(obo:CL_4047006 obo:CL_1000413)
+
 # Class: obo:CL_4052001 (multiciliated ependymal cell)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:25045600") Annotation(oboInOwl:hasDbXref "PMID:28067220") Annotation(oboInOwl:hasDbXref "PMID:37008045") obo:IAO_0000115 obo:CL_4052001 "An ependymal cell that lines the lateral, third, and fourth ventricles of the brain. The cell is characterized by multiple motile cilia on its apical surface, which beats in a coordinated manner to facilitate the movement of cerebrospinal fluid (CSF), contributing to brain homeostasis.")
@@ -32337,17 +32355,6 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "WBbt:0008074") oboInOwl:hasEx
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:9067520") Annotation(oboInOwl:hasSynonymType obo:OMO_0003000) oboInOwl:hasRelatedSynonym obo:CL_4052002 "SC")
 AnnotationAssertion(rdfs:label obo:CL_4052002 "syncytial cell")
 EquivalentClasses(obo:CL_4052002 ObjectIntersectionOf(obo:CL_0000000 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0001908) ObjectSomeValuesFrom(obo:RO_0000056 obo:GO_0000768)))
-
-# Class: obo:CL_4047006 (fetal artery endothelial cell)
-
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:34497389") obo:IAO_0000115 obo:CL_4047006 "An endothelial cell that lines an artery in the fetal circulatory system.")
-AnnotationAssertion(terms:contributor obo:CL_4047006 <https://orcid.org/0009-0005-7919-4905>)
-AnnotationAssertion(terms:date obo:CL_4047006 "2024-08-16T13:52:25Z"^^xsd:dateTime)
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:34497389") oboInOwl:hasExactSynonym obo:CL_4047006 "endothelial cell of fetal artery")
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:34497389") oboInOwl:hasExactSynonym obo:CL_4047006 "fetal arterial EC")
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:34497389") oboInOwl:hasExactSynonym obo:CL_4047006 "fetal artery EC")
-AnnotationAssertion(rdfs:label obo:CL_4047006 "fetal artery endothelial cell")
-SubClassOf(obo:CL_4047006 obo:CL_1000413)
 
 # Class: obo:CP_0000000 (obsolete CP:0000000)
 


### PR DESCRIPTION
Fixes #2429 merge 'epithelial cell of alveolus of lung' into 'pulmonary alveolar epithelial cell'. 
Also adds SubclassOf 'squamous epithelial cell' to 'pulmonary alveolar type 1' cell.
'pulmonary alveolar epithelial cell' is classified as 'squamous epithelial cell' because the alveolar epithelium in uberon is categorized as squamous, although pulmoanry alveolar cells type 2 are not squamous. Getting fixed in https://github.com/obophenotype/uberon/issues/3350