### PR TITLE
Break down SubClassOf axioms with an intersection as the superclass.

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -4577,7 +4577,8 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "FMA:67287") Annotation(oboInO
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000104 "FMA:67287")
 AnnotationAssertion(oboInOwl:inSubset obo:CL_0000104 cl:BDS_subset)
 AnnotationAssertion(rdfs:label obo:CL_0000104 "multipolar neuron")
-SubClassOf(obo:CL_0000104 ObjectIntersectionOf(obo:CL_0000540 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0070026)))
+SubClassOf(obo:CL_0000104 obo:CL_0000540)
+SubClassOf(obo:CL_0000104 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0070026))
 SubClassOf(obo:CL_0000104 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001017))
 
 # Class: obo:CL_0000105 (pseudounipolar neuron)
@@ -8247,7 +8248,8 @@ SubClassOf(obo:CL_0000554 obo:CL_0000167)
 # Class: obo:CL_0000555 (neuronal brush cell)
 
 AnnotationAssertion(rdfs:label obo:CL_0000555 "neuronal brush cell")
-SubClassOf(obo:CL_0000555 ObjectIntersectionOf(obo:CL_0000540 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001017)))
+SubClassOf(obo:CL_0000555 obo:CL_0000540)
+SubClassOf(obo:CL_0000555 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001017))
 
 # Class: obo:CL_0000556 (megakaryocyte)
 
@@ -18522,7 +18524,8 @@ AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0002453 "MESH:D000073637")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:24133281") Annotation(oboInOwl:hasSynonymType obo:OMO_0003000) oboInOwl:hasRelatedSynonym obo:CL_0002453 "O-2A/OPC")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:11756508") Annotation(oboInOwl:hasSynonymType obo:OMO_0003000) oboInOwl:hasRelatedSynonym obo:CL_0002453 "O2A/OPC")
 AnnotationAssertion(rdfs:label obo:CL_0002453 "oligodendrocyte precursor cell")
-SubClassOf(obo:CL_0002453 ObjectIntersectionOf(obo:CL_0000123 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0001017)))
+SubClassOf(obo:CL_0002453 obo:CL_0000123)
+SubClassOf(obo:CL_0002453 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0001017))
 SubClassOf(obo:CL_0002453 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000339))
 SubClassOf(obo:CL_0002453 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0030154))
 
@@ -22646,10 +22649,11 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1038/s41593-018-0205-2
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1038/s41593-018-0205-2") rdfs:comment obo:CL_0008032 "A rosehip cell has been shown to have an immunohistochemical profile GAD1+CCK+, CNR1–SST–CALB2–PVALB– that matches a single transcriptomically defined cell type whose specific molecular marker signature is not seen in mouse cortex.")
 AnnotationAssertion(rdfs:label obo:CL_0008032 "rosehip neuron"@en)
 SubClassOf(obo:CL_0008032 obo:CL_0000099)
-SubClassOf(obo:CL_0008032 ObjectIntersectionOf(ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000005110) ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000007785)))
 SubClassOf(obo:CL_0008032 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0005390))
 SubClassOf(obo:CL_0008032 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_9606))
 SubClassOf(obo:CL_0008032 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534))
+SubClassOf(obo:CL_0008032 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000005110))
+SubClassOf(obo:CL_0008032 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000007785))
 SubClassOf(obo:CL_0008032 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000011467))
 
 # Class: obo:CL_0008033 (decidual pericyte)
@@ -24162,8 +24166,8 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0011003 "magnocellular neuro
 AnnotationAssertion(rdfs:label obo:CL_0011003 "magnocellular neurosecretory cell")
 SubClassOf(obo:CL_0011003 obo:CL_0000165)
 SubClassOf(obo:CL_0011003 obo:CL_0000540)
-SubClassOf(obo:CL_0011003 ObjectIntersectionOf(obo:CL_0000540 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0046879)))
 SubClassOf(obo:CL_0011003 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001898))
+SubClassOf(obo:CL_0011003 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0046879))
 
 # Class: obo:CL_0011004 (lens fiber cell)
 
@@ -32405,7 +32409,12 @@ AnnotationAssertion(terms:date obo:CL_4042013 "2024-04-23T09:37:55Z"^^xsd:dateTi
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:36007006") oboInOwl:hasExactSynonym obo:CL_4042013 "Ivy cell")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30382198") oboInOwl:hasExactSynonym obo:CL_4042013 "Lamp5-Lhx6 type")
 AnnotationAssertion(rdfs:label obo:CL_4042013 "Lamp5 Lhx6 neuron"@en)
-SubClassOf(obo:CL_4042013 ObjectIntersectionOf(obo:CL_4023011 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000956) ObjectSomeValuesFrom(obo:RO_0002202 obo:UBERON_0004026) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534) ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000032148) ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000032533)))
+SubClassOf(obo:CL_4042013 obo:CL_4023011)
+SubClassOf(obo:CL_4042013 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000956))
+SubClassOf(obo:CL_4042013 ObjectSomeValuesFrom(obo:RO_0002202 obo:UBERON_0004026))
+SubClassOf(obo:CL_4042013 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534))
+SubClassOf(obo:CL_4042013 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000032148))
+SubClassOf(obo:CL_4042013 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000032533))
 
 # Class: obo:CL_4042014 (spiny VIP neuron)
 
@@ -32429,7 +32438,8 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:32027647") Annotation(ob
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:33301603") oboInOwl:hasRelatedSynonym obo:CL_4042015 "VIP+/ChAT+ cell")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:30382198") Annotation(oboInOwl:hasDbXref "PMID:32027647") Annotation(oboInOwl:hasDbXref "PMID:33301603") rdfs:comment obo:CL_4042015 "Work in the mouse barrel cortex and somatosensory cortex shows that a VIP-ChAT interneuron is predominantely located in L2/3 and more rarely in the deeper layers of the cortex (Dudai et al., 2021; Dudai et al., 2020). This neuronal type could be transcriptomically distinct as transcriptomic studies have identified VIP neurons expressing ChAT in a whole brain mouse transcriptomic study (Tasic et al., 2018).")
 AnnotationAssertion(rdfs:label obo:CL_4042015 "VIP-ChAT interneuron"@en)
-SubClassOf(obo:CL_4042015 ObjectIntersectionOf(obo:CL_4023016 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0014055)))
+SubClassOf(obo:CL_4042015 obo:CL_4023016)
+SubClassOf(obo:CL_4042015 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0014055))
 
 # Class: obo:CL_4042016 (nasal serous secreting cell)
 


### PR DESCRIPTION
We have a handful of classes that are at least partially defined with SubClassOf axioms where the superclass is an object intersection, as in the following example:

>  CL:0000104 **SubClassOf:** CL:0000540 _and_ (RO:0000053 _some_ PATO:0070026)

This is logically equivalent to individual SubClassOf axioms for each member of the intersection:

>  CL:0000104 **SubClassOf:** CL:0000540
>  CL:0000104 **SubClassOf:** RO:0000053 _some_ PATO:0070026

but the first form may not always be handled correctly and is therefore best avoided. In particular, the OboGraphs JSON converter does not know how to handle those axioms, and simply drops them, resulting in those classifications being absent from the JSON artifacts.

So here, we replace known cases of SubClassOf axioms where the superclass is an object intersection (7 found) by equivalent individual SubClassOf axioms.

closes #2692