### PR TITLE
Relax taxon constraints for some cell types found beyond mammals

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -13505,7 +13505,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0001201 "B-lymphocyte, CD19-
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0001201 "CD19+ B cell")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0001201 "CD19-positive B cell")
 AnnotationAssertion(rdfs:label obo:CL_0001201 "B cell, CD19-positive")
-EquivalentClasses(obo:CL_0001201 ObjectIntersectionOf(obo:CL_0001200 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001002) ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_40674) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0019724)))
+EquivalentClasses(obo:CL_0001201 ObjectIntersectionOf(obo:CL_0001200 ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001002) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0019724)))
 SubClassOf(obo:CL_0001201 obo:CL_0000236)
 
 # Class: obo:CL_0001202 (CD86-positive plasmablast)

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -9911,13 +9911,13 @@ SubClassOf(obo:CL_0000750 obo:CL_0000748)
 # Class: obo:CL_0000751 (rod bipolar cell)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "PMID:14689473") obo:IAO_0000115 obo:CL_0000751 "A bipolar neuron found in the retina that is synapsed by rod photoreceptor cells but not by cone photoreceptor cells.  These neurons depolarize in response to light.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:38627529") obo:RO_0002175 obo:CL_0000751 obo:NCBITaxon_32443)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000751 "FMA:67750")
 AnnotationAssertion(rdfs:label obo:CL_0000751 "rod bipolar cell")
 SubClassOf(obo:CL_0000751 obo:CL_0000749)
 SubClassOf(obo:CL_0000751 ObjectSomeValuesFrom(obo:RO_0002102 obo:UBERON_0008925))
 SubClassOf(obo:CL_0000751 ObjectSomeValuesFrom(obo:RO_0002102 obo:UBERON_0008926))
 SubClassOf(obo:CL_0000751 ObjectSomeValuesFrom(obo:RO_0002103 obo:CL_0000604))
-SubClassOf(obo:CL_0000751 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_40674))
 
 # Class: obo:CL_0000752 (cone retinal bipolar cell)
 


### PR DESCRIPTION
This PR relaxes the taxon constraints for two cell types that were assumed in CL to be specific to mammals, but that are in fact known to exist in teleost fishes:

* `rod bipolar cell`
* `B cell, CD19-positive`

closes #2542