### PR TITLE
Fixes #2976 luteal cell classification

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -5342,14 +5342,13 @@ EquivalentClasses(obo:CL_0000174 ObjectIntersectionOf(obo:CL_0000151 ObjectSomeV
 
 # Class: obo:CL_0000175 (luteal cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "MESH:D008184") obo:IAO_0000115 obo:CL_0000175 "A progesterone secreting cell in the corpus luteum. The large luteal cells develop from the granulosa cells. The small luteal cells develop from the theca cells.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "MESH:D008184") Annotation(oboInOwl:hasDbXref "PMID:31849844") obo:IAO_0000115 obo:CL_0000175 "A progesterone secreting cell in the corpus luteum. The large luteal cells develop from the granulosa cells. The small luteal cells develop from the theca cells.")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000175 "BTO:0003939")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000175 "FMA:18688")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:16790079") oboInOwl:hasExactSynonym obo:CL_0000175 "corpus luteum cell")
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000175 "lutein cell")
 AnnotationAssertion(rdfs:label obo:CL_0000175 "luteal cell")
 SubClassOf(obo:CL_0000175 obo:CL_0000174)
-SubClassOf(obo:CL_0000175 obo:CL_0002132)
 SubClassOf(obo:CL_0000175 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0002512))
 SubClassOf(obo:CL_0000175 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0042701))
 


### PR DESCRIPTION
Fixes #2976

Changed logical definition of luteal cell - removed SubclassOf "stromal cell of ovary"