### PR TITLE
Fixes #3016 obsolete attachment cell

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -7000,10 +7000,12 @@ AnnotationAssertion(obo:RO_0002161 obo:CL_0000385 obo:NCBITaxon_33511)
 AnnotationAssertion(rdfs:label obo:CL_0000385 "prohemocyte (sensu Nematoda and Protostomia)")
 SubClassOf(obo:CL_0000385 obo:CL_0008001)
 
-# Class: obo:CL_0000386 (attachment cell)
+# Class: obo:CL_0000386 (obsolete attachment cell)
 
-AnnotationAssertion(rdfs:label obo:CL_0000386 "attachment cell")
-SubClassOf(obo:CL_0000386 obo:CL_0000630)
+AnnotationAssertion(obo:IAO_0000233 obo:CL_0000386 <https://github.com/obophenotype/cell-ontology/issues/3016>)
+AnnotationAssertion(rdfs:comment obo:CL_0000386 "The obsoleted term is redundant")
+AnnotationAssertion(rdfs:label obo:CL_0000386 "obsolete attachment cell")
+AnnotationAssertion(owl:deprecated obo:CL_0000386 "true"^^xsd:boolean)
 
 # Class: obo:CL_0000387 (hemocyte (sensu Arthropoda))
 
@@ -7021,7 +7023,6 @@ AnnotationAssertion(oboInOwl:hasRelatedSynonym obo:CL_0000388 "tenocyte")
 AnnotationAssertion(rdfs:label obo:CL_0000388 "tendon cell")
 EquivalentClasses(obo:CL_0000388 ObjectIntersectionOf(obo:CL_0000135 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0000043)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0000388 obo:CL_0000135)
-SubClassOf(obo:CL_0000388 obo:CL_0000386)
 
 # Class: obo:CL_0000389 (socket cell (sensu Nematoda))
 
@@ -33412,7 +33413,7 @@ SubClassOf(obo:CL_4047054 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0002468))
 
 # Class: obo:CL_4047056 (large mucus secreting cholangiocyte)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:26273695") Annotation(oboInOwl:hasDbXref "doi:10.1002/hep.25595") Annotation(oboInOwl:hasDbXref "doi:10.1152/ajpgi.00227.2012") Annotation(oboInOwl:hasDbXref "PMID:15579435") Annotation(oboInOwl:hasDbXref "PMID:28261592") obo:IAO_0000115 obo:CL_4047056 "A columnar, mucin-producing cholangiocyte that lines large bile ducts, including the hilar bile duct, right and left hepatic bile ducts, and large intrahepatic bile ducts. This cell expresses phosphorylated STAT3 and TFF-3 in humans and mice.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:15579435") Annotation(oboInOwl:hasDbXref "PMID:26273695") Annotation(oboInOwl:hasDbXref "PMID:28261592") Annotation(oboInOwl:hasDbXref "doi:10.1002/hep.25595") Annotation(oboInOwl:hasDbXref "doi:10.1152/ajpgi.00227.2012") obo:IAO_0000115 obo:CL_4047056 "A columnar, mucin-producing cholangiocyte that lines large bile ducts, including the hilar bile duct, right and left hepatic bile ducts, and large intrahepatic bile ducts. This cell expresses phosphorylated STAT3 and TFF-3 in humans and mice.")
 AnnotationAssertion(terms:contributor obo:CL_4047056 <https://orcid.org/0009-0005-7919-4905>)
 AnnotationAssertion(terms:date obo:CL_4047056 "2025-03-20T14:21:41Z"^^xsd:dateTime)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1152/ajpgi.00227.2012") oboInOwl:hasNarrowSynonym obo:CL_4047056 "mucin-secreting cholangiocyte")


### PR DESCRIPTION
Fixes #3016 obsolete attachment cell

The term is redundant and had only one child term (tendon cell)