### PR TITLE
Fixes 3238 copilot setup

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,15 +1,15 @@
 name: "Copilot Setup Steps"
-inputs:
-  robot-version:
-    description: 'Version of ROBOT tool to install'
-    required: false
-    default: 'v1.9.7'
+on:
+  workflow_dispatch:
+    inputs:
+      robot-version:
+        description: 'Version of ROBOT tool to install'
+        required: false
+        default: 'v1.9.7'
 
 
 # Automatically run the setup steps when they are changed to allow for easy validation, and
 # allow manual testing through the repository's "Actions" tab
-on:
-  workflow_dispatch:
   push:
     paths:
       - .github/workflows/copilot-setup-steps.yml
@@ -42,21 +42,21 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.jar-cache
-        key: ${{ runner.os }}-robot-v1.9.7
+        key: ${{ runner.os }}-robot-${{ github.event.inputs.robot-version }}
         restore-keys: ${{ runner.os }}-robot-
 
     - name: Download ROBOT JAR if not cached
       run: |
         mkdir -p ~/.jar-cache
         if [ ! -f ~/.jar-cache/robot.jar ]; then
-          curl -L https://github.com/ontodev/robot/releases/download/v1.9.7/robot.jar -o ~/.jar-cache/robot.jar
+          curl -L https://github.com/ontodev/robot/releases/download/${{ github.event.inputs.robot-version }}/robot.jar -o ~/.jar-cache/robot.jar
         fi
       shell: bash
     
     - name: Setup ROBOT tools
       run: |
         cp ~/.jar-cache/robot.jar ${{ github.workspace }}/tools/robot.jar
-        curl -L https://raw.githubusercontent.com/ontodev/robot/v1.9.7/bin/robot -o ${{ github.workspace }}/tools/robot
+        curl -L https://raw.githubusercontent.com/ontodev/robot/${{ github.event.inputs.robot-version }}/bin/robot -o ${{ github.workspace }}/tools/robot
         chmod +x ${{ github.workspace }}/tools/robot
         ${{ github.workspace }}/tools/robot --help
       shell: bash


### PR DESCRIPTION
Fixes 3238
Moved 'robot-version' input under 'workflow_dispatch' and updated cache keys and download URLs to use the specified version dynamically.