### PR TITLE
Fixed #3035 Improved axiomatisation Candelabrum Cell

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -33015,7 +33015,7 @@ SubClassOf(obo:CL_4042029 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_000095
 
 # Class: obo:CL_4042030 (candelabrum cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:35578131") obo:IAO_0000115 obo:CL_4042030 "A GABAergic interneuron located in the cerebellar cortex. This GABAergic interneuron type has a distinct morphology, it presents a small cell soma near the Purkinje cell layer (PCL), dendrites that extend to the surface of the molecular layer, and beaded axons that make local synapses contacts within the molecular layer. A candelabrum cell is excited by mossy fibers and granule cells but inhibited by Purkinje cells, and it inhibits molecular layer interneurons, which leads to the disinhibition of Purkinje cells.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:35578131") obo:IAO_0000115 obo:CL_4042030 "A GABAergic interneuron located in the Purkinje layer of the cerebellar cortex. This GABAergic interneuron type has a distinct morphology, it presents a small cell soma near the Purkinje cell layer (PCL), dendrites that extend to the surface of the molecular layer, and beaded axons that make local synapses contacts within the molecular layer. A candelabrum cell is excited by mossy fibers and granule cells but inhibited by Purkinje cells, and it inhibits molecular layer interneurons, which leads to the disinhibition of Purkinje cells.")
 AnnotationAssertion(terms:contributor obo:CL_4042030 <https://orcid.org/0000-0002-0098-8958>)
 AnnotationAssertion(terms:date obo:CL_4042030 "2024-10-15T11:06:31Z"^^xsd:dateTime)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:35578131") oboInOwl:hasExactSynonym obo:CL_4042030 "candelabrum interneuron")

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -3537,7 +3537,7 @@ AnnotationAssertion(rdfs:label oboInOwl:consider "consider")
 
 AnnotationAssertion(rdfs:label oboInOwl:hasBroadSynonym "has_broad_synonym")
 
-# Annotation Property: oboInOwl:hasDbXref (has cross-reference)
+# Annotation Property: oboInOwl:hasDbXref (database_cross_reference)
 
 AnnotationAssertion(rdfs:label oboInOwl:hasDbXref "database_cross_reference")
 
@@ -33014,7 +33014,9 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:35578131") oboInOwl:hasE
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:35578131") Annotation(oboInOwl:hasSynonymType obo:OMO_0003000) oboInOwl:hasRelatedSynonym obo:CL_4042030 "CC")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:35578131") rdfs:comment obo:CL_4042030 "Candelabrum cells are the most abundant interneurons in the Purkinje cell layer and are present in all cerebellar lobules.")
 AnnotationAssertion(rdfs:label obo:CL_4042030 "candelabrum cell"@en)
-SubClassOf(obo:CL_4042030 obo:CL_1001611)
+SubClassOf(obo:CL_4042030 obo:CL_0000099)
+SubClassOf(obo:CL_4042030 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0002979))
+SubClassOf(obo:CL_4042030 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061534))
 
 # Class: obo:CL_4042031 (immune oligodendroglia)
 


### PR DESCRIPTION
… removing redundant term

SubClass Of: interneuron
SubClass Of: 'capable of' some 'gamma-aminobutyric acid secretion, neurotransmission' SubClass Of: 'has soma location' some 'purkinje cell layer' AND
Removed cerebellar neuron