### PR TITLE
Fixes #2695 #2468 Re-labelled glandular cell of endometrium and improved classifications 

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -3343,7 +3343,7 @@ AnnotationAssertion(rdfs:label obo:IAO_0000115 "definition")
 
 AnnotationAssertion(rdfs:label obo:IAO_0000424 "expand expression to")
 
-# Annotation Property: obo:IAO_0000700 (has ontology root term)
+# Annotation Property: obo:IAO_0000700 (preferred_root)
 
 AnnotationAssertion(rdfs:label obo:IAO_0000700 "preferred_root")
 
@@ -3437,11 +3437,11 @@ AnnotationAssertion(rdfs:label oboInOwl:hasBroadSynonym "has_broad_synonym")
 
 AnnotationAssertion(rdfs:label oboInOwl:hasDbXref "database_cross_reference")
 
-# Annotation Property: oboInOwl:hasExactSynonym (has exact synonym)
+# Annotation Property: oboInOwl:hasExactSynonym (has_exact_synonym)
 
 AnnotationAssertion(rdfs:label oboInOwl:hasExactSynonym "has_exact_synonym")
 
-# Annotation Property: oboInOwl:hasNarrowSynonym (has narrow synonym)
+# Annotation Property: oboInOwl:hasNarrowSynonym (has_narrow_synonym)
 
 AnnotationAssertion(rdfs:label oboInOwl:hasNarrowSynonym "has_narrow_synonym")
 
@@ -20424,13 +20424,14 @@ AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0002655 "FMA:70732")
 AnnotationAssertion(rdfs:label obo:CL_0002655 "epithelial cell of stratum spinosum of esophageal epithelium")
 SubClassOf(obo:CL_0002655 obo:CL_0002252)
 
-# Class: obo:CL_0002656 (glandular cell of endometrium)
+# Class: obo:CL_0002656 (glandular endometrial unciliated epithelial cell)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "PMID:25023676") obo:IAO_0000115 obo:CL_0002656 "A glandular epithelial cell of the endometrium. Following ovulation, these cells secrete a glycogen-rich substance known as histotroph or uterine milk, which nourishes the embryo if implantation occurs.")
 AnnotationAssertion(terms:contributor obo:CL_0002656 <https://orcid.org/0000-0003-1980-3228>)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002656 "2011-07-08T03:54:08Z"^^xsd:dateTime)
+AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0002656 "glandular cell of endometrium")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0002656 "FMA:86489")
-AnnotationAssertion(rdfs:label obo:CL_0002656 "glandular cell of endometrium")
+AnnotationAssertion(rdfs:label obo:CL_0002656 "glandular endometrial unciliated epithelial cell")
 EquivalentClasses(obo:CL_0002656 ObjectIntersectionOf(obo:CL_0000066 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0002451) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0032940)))
 
 # Class: obo:CL_0002657 (glandular cell of esophagus)
@@ -23624,7 +23625,7 @@ AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0009084 "EFO:0010710")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0009084 "endometrial glandular epithelial cell")
 AnnotationAssertion(oboInOwl:inSubset obo:CL_0009084 pato:location_grouping)
 AnnotationAssertion(rdfs:label obo:CL_0009084 "epithelial cell of endometrial gland")
-EquivalentClasses(obo:CL_0009084 ObjectIntersectionOf(obo:CL_0000066 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0002451)))
+EquivalentClasses(obo:CL_0009084 ObjectIntersectionOf(obo:CL_0000066 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0012276)))
 
 # Class: obo:CL_0009085 (colony forming unit – Hill cell)
 


### PR DESCRIPTION
Fixes #2695 #2468

Related #1760 

- Re-labelled glandular cell of endometrium
- Improved classifications