### PR TITLE
Fix reference to deprecated GO class.

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -14280,7 +14280,7 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:22552227") oboInOwl:hasR
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:22649468") oboInOwl:hasRelatedSynonym obo:CL_0002038 "follicular helper T cell")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:22508770") oboInOwl:hasRelatedSynonym obo:CL_0002038 "follicular helper T-cell")
 AnnotationAssertion(rdfs:label obo:CL_0002038 "T follicular helper cell")
-EquivalentClasses(obo:CL_0002038 ObjectIntersectionOf(obo:CL_0000492 ObjectSomeValuesFrom(obo:BFO_0000051 obo:PR_000003450) ObjectSomeValuesFrom(obo:CL_4030046 obo:PR_000001203) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001209) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001860) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001919) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0045830) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0051024)))
+EquivalentClasses(obo:CL_0002038 ObjectIntersectionOf(obo:CL_0000492 ObjectSomeValuesFrom(obo:BFO_0000051 obo:PR_000003450) ObjectSomeValuesFrom(obo:CL_4030046 obo:PR_000001203) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001209) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001860) ObjectSomeValuesFrom(obo:RO_0002104 obo:PR_000001919) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0002639) ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0045830)))
 SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0002038 obo:CL_0000492)
 SubClassOf(obo:CL_0002038 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000896))
 


### PR DESCRIPTION
'T follicular helper cell' (CL:0002038) is currently logically defined in relation to GO:0051024, which is deprecated.

This PR updates the logical definition to refer to GO:0051024's replacement term, GO:0002639 ('positive regulation of immunoglobulin production').

closes #2967