### PR TITLE
Add ID format check

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -10,7 +10,7 @@
 # More information: https://github.com/INCATools/ontology-development-kit/
 
 # Fingerprint of the configuration file when this Makefile was last generated
-CONFIG_HASH=                54146b660b46ab72c0abd98ae67a46d194ff618c90da889ded7ed1b99fd74ae2
+CONFIG_HASH=                f7d9e8d156ea19124c47084171b68728b3f6cf2fddba07984f7985402bfc2b36
 
 
 # ----------------------------------------
@@ -44,7 +44,7 @@ REPORT_FAIL_ON =            ERROR
 REPORT_LABEL =              
 REPORT_PROFILE_OPTS =       
 OBO_FORMAT_OPTIONS =        
-SPARQL_VALIDATION_CHECKS =  equivalent-classes owldef-self-reference nolabels pmid-not-dbxref obsolete-replaced_by obsolete-alt-id orcid-contributor illegal-annotation-property label-synonym-polysemy illegal-date def-not-only-xref 
+SPARQL_VALIDATION_CHECKS =  equivalent-classes owldef-self-reference nolabels pmid-not-dbxref obsolete-replaced_by obsolete-alt-id orcid-contributor illegal-annotation-property label-synonym-polysemy illegal-date def-not-only-xref id-format 
 SPARQL_EXPORTS =            cl_terms cl-edges cl-synonyms cl-xrefs cl-def-xrefs 
 ODK_VERSION_MAKEFILE =      v1.5.3
 

--- a/src/ontology/cl-odk.yaml
+++ b/src/ontology/cl-odk.yaml
@@ -119,6 +119,7 @@ robot_report:
     - label-synonym-polysemy
     - illegal-date
     - def-not-only-xref
+    - id-format
   custom_sparql_exports:
     - cl_terms
     - cl-edges

--- a/src/sparql/id-format-violation.sparql
+++ b/src/sparql/id-format-violation.sparql
@@ -1,0 +1,10 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+SELECT ?cls WHERE {
+	?cls a owl:Class .
+	FILTER (strstarts(str(?cls), "http://purl.obolibrary.org/obo/CL_") &&
+	        ! regex(str(?cls), "^http://purl.obolibrary.org/obo/CL_[0-9]{7}$"))
+	FILTER NOT EXISTS { ?cls owl:deprecated ?v }
+}


### PR DESCRIPTION
This PR imports for CL the same “ID format check” already used in Uberon, to ensure that CL IDs follow the expected format `http://purl.obolibrary.org/obo/CL_[0-9]{7}`.

This is a partial fix to #763, though it does not fully implement what was requested there. The requested check was to ensure that no class could be added with an ID in a namespace other than the CL namespace -- something that is actually tricky to check because of the imported classes.

Here, we are simply checking that, _if_ a class is in the CL namespace, it follows the expected format. That is, the check would catch a bogus ID like `http://purl.obolibrary.org/obo/CL_12345678` (8 digits instead of 7), but _not_ an ID like `http://purl.obolibrary.org/obo/NOTCL_1234567` (not in the CL namespace).