### PR TITLE
Fixed #3552 hierarchy for listed cells

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -33613,6 +33613,7 @@ AnnotationAssertion(terms:date obo:CL_4042026 "2024-09-23T13:56:01Z"^^xsd:dateTi
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:36148148") Annotation(oboInOwl:hasSynonymType obo:OMO_0003000) oboInOwl:hasRelatedSynonym obo:CL_4042026 "aSNpr")
 AnnotationAssertion(rdfs:label obo:CL_4042026 "GABAergic interneuron of the anterior substantia nigra pars reticulata"@en)
 SubClassOf(obo:CL_4042026 obo:CL_0002614)
+SubClassOf(obo:CL_4042026 obo:CL_0011005)
 SubClassOf(obo:CL_4042026 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000007643))
 SubClassOf(obo:CL_4042026 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000013047))
 SubClassOf(obo:CL_4042026 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000014898))
@@ -35413,6 +35414,34 @@ SubClassOf(obo:CL_4072104 ObjectSomeValuesFrom(obo:RO_0002202 obo:CL_0020021))
 SubClassOf(obo:CL_4072104 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000003264))
 SubClassOf(obo:CL_4072104 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000003328))
 SubClassOf(obo:CL_4072104 ObjectSomeValuesFrom(obo:RO_0002292 obo:PR_000003353))
+
+# Class: obo:CL_4310109 (SN-VTR CALB1 Dopa substantia nigra dopaminergic neuron (Primate))
+
+SubClassOf(obo:CL_4310109 obo:CL_4042025)
+
+# Class: obo:CL_4310111 (SN-VTR GAD2 Dopa dopaminergic neuron (Primate))
+
+SubClassOf(obo:CL_4310111 obo:CL_4042025)
+
+# Class: obo:CL_4310113 (SN GATA3-PVALB GABA GABAergic neuron (Primate))
+
+SubClassOf(obo:CL_4310113 obo:CL_4042026)
+
+# Class: obo:CL_4310115 (SN SOX6 Dopa substantia nigra dopaminergic neuron (Primate))
+
+SubClassOf(obo:CL_4310115 obo:CL_4042025)
+
+# Class: obo:CL_4310131 (STRd D1/D2-hybrid medium spiny neuron (Primate))
+
+SubClassOf(obo:CL_4310131 obo:CL_4030050)
+
+# Class: obo:CL_4310133 (STRd D2 Striomat hybrid medium spiny neuron (Primate))
+
+SubClassOf(obo:CL_4310133 obo:CL_0002613)
+
+# Class: obo:CL_4310148 (OB FRMD7 GABA GABAergic neuron (Primate))
+
+SubClassOf(obo:CL_4310148 obo:CL_0000617)
 
 # Class: obo:CL_7770002 (juxtacanalicular tissue cell)
 

--- a/src/ontology/components/bgo-cl-comp.owl
+++ b/src/ontology/components/bgo-cl-comp.owl
@@ -2241,17 +2241,6 @@
     <!-- http://purl.obolibrary.org/obo/CL_4310109 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_4310109">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CL_0000000"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0015001"/>
-                        <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0029"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0015001"/>
@@ -2377,17 +2366,6 @@
     <!-- http://purl.obolibrary.org/obo/CL_4310111 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_4310111">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CL_0000000"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0015001"/>
-                        <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0031"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0015001"/>
@@ -2522,17 +2500,6 @@
     <!-- http://purl.obolibrary.org/obo/CL_4310113 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_4310113">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CL_0000000"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0015001"/>
-                        <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0033"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0015001"/>
@@ -2668,17 +2635,6 @@
     <!-- http://purl.obolibrary.org/obo/CL_4310115 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_4310115">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CL_0000000"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0015001"/>
-                        <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0035"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0015001"/>
@@ -3580,17 +3536,6 @@
     <!-- http://purl.obolibrary.org/obo/CL_4310131 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_4310131">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CL_0000000"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0015001"/>
-                        <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0051"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0015001"/>
@@ -3717,17 +3662,6 @@
     <!-- http://purl.obolibrary.org/obo/CL_4310133 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_4310133">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CL_0000000"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0015001"/>
-                        <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0053"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0015001"/>
@@ -4432,17 +4366,6 @@
     <!-- http://purl.obolibrary.org/obo/CL_4310148 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CL_4310148">
-        <owl:equivalentClass>
-            <owl:Class>
-                <owl:intersectionOf rdf:parseType="Collection">
-                    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CL_0000000"/>
-                    <owl:Restriction>
-                        <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0015001"/>
-                        <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0068"/>
-                    </owl:Restriction>
-                </owl:intersectionOf>
-            </owl:Class>
-        </owl:equivalentClass>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0015001"/>
@@ -9685,5 +9608,5 @@
 
 
 
-<!-- Generated by the OWL API (version 4.5.29) https://github.com/owlcs/owlapi -->
+<!-- Generated by the OWL API (version 4.5.29.2024-05-13T12:11:03Z) https://github.com/owlcs/owlapi -->
 


### PR DESCRIPTION
Fixes #3552 

Added relevant parent to OB FRMD7 GABA GABAergic neuron (Primate) SN GATA3-PVALB GABA GABAergic neuron (Primate)
SN SOX6 Dopa substantia nigra dopaminergic neuron (Primate) 
SN-VTR CALB1 Dopa substantia nigra dopaminergic neuron (Primate) 
SN-VTR GAD2 Dopa dopaminergic neuron (Primate)
STRd D1/D2-hybrid medium spiny neuron (Primate)
STRd D2 Striomat hybrid medium spiny neuron (Primate)

- Added subclass Gabaergic interneuron to: GABAergic interneuron of the anterior substantia nigra pars reticulata.