### PR TITLE
Add `def-not-only-xref-violation.sparql`

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -10,7 +10,7 @@
 # More information: https://github.com/INCATools/ontology-development-kit/
 
 # Fingerprint of the configuration file when this Makefile was last generated
-CONFIG_HASH=                b30da9471aba970de63ae9153976cf8ce20f44a23d2dda7923dc04560cd0ae11
+CONFIG_HASH=                5726a8effc41f60465bcbc0d3b62fc006af7e9379ed79932a5b119ca0ad5039f
 
 
 # ----------------------------------------
@@ -44,7 +44,7 @@ REPORT_FAIL_ON =            ERROR
 REPORT_LABEL =              
 REPORT_PROFILE_OPTS =       
 OBO_FORMAT_OPTIONS =        
-SPARQL_VALIDATION_CHECKS =  equivalent-classes owldef-self-reference nolabels pmid-not-dbxref obsolete-replaced_by obsolete-alt-id orcid-contributor illegal-annotation-property label-synonym-polysemy illegal-date 
+SPARQL_VALIDATION_CHECKS =  equivalent-classes owldef-self-reference nolabels pmid-not-dbxref obsolete-replaced_by obsolete-alt-id orcid-contributor illegal-annotation-property label-synonym-polysemy illegal-date def-not-only-xref 
 SPARQL_EXPORTS =            cl_terms cl-edges cl-synonyms cl-xrefs cl-def-xrefs 
 ODK_VERSION_MAKEFILE =      v1.5.2
 

--- a/src/ontology/cl-odk.yaml
+++ b/src/ontology/cl-odk.yaml
@@ -116,6 +116,7 @@ robot_report:
     - illegal-annotation-property
     - label-synonym-polysemy
     - illegal-date
+    - def-not-only-xref
   custom_sparql_exports:
     - cl_terms
     - cl-edges

--- a/src/sparql/def-not-only-xref-violation.sparql
+++ b/src/sparql/def-not-only-xref-violation.sparql
@@ -1,0 +1,18 @@
+PREFIX oio: <http://www.geneontology.org/formats/oboInOwl#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX definition: <http://purl.obolibrary.org/obo/IAO_0000115>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT ?cls ?annotation WHERE 
+{
+  ?cls definition: ?def .
+  ?ax a owl:Axiom;
+    owl:annotatedSource ?cls;
+    owl:annotatedProperty definition:;
+    owl:annotatedTarget ?def;
+    ?annotation ?value .
+    FILTER NOT EXISTS { ?cls owl:deprecated "true"^^xsd:boolean . }
+    FILTER(isIRI(?cls) && STRSTARTS(str(?cls), "http://purl.obolibrary.org/obo/CL_") || STRSTARTS(str(?cls), "http://purl.obolibrary.org/obo/cl#"))
+    FILTER (?annotation NOT IN (rdf:type, owl:annotatedSource, owl:annotatedProperty, owl:annotatedTarget, oio:hasDbXref))
+}


### PR DESCRIPTION
This violation results when a definition has other annotations
than `oio:hasDbXref`. Only `oio:hasDbXref` is allowed in the definition.

Fixes #2523 