### PR TITLE
Test: Move an axiom out of place.

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -7050,10 +7050,10 @@ SubClassOf(obo:CL_0000384 obo:CL_0000630)
 
 # Class: obo:CL_0000385 (prohemocyte (sensu Nematoda and Protostomia))
 
+SubClassOf(obo:CL_0000385 obo:CL_0008001)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1016/B978-012369493-5.50008-0") obo:IAO_0000115 obo:CL_0000385 "A precursor of mature hemocytes.")
 AnnotationAssertion(obo:RO_0002161 obo:CL_0000385 obo:NCBITaxon_33511)
 AnnotationAssertion(rdfs:label obo:CL_0000385 "prohemocyte (sensu Nematoda and Protostomia)")
-SubClassOf(obo:CL_0000385 obo:CL_0008001)
 
 # Class: obo:CL_0000386 (obsolete attachment cell)
 


### PR DESCRIPTION
This PR is a test for the "allocate definitive IDs" GitHub Action. It simply moves an axiom slightly out of place -- this has no meaningful consequences, but should trigger the action to reserialize the edit file to restore the canonical order of axioms.