### PR TITLE
added dc/terms/creator to sparql list + updated claude.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ terms to "skip" the obsoleted term.
 
 - Link back to the issue you are dealing with using the `term_tracker_item`
 - All terms should have definitions, with at least one definition xref, ideally a PMID
-- You can sign terms as `dc:creator "GitHub Copilot"` only when creating new terms. You should not add yourself as a creator if you are editing existing terms.
+- You can sign terms as `terms:creator "GitHub Copilot"` only when creating new terms. You should not add yourself as a creator if you are editing existing terms. (Note: terms: is the prefix for http://purl.org/dc/terms/)
 
 ## Relationships
 

--- a/src/sparql/illegal-annotation-property-violation.sparql
+++ b/src/sparql/illegal-annotation-property-violation.sparql
@@ -31,6 +31,7 @@ SELECT DISTINCT ?term ?annotation WHERE {
     <http://purl.org/dc/terms/description>,
     <http://purl.org/dc/terms/source>,
     <http://purl.org/dc/terms/contributor>,
+    <http://purl.org/dc/terms/creator>,
     <http://purl.org/dc/elements/1.1/creator>,
     <http://purl.org/spar/cito/citesAsAuthority>,
     <http://www.geneontology.org/formats/oboInOwl#consider>,


### PR DESCRIPTION
added dc/terms/creator to sparql list of allowed annotation properties.
+ updated claude.md to use terms:creator instead of dc:creator.