### PR TITLE
Produce and publish release artefacts as SemSQL DB files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,10 @@ src/patterns/all_pattern_terms.txt
 cl-non-classified.*
 cl-plus.*
 
+# SemSQL files (compressed and uncompressed)
+*.db
+*.db.gz
+
 # Auto-generated mapping files
 src/mappings/cl-local.sssom.tsv
 src/mappings/cl.sssom.tsv

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -10,7 +10,7 @@
 # More information: https://github.com/INCATools/ontology-development-kit/
 
 # Fingerprint of the configuration file when this Makefile was last generated
-CONFIG_HASH=                2566b3b0aecd78983d50bf49e62631a8eb95a153d416c6f4113d2843fd69d7fe
+CONFIG_HASH=                e584d2d6e23caeef045397b6870989b94f7ed5fc973e3b51769514058f55c54d
 
 
 # ----------------------------------------
@@ -73,7 +73,7 @@ MAPPINGS=                   cl-local cl fbbt zfa
 MAPPING_RELEASE_FILES=      $(foreach n,$(MAPPINGS), $(MAPPINGDIR)/$(n).sssom.tsv)
 
 
-FORMATS = $(sort  owl obo json db owl)
+FORMATS = $(sort  owl obo json owl)
 FORMATS_INCL_TSV = $(sort $(FORMATS) tsv)
 RELEASE_ARTEFACTS = $(sort $(ONT)-base $(ONT)-full $(ONT)-simple $(ONT)-basic $(ONT)-non-classified cl-plus )
 
@@ -988,11 +988,6 @@ cl-plus.json: cl-plus.owl
 	$(ROBOT) annotate --input $< --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) \
 		convert --check false -f json -o $@.tmp.json &&\
 		mv $@.tmp.json $@
-%.db: %.owl
-	@rm -f $*.db $*-relation-graph.tsv.gz .template.db .template.db.tmp
-	semsql make $*.db
-	@rm -f $*-relation-graph.tsv.gz .template.db .template.db.tmp
-	@test -f $*.db || (echo "SQLite/SemSQL generation failed" && exit 1)
 # ----------------------------------------
 # Release artefacts: main release artefacts
 # ----------------------------------------

--- a/src/ontology/cl-odk.yaml
+++ b/src/ontology/cl-odk.yaml
@@ -15,7 +15,6 @@ export_formats:
   - owl
   - obo
   - json
-  - db
 obo_format_options: --clean-obo 'simple merge-comments'
 namespaces: 
   - http://purl.obolibrary.org/obo/CP_

--- a/src/ontology/cl.Makefile
+++ b/src/ontology/cl.Makefile
@@ -221,7 +221,7 @@ subsets/%-view.owl subsets/%-tags.ofn: $(ONT)-full.owl | all_robot_plugins
 		 annotate --ontology-iri $(ONTBASE)/subsets/$*-view.owl \
 		          --version-iri $(ONTBASE)/releases/$(VERSION)/subsets/$*-view.owl \
 		          --annotation owl:versionInfo $(VERSION) \
-		          --output subsets/$*-view.owl
+		 convert --format ofn --output subsets/$*-view.owl
 
 
 # ----------------------------------------
@@ -307,6 +307,25 @@ endif
 
 update-HRA-illustrations:
 	python3 ./$(SCRIPTSDIR)/2D_FTU_images.py
+
+
+# ----------------------------------------
+# SemSQL release artefacts
+# ----------------------------------------
+# We do _not_ use the ODK builtin feature for now because it only
+# creates _uncompressed_ DB files, which are way too large to be
+# practical.
+
+DB_FILES = cl.db.gz $(foreach f, $(RELEASE_ARTEFACTS), $f.db.gz)
+RELEASE_ASSETS += $(DB_FILES)
+all_assets: $(DB_FILES)
+
+%.db.gz: %.owl
+	@rm -f $*.db $*.db.gz $*-relation-graph.tsv.gz .template.db .template.db.tmp
+	semsql make $*.db
+	@test -f $*.db || (echo "SQLite/SemSQL generation failed" && exit 1)
+	gzip $*.db
+	@rm -f $*-relation-graph.tsv.gz .template.db .template.db.tmp
 
 # ----------------------------------------
 # RELEASE DEPLOYMENT


### PR DESCRIPTION
This PR enables the production of SemSQL versions of the release artefacts, suitable for use by the Ontology Access Kit’s [SQL Database adapter](https://incatools.github.io/ontology-access-kit/packages/implementations/sqldb.html#sql-implementation).

Few things to note:

* This required changing the format of the various `-view.owl` subsets from OFN to RDF/XML, because [RDFTab.rs](https://github.com/ontodev/rdftab.rs) (a critical tool in the pipeline that produces the SemSQL files) only supports the RDF/XML format. This should not be a big deal, but it will cause massive diffs upon the next release (when the newly generated subsets will be committed), because all the `-view.owl` subsets will be completely rewritten from OFN to RDF/XML. (This could easily be avoided if we just stopped committing the subsets to the repository – they are _release artefacts_, not files that need to be tracked.)

* This adds ~2.6 GB worth of release artefacts to be uploaded upon every release. Depending on the network connection available, this could make publishing a release quite slow.

* The largest release artefact (`cl-plus`) is about ~1.1 GB in SemSQL format. The [limit for a release artefact](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#storage-and-bandwidth-quotas) on GitHub is 2 GB – so we have some margin, but maybe not that much.

* The PR also cleans up the `.gitignore` file, since it needed to be amended to be sure none of the SemSQL files will ever be inadvertently committed.

closes #3396