### PR TITLE
Fixes #2704 - Revise classification of intestinal crypt stem cell of large intestine and subclasses 

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -23232,11 +23232,11 @@ EquivalentClasses(obo:CL_0009042 ObjectIntersectionOf(obo:CL_0000164 ObjectSomeV
 
 # Class: obo:CL_0009043 (intestinal crypt stem cell of colon)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "http://orcid.org/0000-0003-3440-1876") obo:IAO_0000115 obo:CL_0009043 "An intestinal crypt stem cell that is located in the colon.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "http://orcid.org/0000-0003-3440-1876") Annotation(oboInOwl:hasDbXref "PMID:10841502") obo:IAO_0000115 obo:CL_0009043 "An intestinal crypt stem cell that is located in the crypt of Lieberkuhn of colon.")
 AnnotationAssertion(terms:contributor obo:CL_0009043 <https://orcid.org/0000-0002-2825-0621>)
 AnnotationAssertion(oboInOwl:inSubset obo:CL_0009043 pato:location_grouping)
 AnnotationAssertion(rdfs:label obo:CL_0009043 "intestinal crypt stem cell of colon")
-EquivalentClasses(obo:CL_0009043 ObjectIntersectionOf(obo:CL_0002250 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0001155)))
+EquivalentClasses(obo:CL_0009043 ObjectIntersectionOf(obo:CL_0002250 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0013485)))
 
 # Class: obo:CL_0009044 (lymphocyte of small intestine lamina propria)
 
@@ -23411,7 +23411,7 @@ AnnotationAssertion(terms:contributor obo:CL_0009061 <https://orcid.org/0000-000
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0009061 "anorectum intestinal crypt stem cell")
 AnnotationAssertion(oboInOwl:inSubset obo:CL_0009061 pato:location_grouping)
 AnnotationAssertion(rdfs:label obo:CL_0009061 "intestinal crypt stem cell of anorectum")
-EquivalentClasses(obo:CL_0009061 ObjectIntersectionOf(obo:CL_0002250 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_8410050)))
+EquivalentClasses(obo:CL_0009061 ObjectIntersectionOf(obo:CL_0009016 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_8410050)))
 
 # Class: obo:CL_0009062 (germinal center T cell)
 


### PR DESCRIPTION
Fixes #2704

- Added intestinal crypt stem cell of colon and intestinal crypt stem cell of anorectum under the grouping term intestinal crypt stem cell of large intestine