### PR TITLE
Fixes #2818 NTR GABA-Gly AC

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -3045,6 +3045,7 @@ Declaration(Class(obo:CL_4033087))
 Declaration(Class(obo:CL_4033088))
 Declaration(Class(obo:CL_4033089))
 Declaration(Class(obo:CL_4033090))
+Declaration(Class(obo:CL_4033091))
 Declaration(Class(obo:CL_4040000))
 Declaration(Class(obo:CL_4040001))
 Declaration(Class(obo:CL_4040002))
@@ -32337,6 +32338,15 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:15353131") oboInOwl:hasR
 AnnotationAssertion(rdfs:label obo:CL_4033090 "atretic granulosa cell")
 SubClassOf(obo:CL_4033090 obo:CL_4033089)
 SubClassOf(obo:CL_4033090 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000501))
+
+# Class: obo:CL_4033091 (glycinergic-GABAergic amacrine cell)
+
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:37124720") obo:IAO_0000115 obo:CL_4033091 "An amacrine cell that uses both GABA and glycine as neurotransmitters.")
+AnnotationAssertion(terms:contributor obo:CL_4033091 <https://orcid.org/0000-0001-6677-8489>)
+AnnotationAssertion(terms:date obo:CL_4033091 "2024-12-02T13:44:17Z"^^xsd:dateTime)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:37124720") oboInOwl:hasExactSynonym obo:CL_4033091 "glycinergic/GABAergic amacrine neuron")
+AnnotationAssertion(rdfs:label obo:CL_4033091 "glycinergic-GABAergic amacrine cell")
+EquivalentClasses(obo:CL_4033091 ObjectIntersectionOf(obo:CL_0000561 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061537)))
 
 # Class: obo:CL_4040000 (glial restricted tripotential precursor cell)
 


### PR DESCRIPTION
Fixes #2818 NTR GABA-Gly AC
reason for label decision:
To follow the amacrine cell pattern, it uses amacrince cell and not amacrine neuron.
CL doesn't use '/' in the labels, so a substituted with a hyphen.