### PR TITLE
Add cl-full to CL sparql QC checking

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -10,7 +10,7 @@
 # More information: https://github.com/INCATools/ontology-development-kit/
 
 # Fingerprint of the configuration file when this Makefile was last generated
-CONFIG_HASH=                6e93c5342d83d66041ce747e0df055a69241fe42a17d5554ba47d553f5458331
+CONFIG_HASH=                e584d2d6e23caeef045397b6870989b94f7ed5fc973e3b51769514058f55c54d
 
 
 # ----------------------------------------
@@ -247,8 +247,8 @@ all_mappings: $(MAPPING_FILES)
 # QC Reports & Utilities
 # ----------------------------------------
 
-OBO_REPORT =  $(SRC)-obo-report
-ALIGNMENT_REPORT =  $(SRC)-align-report
+OBO_REPORT =  $(SRC)-obo-report cl-full.owl-obo-report
+ALIGNMENT_REPORT =  $(SRC)-align-report cl-full.owl-align-report
 REPORTS = $(OBO_REPORT)
 REPORT_FILES = $(patsubst %, $(REPORTDIR)/%.tsv, $(REPORTS))
 
@@ -280,10 +280,12 @@ validate_profile_%: $(REPORTDIR)/validate_profile_owl2dl_%.txt
 
 SPARQL_VALIDATION_QUERIES = $(foreach V,$(SPARQL_VALIDATION_CHECKS),$(SPARQLDIR)/$(V)-violation.sparql)
 
-sparql_test:  $(SRCMERGED) | $(REPORTDIR)
+sparql_test:  $(SRCMERGED) cl-full.owl | $(REPORTDIR)
 ifneq ($(SPARQL_VALIDATION_QUERIES),)
   
 	$(ROBOT) verify -i $(SRCMERGED) --queries $(SPARQL_VALIDATION_QUERIES) -O $(REPORTDIR)
+  
+	$(ROBOT) verify -i cl-full.owl --queries $(SPARQL_VALIDATION_QUERIES) -O $(REPORTDIR)
 endif
 
 # ----------------------------------------
@@ -291,10 +293,10 @@ endif
 # ----------------------------------------
 
 $(REPORTDIR)/$(SRC)-obo-report.tsv: $(SRCMERGED) | $(REPORTDIR)
-	$(ROBOT) report -i $< $(REPORT_LABEL) $(REPORT_PROFILE_OPTS) --fail-on $(REPORT_FAIL_ON) --print 5 -o $@
+	$(ROBOT) report -i $< $(REPORT_LABEL) $(REPORT_PROFILE_OPTS) --fail-on $(REPORT_FAIL_ON) --base-iri http://purl.obolibrary.org/obo/CP_ --base-iri http://purl.obolibrary.org/obo/CL_ --base-iri http://purl.obolibrary.org/obo/cl# --print 5 -o $@
 
 $(REPORTDIR)/%-obo-report.tsv: % | $(REPORTDIR)
-	$(ROBOT) report -i $< $(REPORT_LABEL) $(REPORT_PROFILE_OPTS) --fail-on $(REPORT_FAIL_ON) --print 5 -o $@
+	$(ROBOT) report -i $< $(REPORT_LABEL) $(REPORT_PROFILE_OPTS) --fail-on $(REPORT_FAIL_ON) --base-iri http://purl.obolibrary.org/obo/CP_ --base-iri http://purl.obolibrary.org/obo/CL_ --base-iri http://purl.obolibrary.org/obo/cl# --print 5 -o $@
 
 check_for_robot_updates:
 	echo "You are not using a custom profile, so you are getting the joy of the latest ROBOT report!"

--- a/src/ontology/cl-odk.yaml
+++ b/src/ontology/cl-odk.yaml
@@ -117,8 +117,13 @@ robot_report:
   fail_on : ERROR
   use_labels : False
   custom_profile : False
+  use_base_iris: True
   report_on :
     - edit
+    - cl-full.owl
+  sparql_test_on:
+    - edit
+    - cl-full.owl
   custom_sparql_checks :
     - equivalent-classes
     - owldef-self-reference

--- a/src/sparql/illegal-annotation-property-violation.sparql
+++ b/src/sparql/illegal-annotation-property-violation.sparql
@@ -56,7 +56,8 @@ SELECT DISTINCT ?term ?annotation WHERE {
     <http://purl.obolibrary.org/obo/CLM_0010001>,
     <http://purl.obolibrary.org/obo/CLM_0010002>,
     <http://purl.obolibrary.org/obo/CLM_0010003>,
-    <http://purl.obolibrary.org/obo/CLM_0010004>
+    <http://purl.obolibrary.org/obo/CLM_0010004>,
+    <http://www.w3.org/2004/02/skos/core#prefLabel>
   ))
   FILTER (isIRI(?term) && STRSTARTS(str(?term), "http://purl.obolibrary.org/obo/CL_"))
 } 

--- a/src/sparql/illegal-date-violation.sparql
+++ b/src/sparql/illegal-date-violation.sparql
@@ -8,5 +8,6 @@ SELECT DISTINCT ?term ?property ?value WHERE
   ?term ?property ?value .
   FILTER (datatype(?value) != xsd:date || !regex(str(?value), '^\\d{4}-\\d\\d-\\d\\d$'))
   FILTER (datatype(?value) != xsd:dateTime || !regex(str(?value), '^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z'))
+  FILTER (isIRI(?term) && STRSTARTS(str(?term), "http://purl.obolibrary.org/obo/CL_"))
 }
 

--- a/src/sparql/label-synonym-polysemy-violation.sparql
+++ b/src/sparql/label-synonym-polysemy-violation.sparql
@@ -27,10 +27,12 @@ SELECT ?entity ?property ?value WHERE {
       BIND(UCASE((?name)) AS ?iname)
       FILTER (!isBlank(?entity) && !BOUND(?abbr))
       FILTER NOT EXISTS { ?entity owl:deprecated true }
+      FILTER (isIRI(?entity) && STRSTARTS(str(?entity), "http://purl.obolibrary.org/obo/CL_"))
     } GROUP BY ?iname HAVING (?cnt > 1)
   }
   ?entity ?property ?value .
   FILTER (!isBlank(?entity))
   FILTER NOT EXISTS { ?entity owl:deprecated true }
+  FILTER (isIRI(?entity) && STRSTARTS(str(?entity), "http://purl.obolibrary.org/obo/CL_"))
   FILTER (UCASE(?value) = ?iname)
 } ORDER BY ?entity

--- a/src/sparql/pmid-not-dbxref-violation.sparql
+++ b/src/sparql/pmid-not-dbxref-violation.sparql
@@ -4,4 +4,5 @@ WHERE {
 	?subject ?annotation ?pmid .
   FILTER (STRSTARTS(str(?pmid), "PMID:"))
   MINUS {?subject oboInOwl:hasDbXref ?pmid}
+  FILTER(isIRI(?subject) && (STRSTARTS(str(?subject), "http://purl.obolibrary.org/obo/CL_") || STRSTARTS(str(?subject), "http://purl.obolibrary.org/obo/cl#")))
 }


### PR DESCRIPTION
Related to: https://github.com/obophenotype/cell-ontology/pull/3309

This pull request updates the ontology build and quality control pipeline to ensure that reports and SPARQL validation checks are consistently run on both the merged source ontology and the full CL ontology file (`cl-full.owl`). It also improves the specificity of SPARQL validation queries by restricting them to CL terms.