### PR TITLE
Fixed #3038 Improved Axiomatisation for Molecular layer interneuron MLI

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -3537,7 +3537,7 @@ AnnotationAssertion(rdfs:label oboInOwl:consider "consider")
 
 AnnotationAssertion(rdfs:label oboInOwl:hasBroadSynonym "has_broad_synonym")
 
-# Annotation Property: oboInOwl:hasDbXref (has cross-reference)
+# Annotation Property: oboInOwl:hasDbXref (database_cross_reference)
 
 AnnotationAssertion(rdfs:label oboInOwl:hasDbXref "database_cross_reference")
 
@@ -33075,7 +33075,9 @@ AnnotationAssertion(terms:contributor obo:CL_4042035 <https://orcid.org/0000-000
 AnnotationAssertion(terms:date obo:CL_4042035 "2024-10-31T15:55:31Z"^^xsd:dateTime)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:33075461") Annotation(oboInOwl:hasRelatedSynonym obo:OMO_0003000) oboInOwl:hasRelatedSynonym obo:CL_4042035 "MLI")
 AnnotationAssertion(rdfs:label obo:CL_4042035 "molecular layer interneuron"@en)
-SubClassOf(obo:CL_4042035 obo:CL_1001611)
+SubClassOf(obo:CL_4042035 obo:CL_0000099)
+SubClassOf(obo:CL_4042035 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0002974))
+SubClassOf(obo:CL_4042035 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534))
 
 # Class: obo:CL_4042036 (melanin-concentrating hormone neuron)
 


### PR DESCRIPTION
added: SubClass Of: interneuron
SubClass Of: 'capable of' some 'gamma-aminobutyric acid secretion, neurotransmission' SubClass Of: 'has soma location' some 'molecular layer of cerebellar cortex' AND
removed Cerebellar neuron