### PR TITLE
Fix the ID range allocated to Whitney Leach.

### DIFF
--- a/src/ontology/cl-idranges.owl
+++ b/src/ontology/cl-idranges.owl
@@ -383,7 +383,7 @@ Datatype: idrange:55
     Annotations:
         allocatedto: "Whitney Leach"
     EquivalentTo:
-        xsd:integer[>4018500 , <= 4018499]
+        xsd:integer[>4018500 , <= 4018999]
 
 Datatype: idrange:56
     Annotations:


### PR DESCRIPTION
From the very beginning (commit 50200dd), Whitney Leach has been assigned the bogus ID range (4,018,500..4,018,499] -- note how the upper boundary is _lower_ than the lower boundary.

The intention was probably to assign the range (4,018,500..4,018,999], which is what we do here.

Given that nobody (not even Whitney Leach) has complained about this invalid range for more than 4 years, it is likely that the range is not actually needed, but even if it is unused, a bogus range will prevent the file from being used by tools that actually _validates_ the contents of an ID range policy file.