### PR TITLE
Juxtaglomerular complex cell definition update

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -3400,7 +3400,7 @@ AnnotationAssertion(rdfs:label obo:IAO_0000115 "definition")
 
 AnnotationAssertion(rdfs:label obo:IAO_0000424 "expand expression to")
 
-# Annotation Property: obo:IAO_0000700 (preferred_root)
+# Annotation Property: obo:IAO_0000700 (has ontology root term)
 
 AnnotationAssertion(rdfs:label obo:IAO_0000700 "preferred_root")
 
@@ -3490,11 +3490,11 @@ AnnotationAssertion(rdfs:label oboInOwl:hasBroadSynonym "has_broad_synonym")
 
 AnnotationAssertion(rdfs:label oboInOwl:hasDbXref "database_cross_reference")
 
-# Annotation Property: oboInOwl:hasExactSynonym (has_exact_synonym)
+# Annotation Property: oboInOwl:hasExactSynonym (has exact synonym)
 
 AnnotationAssertion(rdfs:label oboInOwl:hasExactSynonym "has_exact_synonym")
 
-# Annotation Property: oboInOwl:hasNarrowSynonym (has_narrow_synonym)
+# Annotation Property: oboInOwl:hasNarrowSynonym (has narrow synonym)
 
 AnnotationAssertion(rdfs:label oboInOwl:hasNarrowSynonym "has_narrow_synonym")
 
@@ -5186,7 +5186,6 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000162 "BTO:0001780")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000162 "FMA:62901")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:29263912") oboInOwl:hasExactSynonym obo:CL_0000162 "gastric parietal cell")
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "Wikipedia:Parietal_cell") oboInOwl:hasExactSynonym obo:CL_0000162 "oxyntic cell")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "Wikipedia:Parietal_cell") oboInOwl:hasExactSynonym obo:CL_0000162 "oxyntic cell")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:29263912") Annotation(oboInOwl:hasDbXref "PMID:31613538") rdfs:comment obo:CL_0000162 "Parietal cells have dynamic, actin-supported microvilli that increase in number during active secretion, playing a crucial role in secreting hydrochloric acid and intrinsic factor. The structure and regulation of these microvilli are influenced by proteins such as ASAP3, which modulates Arf6 activity and actin assembly, thereby controlling microvilli formation and parietal cell function.")
 AnnotationAssertion(rdfs:label obo:CL_0000162 "parietal cell")
@@ -27071,8 +27070,10 @@ SubClassOf(obo:CL_1000617 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_000129
 
 # Class: obo:CL_1000618 (juxtaglomerular complex cell)
 
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "DOI:10.1007/s00424-012-1126-7") Annotation(oboInOwl:hasDbXref "PMID:31579192") obo:IAO_0000115 obo:CL_1000618 "A specialized, granular, smooth muscle cell located in the media of the afferent arteriole near the entrance to the glomerulus in the kidney. This cell functions as the primary site of renin synthesis, storage, and release. It plays a crucial role in the renin-angiotensin-aldosterone system and is a key component of the juxtaglomerular apparatus, contributing to the regulation of blood pressure and fluid-electrolyte balance.")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_1000618 "KUPO:0001028")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GO:0072052") oboInOwl:hasExactSynonym obo:CL_1000618 "juxtaglomerulus cell")
+AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_1000618 "JG cells")
 AnnotationAssertion(rdfs:label obo:CL_1000618 "juxtaglomerular complex cell")
 EquivalentClasses(obo:CL_1000618 ObjectIntersectionOf(obo:CL_0002681 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0002303)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_1000618 obo:CL_0002681)


### PR DESCRIPTION
definition updated to:
A specialized, granular, smooth muscle cell located in the media of the afferent arteriole near the entrance to the glomerulus in the kidney. This cell functions as the primary site of renin synthesis, storage, and release. It plays a crucial role in the renin-angiotensin-aldosterone system and is a key component of the juxtaglomerular apparatus, contributing to the regulation of blood pressure and fluid-electrolyte balance.

 PMID: [31579192](https://pubmed.ncbi.nlm.nih.gov/31579192/) DOI: [10.1007/s00424-012-1126-7](https://doi.org/10.1007/s00424-012-1126-7)

JG cell added as synonym