### PR TITLE
Compute diff on -base rather than -simple.

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -53,7 +53,7 @@ jobs:
     needs: [branch_status]
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5
+    container: obolibrary/odkfull:v1.5.3
     steps:
       - uses: khan/pull-request-comment-trigger@v1.1.0
         id: check
@@ -87,7 +87,7 @@ jobs:
     needs: [branch_status]
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5
+    container: obolibrary/odkfull:v1.5.3
     steps:
       - uses: khan/pull-request-comment-trigger@v1.1.0
         id: check
@@ -103,19 +103,19 @@ jobs:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
       - name: Classify ontology
         if: steps.check.outputs.triggered == 'true'
-        run: cd src/ontology; make IMP=FALSE PAT=FALSE MIR=FALSE cl-simple.owl
-      - name: Upload PR cl-simple.owl
+        run: cd src/ontology; make IMP=FALSE PAT=FALSE MIR=FALSE cl-base.owl
+      - name: Upload PR cl-base.owl
         if: steps.check.outputs.triggered == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: cl-simple-pr.owl
-          path: src/ontology/cl-simple.owl
+          name: cl-base-pr.owl
+          path: src/ontology/cl-base.owl
           retention-days: 1
   classify_main:
     needs: [branch_status]
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5
+    container: obolibrary/odkfull:v1.5.3
     steps:
       - uses: khan/pull-request-comment-trigger@v1.1.0
         id: check
@@ -129,18 +129,18 @@ jobs:
           ref: master
       - name: Classify ontology
         if: steps.check.outputs.triggered == 'true'
-        run: cd src/ontology; make IMP=FALSE PAT=FALSE MIR=FALSE cl-simple.owl
-      - name: Upload master cl-simple.owl
+        run: cd src/ontology; make IMP=FALSE PAT=FALSE MIR=FALSE cl-base.owl
+      - name: Upload master cl-base.owl
         if: steps.check.outputs.triggered == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: cl-simple-master.owl
-          path: src/ontology/cl-simple.owl
+          name: cl-base-master.owl
+          path: src/ontology/cl-base.owl
           retention-days: 1
   diff_classification:
     needs:  [classify_branch, classify_main]
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5
+    container: obolibrary/odkfull:v1.5.3
     steps:
       - uses: khan/pull-request-comment-trigger@v1.1.0
         id: check
@@ -154,17 +154,17 @@ jobs:
         if: steps.check.outputs.triggered == 'true'
         uses: actions/download-artifact@v4
         with:
-          name: cl-simple-master.owl
-          path: src/ontology/cl-simple-master.owl
+          name: cl-base-master.owl
+          path: src/ontology/cl-base-master.owl
       - name: Download PR classification
         if: steps.check.outputs.triggered == 'true'
         uses: actions/download-artifact@v4
         with:
-          name: cl-simple-pr.owl
-          path: src/ontology/cl-simple-pr.owl
+          name: cl-base-pr.owl
+          path: src/ontology/cl-base-pr.owl
       - name: Diff classification
         if: steps.check.outputs.triggered == 'true'
-        run: export ROBOT_JAVA_ARGS=-Xmx6G; cd src/ontology; robot diff --labels True --left cl-simple-master.owl/cl-simple.owl --left-catalog catalog-v001.xml --right cl-simple-pr.owl/cl-simple.owl --right-catalog catalog-v001.xml -f markdown -o classification-diff.md
+        run: export ROBOT_JAVA_ARGS=-Xmx6G; cd src/ontology; robot diff --labels True --left cl-base-master.owl/cl-base.owl --left-catalog catalog-v001.xml --right cl-base-pr.owl/cl-base.owl --right-catalog catalog-v001.xml -f markdown -o classification-diff.md
       - name: Upload diff
         if: steps.check.outputs.triggered == 'true'
         uses: actions/upload-artifact@v4
@@ -191,7 +191,7 @@ jobs:
           path: classification-diff.md
       - name: Prepare reasoned comment
         if: steps.check.outputs.triggered == 'true'
-        run: "echo \"<details>\n <summary> Here's a diff of how these changes impact the classified ontology (on -simple file): </summary> \n\" >comment.md; cat classification-diff.md/classification-diff.md >>comment.md"
+        run: "echo \"<details>\n <summary> Here's a diff of how these changes impact the classified ontology (on -base file): </summary> \n\" >comment.md; cat classification-diff.md/classification-diff.md >>comment.md"
       - name: Post reasoned comment
         if: steps.check.outputs.triggered == 'true'
         env:


### PR DESCRIPTION
When computing the automated diff on pull requests, for the "classification diff" (diff on the classified ontology), we use the cl-base.owl product rather than the cl-simple.owl product.

Until now, we were using -simple as it was the only product that was (1) reasoned over and (2) stripped of all "foreign" classes.

Since ODK 1.5, cl-base also fits those criteria, and it is in fact more sensible to run the diff on that product since it is intended to be the main product that other ontologies are supposed to be importing.

We also bump the ODK version that is being used to compute the diffs.

closes #1737