### PR TITLE
Update the Uberon ROBOT plugin.

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -10,7 +10,7 @@
 # More information: https://github.com/INCATools/ontology-development-kit/
 
 # Fingerprint of the configuration file when this Makefile was last generated
-CONFIG_HASH=                6192ec51b538ce0a87b4c154540f9d62a99c17c66191f0f15db6eccf88f12a12
+CONFIG_HASH=                04550e78d8d725271f6c54a2da3913c557d10b73608bba23bf7ca4fd3c77d4d3
 
 
 # ----------------------------------------
@@ -184,7 +184,7 @@ $(ROBOT_PLUGINS_DIRECTORY)/flybase.jar:
 	curl -L -o $@ https://github.com/FlyBase/flybase-robot-plugin/releases/download/flybase-robot-plugin-0.2.2/flybase.jar
 
 $(ROBOT_PLUGINS_DIRECTORY)/uberon.jar:
-	curl -L -o $@ https://github.com/gouttegd/uberon-robot-plugin/releases/download/uberon-robot-plugin-0.3.3/uberon.jar
+	curl -L -o $@ https://github.com/obophenotype/uberon-robot-plugin/releases/download/uberon-robot-plugin-0.4.0/uberon.jar
 
 
 # ----------------------------------------

--- a/src/ontology/cl-odk.yaml
+++ b/src/ontology/cl-odk.yaml
@@ -35,7 +35,7 @@ robot_plugins:
     - name: flybase
       mirror_from: https://github.com/FlyBase/flybase-robot-plugin/releases/download/flybase-robot-plugin-0.2.2/flybase.jar
     - name: uberon
-      mirror_from: https://github.com/gouttegd/uberon-robot-plugin/releases/download/uberon-robot-plugin-0.3.3/uberon.jar
+      mirror_from: https://github.com/obophenotype/uberon-robot-plugin/releases/download/uberon-robot-plugin-0.4.0/uberon.jar
 subset_group:
   products:
     - id: BDS_subset

--- a/src/ontology/cl.Makefile
+++ b/src/ontology/cl.Makefile
@@ -178,7 +178,8 @@ test: $(REPORTDIR)/taxon-constraint-check.txt
 obocheck: $(SRC) | all_robot_plugins
 	$(ROBOT) merge -i $(SRC) \
 		 remove --base-iri $(URIBASE)/CL_ --axioms external --trim false \
-		 uberon:obo-export --merge-comments --obo-output $(TMPDIR)/cl-check.obo
+		 convert --check false -f obo $(OBO_FORMAT_OPTIONS) \
+		         --output $(TMPDIR)/cl-check.obo
 	fastobo-validator $(TMPDIR)/cl-check.obo
 
 test_obsolete: $(ONT).obo


### PR DESCRIPTION
The Uberon plugin has been moved from my personal GitHub space (https://github.com/gouttegd/) to the “obophenotype” organisation (https://github.com/obophenotype/). So in this PR we update the location we are downloading the plugin from, and get the latest version.

There was also one remaining use of the now deprecated `uberon:obo-export` command, which we replace by a call to the standard `convert` command with the (new in ROBOT 1.9.8) `--clean-obo` option.