### PR TITLE
Fixes #2980 - early and late luteal cell

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -3163,6 +3163,8 @@ Declaration(Class(obo:CL_4052039))
 Declaration(Class(obo:CL_4052040))
 Declaration(Class(obo:CL_4052041))
 Declaration(Class(obo:CL_4052042))
+Declaration(Class(obo:CL_4052046))
+Declaration(Class(obo:CL_4052047))
 Declaration(Class(obo:CL_4052048))
 Declaration(Class(obo:CL_4052049))
 Declaration(Class(obo:CP_0000000))
@@ -33700,6 +33702,25 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:27680547") rdfs:comment 
 AnnotationAssertion(rdfs:label obo:CL_4052042 "tuft cell of urethra")
 EquivalentClasses(obo:CL_4052042 ObjectIntersectionOf(obo:CL_0002204 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0002325)))
 SubClassOf(obo:CL_4052042 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_1904320))
+
+# Class: obo:CL_4052046 (early luteal cell)
+
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:36205477") Annotation(oboInOwl:hasDbXref "doi:/10.1101/2024.12.15.628550") obo:IAO_0000115 obo:CL_4052046 "A luteal cell that is part of the young, developing corpus luteum. This cell promotes progesterone synthesis, marked by high Parm1 expression in mice (Lan et al., 2024). An early luteal cell is associated with steroidogenesis and cell growth, contributing to early corpus luteum function and maturation.")
+AnnotationAssertion(terms:contributor obo:CL_4052046 <https://orcid.org/0009-0000-8480-9277>)
+AnnotationAssertion(terms:date obo:CL_4052046 "2025-03-05T16:40:18Z"^^xsd:dateTime)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:36205477") oboInOwl:hasExactSynonym obo:CL_4052046 "active corpus luteum cell")
+AnnotationAssertion(rdfs:label obo:CL_4052046 "early luteal cell")
+SubClassOf(obo:CL_4052046 obo:CL_0000175)
+
+# Class: obo:CL_4052047 (late luteal cell)
+
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:31803139") Annotation(oboInOwl:hasDbXref "PMID:36205477") Annotation(oboInOwl:hasDbXref "doi:/10.1101/2024.12.15.628550") obo:IAO_0000115 obo:CL_4052047 "A luteal cell that is part of the older, regressing corpus luteum. This cell exhibits increased expression of genes involved in progesterone metabolism - Akr1c18 in mice (Lan et al., 2024), cell cycle arrest, and apoptosis. A late luteal cell contributes to corpus luteum regression and eventual clearance from the ovary through luteolysis.")
+AnnotationAssertion(terms:contributor obo:CL_4052047 <https://orcid.org/0009-0000-8480-9277>)
+AnnotationAssertion(terms:date obo:CL_4052047 "2025-03-05T16:47:20Z"^^xsd:dateTime)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:36205477") oboInOwl:hasExactSynonym obo:CL_4052047 "regressing corpus luteum cell")
+AnnotationAssertion(rdfs:label obo:CL_4052047 "late luteal cell")
+SubClassOf(obo:CL_4052047 obo:CL_0000175)
+SubClassOf(obo:CL_4052047 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0006709))
 
 # Class: obo:CL_4052048 (intercalated cell of salivary gland)
 

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -33711,6 +33711,7 @@ AnnotationAssertion(terms:date obo:CL_4052046 "2025-03-05T16:40:18Z"^^xsd:dateTi
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:36205477") oboInOwl:hasExactSynonym obo:CL_4052046 "active corpus luteum cell")
 AnnotationAssertion(rdfs:label obo:CL_4052046 "early luteal cell")
 SubClassOf(obo:CL_4052046 obo:CL_0000175)
+SubClassOf(obo:CL_4052046 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0006701))
 
 # Class: obo:CL_4052047 (late luteal cell)
 


### PR DESCRIPTION
Fixes #2980

- Added new terms - early and late luteal cells

The general term luteal cell should be updated in a separate ticket (textual and logical definition) - TBD with @aleixpuigb - we probably should remove that luteal cell is capable of progesterone secretion as it contradicts one of the subclasses (late luteal cell)