### PR TITLE
Fixes #2993 renamed mononuclear cell

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -11200,15 +11200,15 @@ EquivalentClasses(obo:CL_0000841 ObjectIntersectionOf(obo:CL_0000990 ObjectSomeV
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000841 obo:CL_0000990)
 SubClassOf(obo:CL_0000841 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000840))
 
-# Class: obo:CL_0000842 (mononuclear cell)
+# Class: obo:CL_0000842 (mononuclear leukocyte)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:add") obo:IAO_0000115 obo:CL_0000842 "A leukocyte with a single non-segmented nucleus in the mature form.")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000842 "BTO:0000878")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000842 "CALOHA:TS-0768")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000842 "FMA:86713")
-AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000842 "mononuclear leukocyte")
+AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0000842 "mononuclear cell")
 AnnotationAssertion(oboInOwl:hasNarrowSynonym obo:CL_0000842 "peripheral blood mononuclear cell")
-AnnotationAssertion(rdfs:label obo:CL_0000842 "mononuclear cell")
+AnnotationAssertion(rdfs:label obo:CL_0000842 "mononuclear leukocyte")
 EquivalentClasses(obo:CL_0000842 ObjectIntersectionOf(obo:CL_0000738 ObjectSomeValuesFrom(obo:RO_0000053 obo:PATO_0001407)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000842 obo:CL_0000738)
 
@@ -16006,11 +16006,11 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl
 AnnotationAssertion(terms:contributor obo:CL_0002204 <https://orcid.org/0000-0003-1980-3228>)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002204 "2010-09-02T02:28:53Z"^^xsd:dateTime)
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0002204 "FMA:67978")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:36704202") oboInOwl:hasExactSynonym obo:CL_0002204 "brush cell")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:36704202") oboInOwl:hasExactSynonym obo:CL_0002204 "caveolated cell")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:36704202") oboInOwl:hasExactSynonym obo:CL_0002204 "fibrillovesicular cell")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:32307399") oboInOwl:hasExactSynonym obo:CL_0002204 "multivesicular cell")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:36704202") oboInOwl:hasExactSynonym obo:CL_0002204 "peculiar cell")
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:36704202") oboInOwl:hasExactSynonym obo:CL_0002204 "brush cell")
 AnnotationAssertion(rdfs:label obo:CL_0002204 "tuft cell")
 EquivalentClasses(obo:CL_0002204 ObjectIntersectionOf(obo:CL_0000066 ObjectSomeValuesFrom(obo:BFO_0000051 obo:GO_0151001)))
 
@@ -23420,7 +23420,7 @@ EquivalentClasses(obo:CL_0009040 ObjectIntersectionOf(obo:CL_0000499 ObjectSomeV
 
 # Class: obo:CL_0009041 (tuft cell of colon)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "http://orcid.org/0000-0003-3440-1876") Annotation(oboInOwl:hasDbXref "PMID:33079783") Annotation(oboInOwl:hasDbXref "PMID:35271673") obo:IAO_0000115 obo:CL_0009041 "A tuft cell that is part of the colonic epithelium, primarily adapted for microbial sensing in the dense colonic microbiota. Unlike its small intestinal counterpart, it does not participate in parasite-driven tuft cell–ILC2 circuits. Instead, it detects bacterial metabolites via taste-signaling pathways (Strine and Craig, 2022). The colonic tuft cell plays a key role in epithelial repair, modulates inflammatory responses through IL-25 secretion, and contributes to intestinal homeostasis by balancing microbiome interactions (Sebastian et al., 2021).")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:33079783") Annotation(oboInOwl:hasDbXref "PMID:35271673") Annotation(oboInOwl:hasDbXref "http://orcid.org/0000-0003-3440-1876") obo:IAO_0000115 obo:CL_0009041 "A tuft cell that is part of the colonic epithelium, primarily adapted for microbial sensing in the dense colonic microbiota. Unlike its small intestinal counterpart, it does not participate in parasite-driven tuft cell–ILC2 circuits. Instead, it detects bacterial metabolites via taste-signaling pathways (Strine and Craig, 2022). The colonic tuft cell plays a key role in epithelial repair, modulates inflammatory responses through IL-25 secretion, and contributes to intestinal homeostasis by balancing microbiome interactions (Sebastian et al., 2021).")
 AnnotationAssertion(terms:contributor obo:CL_0009041 <https://orcid.org/0000-0002-2825-0621>)
 AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_0009041 "colon tuft cell")
 AnnotationAssertion(oboInOwl:inSubset obo:CL_0009041 pato:location_grouping)


### PR DESCRIPTION
Fixes #2993 relabelled mononuclear cell to mononuclear leukocyte AND added mononuclear cell as EXACT SYN