### PR TITLE
Update foreign SSSOM set from ontology

### DIFF
--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -19,7 +19,7 @@ jobs:
   ontology_qc:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5.2
+    container: obolibrary/odkfull:v1.5.3
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/src/ontology/catalog-v001.xml
+++ b/src/ontology/catalog-v001.xml
@@ -22,5 +22,5 @@
     <uri name="http://purl.obolibrary.org/obo/cl/components/general_cell_types_upper_slim.owl" uri="components/general_cell_types_upper_slim.owl"/>
     <uri name="http://purl.obolibrary.org/obo/cl/components/kidney_upper_slim.owl" uri="components/kidney_upper_slim.owl"/>
     <uri name="http://purl.obolibrary.org/obo/cl/components/cellxgene_subset.owl" uri="components/cellxgene_subset.owl"/>
-    <group id="Folder Repository, directory=, recursive=false, Auto-Update=false, version=2" prefer="public" xml:base=""/>
+    <group id="Folder Repository, directory=, recursive=false, Auto-Update=false, version=2" prefer="public"/>
 </catalog>


### PR DESCRIPTION
This PR amends the rules that refresh the externally maintained SSSOM mapping sets (the sets from FBbt and ZFA) to include a step that check those sets against the current version of the ontology to

(1) remove any mapping to a Uberon entity that does not exist or is deprecated;
(2) add any missing label, using the labels found in the ontology.

This necessitates, as a preliminary:

(1) making sure we are using ODK 1.5.3, as previous versions do not include a recent enough version of SSSOM-Java;
(2) removing a bogus empty xml:base attribute in the XML catalog, that prevents sssom-cli from reading it.