### PR TITLE
dogiel type I mesenteric neuron

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -33186,6 +33186,7 @@ AnnotationAssertion(terms:contributor obo:CL_4047038 <https://orcid.org/0009-000
 AnnotationAssertion(terms:date obo:CL_4047038 "2024-12-16T13:42:04Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:CL_4047038 "dogiel type I neuron")
 SubClassOf(obo:CL_4047038 obo:CL_0000104)
+SubClassOf(obo:CL_4047038 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0002439))
 
 # Class: obo:CL_4047040 (smooth muscle circular layer cell)
 


### PR DESCRIPTION
Dogiel type I neuron

A multipolar neuron in the myenteric plexus of the gastrointestinal tract, characterized by a small to medium-sized cell bodyband multiple short dendrites. This cell functions as motor neurons or interneurons, often containing choline acetyltransferase and other neurotransmitters. This neuron exhibits fast excitatory postsynaptic potentials and can be classified into stubby and spiny subtypes based on dendritic morphology.
doi.org/10.1038/s41575-020-0271-2
 https://doi.org/10.1038/s41575-021-00561-y


PMID: [32152479](https://pubmed.ncbi.nlm.nih.gov/32152479/)
PMID: [34170401](https://pubmed.ncbi.nlm.nih.gov/34170401/)


Part of UBERON:0002439 myenteric nerve plexus

Parent term: multipolar neuron