### PR TITLE
Remove 2DFTU_HRA_illustrations and PNS_neurons subsets

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -10,7 +10,7 @@
 # More information: https://github.com/INCATools/ontology-development-kit/
 
 # Fingerprint of the configuration file when this Makefile was last generated
-CONFIG_HASH=                6f1a766372040766b28beb0fcedd73c024f977d65c04b8d77418bb372ce472b2
+CONFIG_HASH=                6e93c5342d83d66041ce747e0df055a69241fe42a17d5554ba47d553f5458331
 
 
 # ----------------------------------------
@@ -219,7 +219,7 @@ all_imports: $(IMPORT_FILES)
 # ----------------------------------------
 
 
-SUBSETS =  BDS_subset blood_and_immune_upper_slim eye_upper_slim general_cell_types_upper_slim kidney_upper_slim human-view mouse-view PNS_neurons 2DFTU_HRA_illustrations
+SUBSETS =  BDS_subset blood_and_immune_upper_slim eye_upper_slim general_cell_types_upper_slim kidney_upper_slim human-view mouse-view
 
 SUBSET_ROOTS = $(patsubst %, $(SUBSETDIR)/%, $(SUBSETS))
 SUBSET_FILES = $(foreach n,$(SUBSET_ROOTS), $(foreach f,$(FORMATS_INCL_TSV), $(n).$(f)))

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -22,6 +22,7 @@ Prefix(ncbitaxon:=<http://purl.obolibrary.org/obo/ncbitaxon#>)
 
 
 Ontology(<http://purl.obolibrary.org/obo/cl.owl>
+Import(<http://purl.obolibrary.org/obo/cl/components/PNS_neurons.owl>)
 Import(<http://purl.obolibrary.org/obo/cl/components/blood_and_immune_upper_slim.owl>)
 Import(<http://purl.obolibrary.org/obo/cl/components/cellxgene_subset.owl>)
 Import(<http://purl.obolibrary.org/obo/cl/components/clm-cl.owl>)
@@ -29,7 +30,6 @@ Import(<http://purl.obolibrary.org/obo/cl/components/eye_upper_slim.owl>)
 Import(<http://purl.obolibrary.org/obo/cl/components/general_cell_types_upper_slim.owl>)
 Import(<http://purl.obolibrary.org/obo/cl/components/hra_subset.owl>)
 Import(<http://purl.obolibrary.org/obo/cl/components/kidney_upper_slim.owl>)
-Import(<http://purl.obolibrary.org/obo/cl/components/PNS_neurons.owl>)
 Import(<http://purl.obolibrary.org/obo/cl/components/mappings.owl>)
 Import(<http://purl.obolibrary.org/obo/cl/components/wmbo-cl-comp.owl>)
 Import(<http://purl.obolibrary.org/obo/cl/components/2DFTU_HRA_illustrations.owl>)

--- a/src/ontology/cl-odk.yaml
+++ b/src/ontology/cl-odk.yaml
@@ -45,7 +45,6 @@ subset_group:
     - id: kidney_upper_slim
     - id: human-view
     - id: mouse-view
-    - id: 2DFTU_HRA_illustrations
 sssom_mappingset_group:
   products:
     - id: cl-local


### PR DESCRIPTION
Eliminated references to 2DFTU_HRA_illustrations and PNS_neurons subsets from Makefile and cl-odk.yaml. Updated cl-edit.owl to adjust import ordering and annotation label for hasDbXref. These changes streamline subset management and correct annotation labeling.