### PR TITLE
Fixes #2974 follicular cell ovary classification

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -3807,6 +3807,7 @@ AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000023 "WBbt:0006797")
 AnnotationAssertion(oboInOwl:hasRelatedSynonym obo:CL_0000023 "oogonium")
 AnnotationAssertion(rdfs:label obo:CL_0000023 "oocyte")
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000023 obo:CL_0000021)
+SubClassOf(obo:CL_0000023 obo:CL_0002174)
 SubClassOf(obo:CL_0000023 ObjectSomeValuesFrom(obo:RO_0000056 obo:GO_0007143))
 SubClassOf(obo:CL_0000023 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_33208))
 
@@ -7852,7 +7853,6 @@ AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000503 "BTO:0002850")
 AnnotationAssertion(rdfs:label obo:CL_0000503 "theca cell")
 SubClassOf(obo:CL_0000503 obo:CL_0000499)
 SubClassOf(obo:CL_0000503 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0000155))
-SubClassOf(obo:CL_0000503 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0001305))
 
 # Class: obo:CL_0000504 (enterochromaffin-like cell)
 
@@ -15660,9 +15660,7 @@ AnnotationAssertion(oboInOwl:creation_date obo:CL_0002174 "2010-08-25T03:01:27Z"
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0002174 "EMAPA:31247")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0002174 "FMA:70589")
 AnnotationAssertion(rdfs:label obo:CL_0002174 "follicular cell of ovary")
-SubClassOf(obo:CL_0002174 obo:CL_0000500)
-SubClassOf(obo:CL_0002174 obo:CL_0002078)
-SubClassOf(obo:CL_0002174 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0001305))
+EquivalentClasses(obo:CL_0002174 ObjectIntersectionOf(obo:CL_0000000 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0001305)))
 
 # Class: obo:CL_0002175 (primary follicular cell of ovary)
 


### PR DESCRIPTION
fixes #2974

Changed the logical definition of follicular cell of ovary.