### PR TITLE
Support temporary IDs.

### DIFF
--- a/.github/workflows/allocate-definitive-ids.yml
+++ b/.github/workflows/allocate-definitive-ids.yml
@@ -1,0 +1,38 @@
+name: Allocate definitive IDs
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'src/ontology/cl-edit.owl'
+  workflow_dispatch:
+
+jobs:
+  assign_ids:
+    runs-on: ubuntu-latest
+    container: obolibrary/odkfull:v1.6
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      # Reallocate all temporary IDs as definitive IDs and rewrite
+      # axioms accordingly; this will have the side-effect of forcing a
+      # reserialisation of the -edit file if needed.
+      - name: Allocate definitive IDs
+        run: |
+          cd src/ontology
+          make allocate-definitive-ids
+
+      # Commit the changes; the 'push' action takes care of checking
+      # whether there are changes to commit at all, so if no IDs were
+      # reallocated (and no reserialisation was needed), nothing will
+      # happen here.
+      - name: Commit and push changes
+        uses: actions-js/push@v1.5
+        with:
+          github_token: ${{ secrets.ID_ALLOCATION_TOKEN }}
+          message: "Replace temporary IDs by definitive IDs and reserialize."
+          branch: ${{ github.ref }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,7 @@ This includes instructions for editing the cl ontology.
 ## OBO Guidelines
 - Term ID format: CL_NNNNNNN (7-digit number)
 - Handling New Term Requests (NTRs):
-  - New terms start  CL_777xxxx
-  - Do `grep CL_777 src/ontology/cl-edit.owl` to check for clashes
+  - New terms start  CL_99xxxxx
 - Each term requires: id, name, definition with references
 - Never guess CL IDs, or ontology term IDs, use search tools above to determine actual term
 - Never guess PMIDs for references, do a web search if needed

--- a/docs/id-management.md
+++ b/docs/id-management.md
@@ -1,0 +1,94 @@
+# ID management in CL
+
+## Temporary IDs
+
+“Temporary IDs” are an experimental mechanism to allow editors to mint
+new term IDs without worrying about potential conflicting IDs.
+
+This is primarily intended for AI agents, which are likely to open many
+PRs in parallel but have to share a single ID range (contrary to human
+editors, who all have their own range) and have no way of keeping track
+of which IDs are being used in concurrent PRs (again contrary to human
+editors, who can rely on Protégé for that).
+
+However temporary IDs are in no way restricted to AI agents, and any
+editor could use them if they so want. For example, they could be useful
+for an _external_, _occasional_ editor – someone who is not a known
+contributor to CL and for whom we may not necessarily want to allocate a
+dedicated ID range.
+
+### Editing the ontology with temporary IDs
+
+From an editor’s point of view, all that is needed to use temporary IDs
+is to use the `Temporary IDs` range defined in the `cl-idranges.owl`
+file.
+
+For editors using Protégé, this means selecting said `Temporary IDs`
+range when Protégé asks you to select an ID range policy, just after
+having opened the Uberon edit file.
+
+For other editors (including AI agents), this means making sure that
+whenever a new ID is needed, it is generated within the range allocated
+to `Temporary IDs` (it should normally be `CL:99NNNNN`, but please check
+the contents of the `cl-idranges.owl` file, just in case the range is
+changed in the future).
+
+### Replacing temporary IDs with definitive IDs
+
+Replacing temporary IDs with definitive IDs is done by invoking the
+`allocate-definitive-ids` target:
+
+```sh
+sh run.sh make allocate-definitive-ids
+```
+
+This will find all temporary IDs within the ontology and replace them
+with newly allocated definitive IDs picked from within the `Automation`
+range defined in the `cl-idranges.owl` file. All axioms that were
+referring to temporary IDs will be automatically re-written so that they
+refer to the corresponding newly allocated definitive IDs.
+
+This replacement must be performed at the latest possible stage, just
+before a PR is merged. If temporary IDs in a PR are replaced by
+definitive IDs, and the PR is then left unmerged for a while, then ID
+conflicts may occur when the PR is finally merged.
+
+For convenience, a GitHub Actions workflow is available to perform the
+ID replacement step on a PR without requiring a CL maintainer to
+check out the PR and invoke the `allocate-definitive-ids` manually. When
+a PR containing temporary IDs has been deemed OK for merging, a
+maintainer should trigger the `allocate-definitive-ids` GitHub Actions
+workflow on the PR’s branch, wait for that workflow to terminate (it
+should take a couple of minutes at most), and then _immediately_ merge
+the PR.
+
+Of note, the `allocate-definitive-ids` GitHub Actions workflow requires
+that a `ID_ALLOCATION_TOKEN` secret exist in the repository, associated
+to an account that is allowed to push to the repository.
+
+### Automatic replacement of temporary IDs upon pushing to master
+
+Alternatively, a PR containing temporary IDs can be merged “as is” to
+the master branch. This will then trigger an automatic ID replacement
+operation (made by the same `allocate-definitive-ids` GitHub Actions
+workflow), directly on the master branch.
+
+Compared to the approach above, where the ID replacement is done on the
+PR _prior to merging_, this approach has the following advantages:
+
+* it is entirely automated, and does not require any manual intervention
+  from a maintainer;
+* it eliminates the risk of an ID conflict still occurring between the
+  moment IDs are replaced on a PR and the moment the PR is merged.
+
+It has the inconvenient that it lets temporary IDs becoming part of the
+history of the master branch, which may make perusing the history more
+cumbersome as the history will be “polluted” by commits that do nothing
+more than rewriting IDs. With the “replace-before-merging” approach,
+such commits can be made invisible if the PR is small enough to allow
+for a “squash merge” instead of a normal merge – then only the
+definitive IDs will only ever make it to the master branch.
+
+This approach additionally requires that the account associated to the
+`ID_ALLOCATION_TOKEN` secret be allowed to push to the repository’s
+master branch (bypassing the branch protection normally in place in CL).

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -36,5 +36,6 @@ nav:
       - Importing classes from another ontology: Adding_classes_from_another_ontology.md
       - Resolving merge conflicts: resolving_merge_conflicts.md
       - Taxon constraints: taxon-restrictions.md
+      - Managing terms IDs: id-management.md
   - Contact: contact_us.md
 

--- a/src/ontology/cl-idranges.owl
+++ b/src/ontology/cl-idranges.owl
@@ -501,3 +501,15 @@ Datatype: idrange:80
         allocatedto: "BICAN, automatic generation"
     EquivalentTo:
         xsd:integer[>= 4300001, < 4800000]
+
+Datatype: idrange:81
+    Annotations:
+        allocatedto: "Temporary IDs"
+    EquivalentTo:
+        xsd:integer[>= 9900000, < 10000000]
+
+Datatype: idrange:82
+    Annotations:
+        allocatedto: "Automation"
+    EquivalentTo:
+        xsd:integer[>= 20000, < 120000]

--- a/src/ontology/cl.Makefile
+++ b/src/ontology/cl.Makefile
@@ -280,6 +280,14 @@ add-replacedby:
 		       --collapse-import-closure false \
 		 convert -f ofn -o $(SRC)
 
+# Allocating definitive IDs
+.PHONY: allocate-definitive-ids
+allocate-definitive-ids: | all_robot_plugins
+	$(ROBOT) kgcl:mint -i $(SRC) \
+		           --temp-id-prefix http://purl.obolibrary.org/obo/CL_99 \
+		           --id-range-name Automation \
+		 convert -f ofn -o $(SRC)
+
 
 # ----------------------------------------
 # EXTERNAL RESOURCES


### PR DESCRIPTION
This PR ports to CL the temporary ID management system already in use in Uberon, for allowing AI agents (or in fact any editor, AI or not) to use “temporary” IDs that are to be later replaced by definitive IDs.

It allocates two new ID ranges:

* the `Temporary IDs` range (CL:99NNNNN): any ID picked within that range is treated as a temporary ID, slated for later replacement by a definitive ID;
* the `Automation` range (CL:0020000–CL:0120000): this is a “normal” ID range (IDs picked within that range are not treated differently from any other ID), but is reserved for automated processes – notably, for the process that replaces temporary IDs by definitive ones.

It also adds a new GitHub Action workflow, `allocate-definitive-ids`, which when triggered finds all temporary IDs (all IDs in the CL:99NNNNN range) in the cl-edit.owl file and replaces them by newly allocated IDs from the `Automation` range. That workflow can be used in two different ways:

(A) Manual trigger: When a PR contains temporary IDs, a CL maintainer can manually trigger the `allocate-definitive-ids` workflow on the PR’s underlying branch, _just before_ merging the PR into the master branch. This will automatically add a commit to the PR, in which temporary IDs are replaced by definitive ones. The PR should then be merged _as soon as possible_ once that commit has been added.

(B) Automatic trigger: If a PR containing temporary IDs is merged into the master branch (with the temporary IDs still present), the `allocate-definitive-ids` workflow will automatically be triggered and push a new commmit to replace the temporary IDs by definitive ones, directly on the master branch.