### PR TITLE
Fixes #2892 NTR diffuse bipolar 4a and 4b cells

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -3049,6 +3049,8 @@ Declaration(Class(obo:CL_4033091))
 Declaration(Class(obo:CL_4033092))
 Declaration(Class(obo:CL_4033093))
 Declaration(Class(obo:CL_4033094))
+Declaration(Class(obo:CL_4033095))
+Declaration(Class(obo:CL_4033096))
 Declaration(Class(obo:CL_4040000))
 Declaration(Class(obo:CL_4040001))
 Declaration(Class(obo:CL_4040002))
@@ -32426,6 +32428,26 @@ AnnotationAssertion(terms:date obo:CL_4033094 "2025-01-08T14:44:57Z"^^xsd:dateTi
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:35798993") Annotation(oboInOwl:hasSynonymType obo:OMO_0003000) oboInOwl:hasRelatedSynonym obo:CL_4033094 "ABC")
 AnnotationAssertion(rdfs:label obo:CL_4033094 "age-associated B cell")
 SubClassOf(obo:CL_4033094 obo:CL_0000787)
+
+# Class: obo:CL_4033095 (diffuse bipolar 4a cell)
+
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:31995762") Annotation(oboInOwl:hasDbXref "doi:10.1101/2023.11.07.566105") obo:IAO_0000115 obo:CL_4033095 "An ON bipolar cell that has high expression of DIRC3, KCNJ3, LINC01915, PTPRK compared with other bipolar cells.")
+AnnotationAssertion(terms:contributor obo:CL_4033095 <https://orcid.org/0000-0001-6677-8489>)
+AnnotationAssertion(terms:date obo:CL_4033095 "2025-01-14T13:48:42Z"^^xsd:dateTime)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1101/2023.11.07.566105") Annotation(oboInOwl:hasSynonymType obo:OMO_0003000) oboInOwl:hasRelatedSynonym obo:CL_4033095 "DB4a")
+AnnotationAssertion(rdfs:label obo:CL_4033095 "diffuse bipolar 4a cell")
+SubClassOf(obo:CL_4033095 obo:CL_0000749)
+SubClassOf(obo:CL_4033095 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_9606))
+
+# Class: obo:CL_4033096 (diffuse bipolar 4b cell)
+
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:31995762") Annotation(oboInOwl:hasDbXref "doi:10.1101/2023.11.07.566105") obo:IAO_0000115 obo:CL_4033096 "An ON bipolar cell that has high expression of NOS1AP compared with other bipolar cells.")
+AnnotationAssertion(terms:contributor obo:CL_4033096 <https://orcid.org/0000-0001-6677-8489>)
+AnnotationAssertion(terms:date obo:CL_4033096 "2025-01-14T13:49:08Z"^^xsd:dateTime)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1101/2023.11.07.566105") Annotation(oboInOwl:hasSynonymType obo:OMO_0003000) oboInOwl:hasRelatedSynonym obo:CL_4033096 "DB4b")
+AnnotationAssertion(rdfs:label obo:CL_4033096 "diffuse bipolar 4b cell")
+SubClassOf(obo:CL_4033096 obo:CL_0000749)
+SubClassOf(obo:CL_4033096 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_9606))
 
 # Class: obo:CL_4040000 (glial restricted tripotential precursor cell)
 


### PR DESCRIPTION
Fixes #2892 NTR diffuse bipolar 4a and 4b cells
The higly expressed genes are not added in logical axioms waiting for HCA feedback and NS-Forest markers.