### PR TITLE
updated the CL release documentation

### DIFF
--- a/docs/cl-release.md
+++ b/docs/cl-release.md
@@ -62,7 +62,7 @@ The release is done in two parts:
 1. Review the release as per the `Review the release` section in [ODK-workflow release document](odk-workflows/ReleaseWorkflow.md#review-the-release)
 1. Create a pull request and get a second set of eyes to review it. As CL uses a custom release pipeline, we ask that you get at least one core developer to review it too.
 1. Merge to main branch once reviewed and CI checks have passed
-1. Deploy release on GitHub by running `make deploy_release GHVERSION="v2022-06-20"` on the release branch (DO NOTE CHANGE TO MAIN BRANCH!), replacing the date with the date of release (NOTE: no `sh run.sh`)
+1. Deploy release on GitHub by running `make public_release GHVERSION="v2025-07-30"` on the release branch (DO NOTE CHANGE TO MAIN BRANCH!), replacing the date with the date of release (NOTE: no `sh run.sh`)
 1. This should end with a GitHub release link that looks something like:`https://github.com/obophenotype/cl/releases/tag/untagged-8935f3432525b27a0d84`. Copy the link and paste it in your browser, this should show you a draft release. 
 1. Click the edit button (the pencil button on the top right corner) and change the tag to the GHVERSION you entered above (eg v2022-06-20)
 1. Change the `TBD.` in the main text to a summary of the main changes in the release if needed. Copy and paste the text and table from the `reports/summary_release.md` file. This file is in `.gitignore` and will only be available to those who have run the release.


### PR DESCRIPTION
#3218

Replaced 

`make deploy_release GHVERSION="v2025-07-30"`

with 

`make public_release GHVERSION="v2025-07-30"`
