### PR TITLE
Fix Ontology ID in -edit file.

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -21,7 +21,7 @@ Prefix(oboInOwl:=<http://www.geneontology.org/formats/oboInOwl#>)
 Prefix(ncbitaxon:=<http://purl.obolibrary.org/obo/ncbitaxon#>)
 
 
-Ontology(<http://purl.obolibrary.org/obo/cl-edit.owl>
+Ontology(<http://purl.obolibrary.org/obo/cl.owl>
 Import(<http://purl.obolibrary.org/obo/cl/components/blood_and_immune_upper_slim.owl>)
 Import(<http://purl.obolibrary.org/obo/cl/components/cellxgene_subset.owl>)
 Import(<http://purl.obolibrary.org/obo/cl/components/clm-cl.owl>)


### PR DESCRIPTION
The Ontology ID in `cl-edit.owl` has recently been set to `http://purl.obolibrary.org/obo/cl-edit.owl`, instead of the normal `http://purl.obolibrary.org/obo/cl.owl`.

The bogus ID has no effect on the ontology itself (as the correct ontology ID is forcefully injected into all release artefacts at release time), but it does cause the derived SSSOM mappings to have a `subject_source` set to `obo:cl-edit.owl` instead of the expected `obo:cl.owl`.