### PR TITLE
Fixes #3009 and #2271 to obsolete absorptive cell

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -5686,11 +5686,13 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "FB:ma") obo:IAO_0000115 obo:C
 AnnotationAssertion(rdfs:label obo:CL_0000211 "electrically active cell")
 SubClassOf(obo:CL_0000211 obo:CL_0000000)
 
-# Class: obo:CL_0000212 (absorptive cell)
+# Class: obo:CL_0000212 (obsolete absorptive cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "CL:CVS") obo:IAO_0000115 obo:CL_0000212 "A cell that takes up and metabolizes substances.")
-AnnotationAssertion(rdfs:label obo:CL_0000212 "absorptive cell")
-SubClassOf(obo:CL_0000212 obo:CL_0000000)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "CL:CVS") obo:IAO_0000115 obo:CL_0000212 "OBSOLETE. A cell that takes up and metabolizes substances.")
+AnnotationAssertion(obo:IAO_0000233 obo:CL_0000212 <https://github.com/obophenotype/cell-ontology/issues/2271>)
+AnnotationAssertion(rdfs:comment obo:CL_0000212 "It has no child terms. Consider using 'gut absorptive cell'.")
+AnnotationAssertion(rdfs:label obo:CL_0000212 "obsolete absorptive cell")
+AnnotationAssertion(owl:deprecated obo:CL_0000212 "true"^^xsd:boolean)
 
 # Class: obo:CL_0000213 (obsolete lining cell)
 


### PR DESCRIPTION
Fixes #3009 and #2271 to obsolete absorptive cell. This term was childless and there are terms that better represent it.