### PR TITLE
Add ID range for the NDI Cloud project.

### DIFF
--- a/src/ontology/cl-idranges.owl
+++ b/src/ontology/cl-idranges.owl
@@ -492,3 +492,9 @@ Datatype: idrange:72
         allocatedto: "KGCL"
     EquivalentTo:
         xsd:integer[>4060000, <= 4069999]
+
+Datatype: idrange:73
+    Annotations:
+        allocatedto: "NDI Cloud"
+    EquivalentTo:
+        xsd:integer[>4070000, <= 4071999]


### PR DESCRIPTION
Assign the ID range 4,070,001--4,071,999 to members of the NDI Cloud project, so that they can participate in creating the terms they need to cover some aspects of arthropod neuroanatomy.

As discussed in Uberon/CL call of 2024-11-18.

closes #2858