### PR TITLE
Replace obsolete SSSOM/T-OWL rule.

### DIFF
--- a/src/scripts/mappings-to-xrefs.rules
+++ b/src/scripts/mappings-to-xrefs.rules
@@ -6,7 +6,7 @@ object==CL:* -> invert();
 !subject==CL:* -> stop();
 
 # Ignore any mapping to an inexistent or obsolete CL class.
-predicate==* -> check_subject_existence();
+!exists(%{subject_id}) -> stop();
 
 # Ignore any mapping where the same foreign term is mapped to more than one CL class.
 !cardinality==1:* -> stop();


### PR DESCRIPTION
The `mappings-to-xrefs.rules` SSSOM/T-OWL ruleset (used to generate the `mappings.owl` component, containing xref representations of foreign mappings) is still using some deprecated, pre-1.0 SSSOM/T-OWL features, namely the `check_subject_existence()` preprocessing function.

This feature will no longer be supported in a future SSSOM-Java version and should be replaced by its SSSOM/T-OWL 1.0 equivalent, which is what we do here.

(This is the same thing as Uberon’s [PR 3587](https://github.com/obophenotype/uberon/pull/3587).)