### PR TITLE
Fixes 2869 wrongly obsoleted 'CNS interneuron'

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -449,6 +449,7 @@ Declaration(Class(obo:CL_0000398))
 Declaration(Class(obo:CL_0000399))
 Declaration(Class(obo:CL_0000400))
 Declaration(Class(obo:CL_0000401))
+Declaration(Class(obo:CL_0000402))
 Declaration(Class(obo:CL_0000403))
 Declaration(Class(obo:CL_0000404))
 Declaration(Class(obo:CL_0000405))
@@ -7036,6 +7037,14 @@ AnnotationAssertion(obo:IAO_0100001 obo:CL_0000401 obo:CL_0000394)
 AnnotationAssertion(rdfs:comment obo:CL_0000401 "Obsoleted as plasmatocytes are the macrophages (phagocytic cells) of Diptera.")
 AnnotationAssertion(rdfs:label obo:CL_0000401 "obsolete macrophage (sensu Diptera)")
 AnnotationAssertion(owl:deprecated obo:CL_0000401 "true"^^xsd:boolean)
+
+# Class: obo:CL_0000402 (obsolete CNS interneuron)
+
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1016/B978-0-12-817424-1.00001-X") obo:IAO_0000115 obo:CL_0000402 "OBSOLETE. An interneuron that has its cell body in a central nervous system.")
+AnnotationAssertion(obo:IAO_0000233 obo:CL_0000402 <https://github.com/obophenotype/cell-ontology/issues/2869>)
+AnnotationAssertion(obo:IAO_0100001 obo:CL_0000402 obo:CL_0000099)
+AnnotationAssertion(rdfs:comment obo:CL_0000402 "Interneurons are commonly described as being only found in the central nervous system. However, in CL we define 'interneuron' more broadly as any neuron that is neither a motor neuron nor a sensory neuron, regardless of its location, so we need this term to refer strictly to interneurons of the central nervous system.")
+AnnotationAssertion(rdfs:label obo:CL_0000402 "obsolete CNS interneuron")
 
 # Class: obo:CL_0000403 (obo:CL_0000403)
 

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -7045,6 +7045,7 @@ AnnotationAssertion(obo:IAO_0000233 obo:CL_0000402 <https://github.com/obophenot
 AnnotationAssertion(obo:IAO_0100001 obo:CL_0000402 obo:CL_0000099)
 AnnotationAssertion(rdfs:comment obo:CL_0000402 "Interneurons are commonly described as being only found in the central nervous system. However, in CL we define 'interneuron' more broadly as any neuron that is neither a motor neuron nor a sensory neuron, regardless of its location, so we need this term to refer strictly to interneurons of the central nervous system.")
 AnnotationAssertion(rdfs:label obo:CL_0000402 "obsolete CNS interneuron")
+AnnotationAssertion(owl:deprecated obo:CL_0000402 "true"^^xsd:boolean)
 
 # Class: obo:CL_0000403 (obo:CL_0000403)
 

--- a/src/ontology/components/hra_subset.owl
+++ b/src/ontology/components/hra_subset.owl
@@ -23,12 +23,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/IAO_0100001 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0100001"/>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/RO_0002175 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002175"/>
@@ -559,11 +553,8 @@
     <!-- http://purl.obolibrary.org/obo/CL_0000402 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0000402">
-        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/CL_0000099"/>
         <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#human_reference_atlas"/>
-        <rdfs:comment>https://github.com/obophenotype/cell-ontology/pull/2686</rdfs:comment>
-        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
     </owl:Class>
     
 
@@ -1057,15 +1048,6 @@
     <!-- http://purl.obolibrary.org/obo/CL_0000750 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0000750">
-        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#human_reference_atlas"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CL_0000751 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0000751">
         <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#human_reference_atlas"/>
     </owl:Class>
@@ -2422,42 +2404,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/CL_0004219 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0004219">
-        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#human_reference_atlas"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CL_0004232 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0004232">
-        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#human_reference_atlas"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CL_0004252 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0004252">
-        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#human_reference_atlas"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CL_0004253 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0004253">
-        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#human_reference_atlas"/>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/CL_0005006 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0005006">
@@ -2866,15 +2812,6 @@
     <!-- http://purl.obolibrary.org/obo/CL_0011004 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0011004">
-        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#human_reference_atlas"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CL_0011005 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_0011005">
         <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#human_reference_atlas"/>
     </owl:Class>
@@ -3703,7 +3640,7 @@
     <!-- http://purl.obolibrary.org/obo/CL_2000054 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_2000054">
-        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10066"/>
+        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#human_reference_atlas"/>
     </owl:Class>
     
@@ -4123,15 +4060,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/CL_4030028 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_4030028">
-        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#human_reference_atlas"/>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/CL_4030032 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_4030032">
@@ -4249,15 +4177,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/CL_4033019 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_4033019">
-        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#human_reference_atlas"/>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/CL_4033020 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_4033020">
@@ -4315,78 +4234,6 @@
     <!-- http://purl.obolibrary.org/obo/CL_4033026 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_4033026">
-        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#human_reference_atlas"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CL_4033027 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_4033027">
-        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#human_reference_atlas"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CL_4033028 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_4033028">
-        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#human_reference_atlas"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CL_4033029 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_4033029">
-        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#human_reference_atlas"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CL_4033030 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_4033030">
-        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#human_reference_atlas"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CL_4033031 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_4033031">
-        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#human_reference_atlas"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CL_4033032 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_4033032">
-        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#human_reference_atlas"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CL_4033033 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_4033033">
-        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
-        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#human_reference_atlas"/>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/CL_4033034 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_4033034">
         <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#human_reference_atlas"/>
     </owl:Class>
@@ -4465,6 +4312,15 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/CL_4033050 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_4033050">
+        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#human_reference_atlas"/>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/CL_4033055 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_4033055">
@@ -4507,9 +4363,18 @@
         <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
         <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#human_reference_atlas"/>
     </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CL_4033077 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_4033077">
+        <obo:RO_0002175 rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_9606"/>
+        <oboInOwl:inSubset rdf:resource="http://purl.obolibrary.org/obo/uberon/core#human_reference_atlas"/>
+    </owl:Class>
 </rdf:RDF>
 
 
 
-<!-- Generated by the OWL API (version 4.5.26.2023-07-17T20:34:13Z) https://github.com/owlcs/owlapi -->
+<!-- Generated by the OWL API (version 4.5.29) https://github.com/owlcs/owlapi -->
 


### PR DESCRIPTION
Fixes #2869 'CNS interneuron' was deleted instead of obsoleted.