### PR TITLE
Test: Move an axiom out of place (4).

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -4793,10 +4793,10 @@ AnnotationAssertion(owl:deprecated obo:CL_0000111 "true"^^xsd:boolean)
 
 # Class: obo:CL_0000112 (columnar neuron)
 
+SubClassOf(obo:CL_0000112 obo:CL_0000028)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:34696823") Annotation(oboInOwl:hasDbXref "PMID:37608556") obo:IAO_0000115 obo:CL_0000112 "A neuron of the invertebrate central nervous system. This neuron innervates the central complex (CX) of an invertebrate brain and it forms columnar patterns with its dendrites. It is involved in navigation and spatial processing.")
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:18837039") Annotation(oboInOwl:hasDbXref "PMID:32374034") Annotation(oboInOwl:hasDbXref "PMID:34696823") Annotation(oboInOwl:hasDbXref "PMID:37608556") Annotation(oboInOwl:hasDbXref "PMID:9153131") rdfs:comment obo:CL_0000112 "Columnar neurons have been widely studied in Diptera, locusts, honey bees and other insects. In the mammalian brain, a \"columnar organisation\" is referred to neurons of the neocortex, however these differ from columnar neurons which are found in the insects central nervous system.")
 AnnotationAssertion(rdfs:label obo:CL_0000112 "columnar neuron")
-SubClassOf(obo:CL_0000112 obo:CL_0000028)
 SubClassOf(obo:CL_0000112 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001017))
 SubClassOf(obo:CL_0000112 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0000338))
 SubClassOf(obo:CL_0000112 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0007601))


### PR DESCRIPTION
This commit is a test for the "allocate definitive IDs" GitHub Action. It simply moves an axiom slightly out of place -- this has no meaningful consequences, but should trigger the action to reserialize the edit file to restore the canonical order of axioms.