### PR TITLE
Remove hasAlternativeID for FMA:83808.

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -3335,7 +3335,6 @@ Declaration(AnnotationProperty(oboInOwl:SubsetProperty))
 Declaration(AnnotationProperty(oboInOwl:SynonymTypeProperty))
 Declaration(AnnotationProperty(oboInOwl:consider))
 Declaration(AnnotationProperty(oboInOwl:creation_date))
-Declaration(AnnotationProperty(oboInOwl:hasAlternativeId))
 Declaration(AnnotationProperty(oboInOwl:hasBroadSynonym))
 Declaration(AnnotationProperty(oboInOwl:hasDbXref))
 Declaration(AnnotationProperty(oboInOwl:hasExactSynonym))
@@ -3447,10 +3446,6 @@ AnnotationAssertion(rdfs:label oboInOwl:SynonymTypeProperty "synonym_type_proper
 # Annotation Property: oboInOwl:consider (consider)
 
 AnnotationAssertion(rdfs:label oboInOwl:consider "consider")
-
-# Annotation Property: oboInOwl:hasAlternativeId (has_alternative_id)
-
-AnnotationAssertion(rdfs:label oboInOwl:hasAlternativeId "has_alternative_id")
 
 # Annotation Property: oboInOwl:hasBroadSynonym (has_broad_synonym)
 
@@ -9968,7 +9963,6 @@ SubClassOf(obo:CL_0000745 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0003902
 # Class: obo:CL_0000746 (cardiac muscle cell)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:mtg_cardiacconduct_nov11") Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "ISBN:0323052908") Annotation(oboInOwl:hasDbXref "PMID:22426062") Annotation(oboInOwl:hasDbXref "PMID:4711263") obo:IAO_0000115 obo:CL_0000746 "Cardiac muscle cells are striated muscle cells that are responsible for heart contraction. In mammals, the contractile fiber resembles those of skeletal muscle but are only one third as large in diameter, are richer in sarcoplasm, and contain centrally located instead of peripheral nuclei.")
-AnnotationAssertion(oboInOwl:hasAlternativeId obo:CL_0000746 "FMA:83808")
 AnnotationAssertion(oboInOwl:hasBroadSynonym obo:CL_0000746 "cardiocyte")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000746 "BTO:0001539")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000746 "CALOHA:TS-0115")


### PR DESCRIPTION
CL term 'cardiac muscle cell' (CL:0000746) carries a `oboInOwl:hasAlternativeId` annotation to FMA:83808.

In effect, because of the way the `oboInOwl:hasAlternativeId` annotation is interpreted, this means that CL is declaring that FMA:83808 is deprecated in favour of CL:0000746, and is therefore akin to an axiom injection from CL into FMA.

Issue #1857 is asking that all `oboInOwl:hasAlternativeId` annotations be converted into the modern way of representing deprecation replacement (by a combination of `owl:deprecated` and `IAO:0100001` annotations). But in this instance (which is the last instance of oboInOwl:hasAlternativeId in CL), because the (supposedly) deprecated term is in FMA, it is up to FMA to act. On the CL side, the correct thing to do is simply to remove the annotation, which is what we do here.

closes #1857