### PR TITLE
gogoeditdiff upload action upgrade

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -79,7 +79,7 @@ jobs:
         run: export ROBOT_JAVA_ARGS=-Xmx6G; robot diff --labels True --left master/src/ontology/cl-edit.owl --left-catalog master/src/ontology/catalog-v001.xml --right branch/src/ontology/cl-edit.owl --right-catalog branch/src/ontology/catalog-v001.xml -f markdown -o edit-diff.md
       - name: Upload diff
         if: steps.check.outputs.triggered == 'true'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: edit-diff.md
           path: edit-diff.md
@@ -106,7 +106,7 @@ jobs:
         run: cd src/ontology; make IMP=FALSE PAT=FALSE MIR=FALSE cl-simple.owl
       - name: Upload PR cl-simple.owl
         if: steps.check.outputs.triggered == 'true'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: cl-simple-pr.owl
           path: src/ontology/cl-simple.owl
@@ -132,7 +132,7 @@ jobs:
         run: cd src/ontology; make IMP=FALSE PAT=FALSE MIR=FALSE cl-simple.owl
       - name: Upload master cl-simple.owl
         if: steps.check.outputs.triggered == 'true'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: cl-simple-master.owl
           path: src/ontology/cl-simple.owl
@@ -167,7 +167,7 @@ jobs:
         run: export ROBOT_JAVA_ARGS=-Xmx6G; cd src/ontology; robot diff --labels True --left cl-simple-master.owl/cl-simple.owl --left-catalog catalog-v001.xml --right cl-simple-pr.owl/cl-simple.owl --right-catalog catalog-v001.xml -f markdown -o classification-diff.md
       - name: Upload diff
         if: steps.check.outputs.triggered == 'true'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: classification-diff.md
           path: src/ontology/classification-diff.md


### PR DESCRIPTION
Upgraded deprecated upload-artifact@v2 to upload-artifact@v4

https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/