### PR TITLE
Hotfix: remove assay term from bgo and wmbo components

### DIFF
--- a/src/ontology/cl.Makefile
+++ b/src/ontology/cl.Makefile
@@ -300,6 +300,22 @@ CELLXGENE_SUBSET_URL="https://raw.githubusercontent.com/hkir-dev/cellxgene-cell-
 $(TEMPLATEDIR)/cellxgene_subset.tsv: .FORCE
 	wget $(CELLXGENE_SUBSET_URL) -O $@
 
+# Override wmbo-cl-comp.owl to remove OBI:0000070 (assay) from the component
+# This is a hotfix while https://github.com/obophenotype/cell-ontology/issues/3578 is being resolved
+.PHONY: component-download-wmbo-cl-comp.owl
+component-download-wmbo-cl-comp.owl: | $(TMPDIR)
+	$(ROBOT) merge -I https://raw.githubusercontent.com/Cellular-Semantics/whole_mouse_brain_ontology/main/wmbo-cl-comp.owl \
+		 remove --term OBI:0000070 \
+		 annotate --annotation owl:versionInfo $(VERSION) --output $(TMPDIR)/$@.owl
+
+# Override bgo-cl-comp.owl to remove OBI:0000070 (assay) from the component
+# This is a hotfix while https://github.com/obophenotype/cell-ontology/issues/3578 is being resolved
+.PHONY: component-download-bgo-cl-comp.owl
+component-download-bgo-cl-comp.owl: | $(TMPDIR)
+	$(ROBOT) merge -I https://raw.githubusercontent.com/Cellular-Semantics/hmba_basal_ganglia_ontology/main/bgo-cl-comp.owl \
+		 remove --term OBI:0000070 \
+		 annotate --annotation owl:versionInfo $(VERSION) --output $(TMPDIR)/$@.owl
+
 endif
 
 # Update the list of terms with 2D FTU images from HRA

--- a/src/ontology/components/bgo-cl-comp.owl
+++ b/src/ontology/components/bgo-cl-comp.owl
@@ -11,8 +11,8 @@
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
      xmlns:CCN20230722="https://purl.brain-bican.org/taxonomy/CCN20230722#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/cl/components/bgo-cl-comp.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/cl/releases/2026-02-19/components/bgo-cl-comp.owl"/>
-        <owl:versionInfo>2026-02-19</owl:versionInfo>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/cl/releases/2026-02-28/components/bgo-cl-comp.owl"/>
+        <owl:versionInfo>2026-02-28</owl:versionInfo>
     </owl:Ontology>
     
 
@@ -77,12 +77,6 @@
     <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0000070 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0000070"/>
     
 
 
@@ -1531,8 +1525,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0003"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10343"/>
         <obo:IAO_0000028>GPin-BF Cholinergic GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A GABA-Chol neuron of the Primates brain. These cells are located in the striatum, external segment of globus pallidus . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:GPin-BF Cholinergic GABA.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>GPin-BF Cholinergic GABA</oboInOwl:hasExactSynonym>
@@ -1541,22 +1533,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBR1Bpbi1CRiBDaG9saW5lcmdpYyBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChMpFmYR%2BVoYDhQxy%2FoU8XEUEV01QOE5NSjVEOFhPMUFPSTFMOQAFg2xvMYI24kGDwAnEgzgCUgAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACElBNlk2U043UVpTSUVKMEZaMFUACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALATc0MTZCNVhKRFNZMEhERjkzUk8AAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAVZNNEU2SjlEUFlZRDdFMEJITkIAAktHWkxBV0lQQ1I0Vzk4RjVMRDYAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAUdQaW4tQkYgQ2hvbGluZXJnaWMgR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoX%2BWYiFjtcfA4YKpk6F9JyqBFdNUDhOTUo1RDhYTzFBT0kxTDkABYQUxBaDjMVShGJpv4S050sGAAcAAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIOUFVVEU5UzEwS0FFQzJVWk8zMQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBWTNQMUpNMUVOQ0dXRVc4VVNUVgACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABM0NQSVAyODA0U0JEWDFEWDFSVwACUzVLUVRGSENSS0hWWlZSUjVIUgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBR1Bpbi1CRiBDaG9saW5lcmdpYyBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFHUGluLUJGIENob2xpbmVyZ2ljIEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAQKBItJbgQi1PgOEXt1mg%2Bp7yQAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACEZUTEFVT1Y2U0xCMDcxU1ZOVTkACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAggA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310083"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.2</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310083"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10343"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310083"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -1600,7 +1576,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0004"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050484"/>
         <obo:IAO_0000028>LAMP5-CXCL14 GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A lamp5 GABAergic interneuron of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:LAMP5-CXCL14 GABA.</obo:IAO_0000115>
@@ -1612,14 +1587,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBTEFNUDUtQ1hDTDE0IEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKEykWZhH5WhgOFDHL%2BhTxcRQRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWDbG8xgjbiQYPACcSDOAJSAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAISUE2WTZTTjdRWlNJRUowRlowVQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBNzQxNkI1WEpEU1kwSERGOTNSTwACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABVk00RTZKOURQWVlEN0UwQkhOQgACS0daTEFXSVBDUjRXOThGNUxENgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBTEFNUDUtQ1hDTDE0IEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKF%2FlmIhY7XHwOGCqZOhfScqgRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWEFMQWg4zFUoRiab%2BEtOdLBgAHAAAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACDlBVVRFOVMxMEtBRUMyVVpPMzEACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAVkzUDFKTTFFTkNHV0VXOFVTVFYAAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAATNDUElQMjgwNFNCRFgxRFgxUlcAAlM1S1FURkhDUktIVlpWUlI1SFIAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAUxBTVA1LUNYQ0wxNCBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFMQU1QNS1DWENMMTQgR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEBAoEi0luBCLU%2BA4Re3WaD6nvJAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIRlRMQVVPVjZTTEIwNzFTVk5VOQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACCAA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310084"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.5</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310084"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -1663,7 +1630,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0005"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050485"/>
         <obo:IAO_0000028>LAMP5-LHX6 GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A Lamp5 Lhx6 neuron of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:LAMP5-LHX6 GABA.</obo:IAO_0000115>
@@ -1674,14 +1640,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBTEFNUDUtTEhYNiBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChMpFmYR%2BVoYDhQxy%2FoU8XEUEV01QOE5NSjVEOFhPMUFPSTFMOQAFg2xvMYI24kGDwAnEgzgCUgAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACElBNlk2U043UVpTSUVKMEZaMFUACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALATc0MTZCNVhKRFNZMEhERjkzUk8AAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAVZNNEU2SjlEUFlZRDdFMEJITkIAAktHWkxBV0lQQ1I0Vzk4RjVMRDYAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAUxBTVA1LUxIWDYgR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoX%2BWYiFjtcfA4YKpk6F9JyqBFdNUDhOTUo1RDhYTzFBT0kxTDkABYQUxBaDjMVShGJpv4S050sGAAcAAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIOUFVVEU5UzEwS0FFQzJVWk8zMQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBWTNQMUpNMUVOQ0dXRVc4VVNUVgACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABM0NQSVAyODA0U0JEWDFEWDFSVwACUzVLUVRGSENSS0hWWlZSUjVIUgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBTEFNUDUtTEhYNiBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFMQU1QNS1MSFg2IEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAQKBItJbgQi1PgOEXt1mg%2Bp7yQAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACEZUTEFVT1Y2U0xCMDcxU1ZOVTkACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAggA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310085"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.5</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310085"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -1725,8 +1683,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0008"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10343"/>
         <obo:IAO_0000028>BF SKOR1 Glut (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A glutamatergic neuron of the basal ganglia of the Primates brain. These cells are located in the striatum, external segment of globus pallidus . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:BF SKOR1 Glut.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>BF SKOR1 Glut</oboInOwl:hasExactSynonym>
@@ -1735,22 +1691,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBQkYgU0tPUjEgR2x1dAAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoTKRZmEflaGA4UMcv6FPFxFBFdNUDhOTUo1RDhYTzFBT0kxTDkABYNsbzGCNuJBg8AJxIM4AlIABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhJQTZZNlNON1FaU0lFSjBGWjBVAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE3NDE2QjVYSkRTWTBIREY5M1JPAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFWTTRFNko5RFBZWUQ3RTBCSE5CAAJLR1pMQVdJUENSNFc5OEY1TEQ2AAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFCRiBTS09SMSBHbHV0AAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChf5ZiIWO1x8DhgqmToX0nKoEV01QOE5NSjVEOFhPMUFPSTFMOQAFhBTEFoOMxVKEYmm%2FhLTnSwYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAg5QVVURTlTMTBLQUVDMlVaTzMxAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwFZM1AxSk0xRU5DR1dFVzhVU1RWAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAEzQ1BJUDI4MDRTQkRYMURYMVJXAAJTNUtRVEZIQ1JLSFZaVlJSNUhSAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFCRiBTS09SMSBHbHV0AAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFCRiBTS09SMSBHbHV0AAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQECgSLSW4EItT4DhF7dZoPqe8kABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhGVExBVU9WNlNMQjA3MVNWTlU5AAlQT1oySENQQlQ2MERTREo4VUE3AAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAIIAA%3D%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0000.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310088"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.2</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310088"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10343"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310088"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -1794,8 +1734,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0013"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10343"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050493"/>
         <obo:IAO_0000028>GPe MEIS2-SOX6 GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A arkypallidal neuron of the Primates brain. These cells are located in the striatum, external segment of globus pallidus . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:GPe MEIS2-SOX6 GABA.</obo:IAO_0000115>
@@ -1806,22 +1744,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBR1BlIE1FSVMyLVNPWDYgR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoTKRZmEflaGA4UMcv6FPFxFBFdNUDhOTUo1RDhYTzFBT0kxTDkABYNsbzGCNuJBg8AJxIM4AlIABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhJQTZZNlNON1FaU0lFSjBGWjBVAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE3NDE2QjVYSkRTWTBIREY5M1JPAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFWTTRFNko5RFBZWUQ3RTBCSE5CAAJLR1pMQVdJUENSNFc5OEY1TEQ2AAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFHUGUgTUVJUzItU09YNiBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChf5ZiIWO1x8DhgqmToX0nKoEV01QOE5NSjVEOFhPMUFPSTFMOQAFhBTEFoOMxVKEYmm%2FhLTnSwYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAg5QVVURTlTMTBLQUVDMlVaTzMxAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwFZM1AxSk0xRU5DR1dFVzhVU1RWAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAEzQ1BJUDI4MDRTQkRYMURYMVJXAAJTNUtRVEZIQ1JLSFZaVlJSNUhSAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFHUGUgTUVJUzItU09YNiBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFHUGUgTUVJUzItU09YNiBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQECgSLSW4EItT4DhF7dZoPqe8kABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhGVExBVU9WNlNMQjA3MVNWTlU5AAlQT1oySENQQlQ2MERTREo4VUE3AAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAIIAA%3D%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310093"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.2</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310093"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10343"/>
-        <obo:CLM_0010002>0.5</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310093"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -1876,8 +1798,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0014"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10343"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050494"/>
         <obo:IAO_0000028>GPe SOX6-CTXND1 GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A prototypic neuron of the Primates brain. These cells are located in the striatum, external segment of globus pallidus . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:GPe SOX6-CTXND1 GABA.</obo:IAO_0000115>
@@ -1887,22 +1807,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBR1BlIFNPWDYtQ1RYTkQxIEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKEykWZhH5WhgOFDHL%2BhTxcRQRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWDbG8xgjbiQYPACcSDOAJSAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAISUE2WTZTTjdRWlNJRUowRlowVQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBNzQxNkI1WEpEU1kwSERGOTNSTwACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABVk00RTZKOURQWVlEN0UwQkhOQgACS0daTEFXSVBDUjRXOThGNUxENgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBR1BlIFNPWDYtQ1RYTkQxIEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKF%2FlmIhY7XHwOGCqZOhfScqgRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWEFMQWg4zFUoRiab%2BEtOdLBgAHAAAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACDlBVVRFOVMxMEtBRUMyVVpPMzEACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAVkzUDFKTTFFTkNHV0VXOFVTVFYAAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAATNDUElQMjgwNFNCRFgxRFgxUlcAAlM1S1FURkhDUktIVlpWUlI1SFIAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAUdQZSBTT1g2LUNUWE5EMSBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFHUGUgU09YNi1DVFhORDEgR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEBAoEi0luBCLU%2BA4Re3WaD6nvJAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIRlRMQVVPVjZTTEIwNzFTVk5VOQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACCAA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310094"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310094"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10343"/>
-        <obo:CLM_0010002>0.8</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310094"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -1953,7 +1857,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0015"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10344"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050495"/>
         <obo:IAO_0000028>GPi Core (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A internal globus pallidus core projecting neuron of the Primates brain. These cells are located in the internal segment of globus pallidus . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:GPi Core.</obo:IAO_0000115>
@@ -1964,14 +1867,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBR1BpIENvcmUAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKEykWZhH5WhgOFDHL%2BhTxcRQRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWDbG8xgjbiQYPACcSDOAJSAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAISUE2WTZTTjdRWlNJRUowRlowVQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBNzQxNkI1WEpEU1kwSERGOTNSTwACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABVk00RTZKOURQWVlEN0UwQkhOQgACS0daTEFXSVBDUjRXOThGNUxENgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBR1BpIENvcmUAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKF%2FlmIhY7XHwOGCqZOhfScqgRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWEFMQWg4zFUoRiab%2BEtOdLBgAHAAAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACDlBVVRFOVMxMEtBRUMyVVpPMzEACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAVkzUDFKTTFFTkNHV0VXOFVTVFYAAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAATNDUElQMjgwNFNCRFgxRFgxUlcAAlM1S1FURkhDUktIVlpWUlI1SFIAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAUdQaSBDb3JlAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFHUGkgQ29yZQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEBAoEi0luBCLU%2BA4Re3WaD6nvJAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIRlRMQVVPVjZTTEIwNzFTVk5VOQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACCAA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310095"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10344"/>
-        <obo:CLM_0010002>0.9</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310095"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -2030,9 +1925,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0016"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10343"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10344"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050496"/>
         <obo:IAO_0000028>GPi Shell (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A internal globus pallidus shell projection neuron of the Primates brain. These cells are located in the striatum, external segment of globus pallidus, internal segment of globus pallidus . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:GPi Shell.</obo:IAO_0000115>
@@ -2044,30 +1936,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIBQ04gR0FCQS1HbHV0AAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChMpFmYR%2BVoYDhQxy%2FoU8XEUEV01QOE5NSjVEOFhPMUFPSTFMOQAFg2xvMYI24kGDwAnEgzgCUgAFAAYBAQIzWEJPRkJSMzAyRVlDMFVRRDUxAAN%2BAAAABAAACElBNlk2U043UVpTSUVKMEZaMFUACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALATc0MTZCNVhKRFNZMEhERjkzUk8AAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAVZNNEU2SjlEUFlZRDdFMEJITkIAAktHWkxBV0lQQ1I0Vzk4RjVMRDYAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAUNOIEdBQkEtR2x1dAAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoX%2BWYiFjtcfA4YKpk6F9JyqBFdNUDhOTUo1RDhYTzFBT0kxTDkABYQUxBaDjMVShGJpv4S050sGAAcAAAUABgEBAjNYQk9GQlIzMDJFWUMwVVFENTEAA34AAAAEAAAIOUFVVEU5UzEwS0FFQzJVWk8zMQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBWTNQMUpNMUVOQ0dXRVc4VVNUVgACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABM0NQSVAyODA0U0JEWDFEWDFSVwACUzVLUVRGSENSS0hWWlZSUjVIUgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIBQ04gR0FCQS1HbHV0AAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECM1hCT0ZCUjMwMkVZQzBVUUQ1MQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgFDTiBHQUJBLUdsdXQAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAQKBItJbgQi1PgOEXt1mg%2Bp7yQAFAAYBAQIzWEJPRkJSMzAyRVlDMFVRRDUxAAN%2BAAAABAAACEZUTEFVT1Y2U0xCMDcxU1ZOVTkACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAggA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0003.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310096"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310096"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10343"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310096"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10344"/>
-        <obo:CLM_0010002>0.6</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310096"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -2120,8 +1988,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0020"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10343"/>
         <obo:IAO_0000028>GPe-NDB-SI LHX6-LHX8-GBX1 GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A GABAergic interneuron of the Primates brain. These cells are located in the striatum, external segment of globus pallidus . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:GPe-NDB-SI LHX6-LHX8-GBX1 GABA.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>GPe-NDB-SI LHX6-LHX8-GBX1 GABA</oboInOwl:hasExactSynonym>
@@ -2130,22 +1996,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBR1BlLU5EQi1TSSBMSFg2LUxIWDgtR0JYMSBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChMpFmYR%2BVoYDhQxy%2FoU8XEUEV01QOE5NSjVEOFhPMUFPSTFMOQAFg2xvMYI24kGDwAnEgzgCUgAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACElBNlk2U043UVpTSUVKMEZaMFUACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALATc0MTZCNVhKRFNZMEhERjkzUk8AAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAVZNNEU2SjlEUFlZRDdFMEJITkIAAktHWkxBV0lQQ1I0Vzk4RjVMRDYAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAUdQZS1OREItU0kgTEhYNi1MSFg4LUdCWDEgR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoX%2BWYiFjtcfA4YKpk6F9JyqBFdNUDhOTUo1RDhYTzFBT0kxTDkABYQUxBaDjMVShGJpv4S050sGAAcAAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIOUFVVEU5UzEwS0FFQzJVWk8zMQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBWTNQMUpNMUVOQ0dXRVc4VVNUVgACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABM0NQSVAyODA0U0JEWDFEWDFSVwACUzVLUVRGSENSS0hWWlZSUjVIUgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBR1BlLU5EQi1TSSBMSFg2LUxIWDgtR0JYMSBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFHUGUtTkRCLVNJIExIWDYtTEhYOC1HQlgxIEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAQKBItJbgQi1PgOEXt1mg%2Bp7yQAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACEZUTEFVT1Y2U0xCMDcxU1ZOVTkACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAggA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310100"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.2</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310100"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10343"/>
-        <obo:CLM_0010002>0.2</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310100"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -2189,7 +2039,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0024"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050504"/>
         <obo:IAO_0000028>OT D1 ICj (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A Island of Calleja granule cell of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:OT D1 ICj.</obo:IAO_0000115>
@@ -2201,14 +2050,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBT1QgRDEgSUNqAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChMpFmYR%2BVoYDhQxy%2FoU8XEUEV01QOE5NSjVEOFhPMUFPSTFMOQAFg2xvMYI24kGDwAnEgzgCUgAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACElBNlk2U043UVpTSUVKMEZaMFUACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALATc0MTZCNVhKRFNZMEhERjkzUk8AAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAVZNNEU2SjlEUFlZRDdFMEJITkIAAktHWkxBV0lQQ1I0Vzk4RjVMRDYAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAU9UIEQxIElDagAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoX%2BWYiFjtcfA4YKpk6F9JyqBFdNUDhOTUo1RDhYTzFBT0kxTDkABYQUxBaDjMVShGJpv4S050sGAAcAAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIOUFVVEU5UzEwS0FFQzJVWk8zMQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBWTNQMUpNMUVOQ0dXRVc4VVNUVgACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABM0NQSVAyODA0U0JEWDFEWDFSVwACUzVLUVRGSENSS0hWWlZSUjVIUgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBT1QgRDEgSUNqAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFPVCBEMSBJQ2oAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAQKBItJbgQi1PgOEXt1mg%2Bp7yQAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACEZUTEFVT1Y2U0xCMDcxU1ZOVTkACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAggA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310104"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>1.0</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310104"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -2258,7 +2099,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0029"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_12251"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050509"/>
         <obo:IAO_0000028>SN-VTR CALB1 Dopa (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A substantia nigra dopaminergic neuron of the Primates brain. These cells are located in the substantia nigra . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:SN-VTR CALB1 Dopa.</obo:IAO_0000115>
@@ -2268,14 +2108,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU04tVlRSIENBTEIxIERvcGEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKEykWZhH5WhgOFDHL%2BhTxcRQRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWDbG8xgjbiQYPACcSDOAJSAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAISUE2WTZTTjdRWlNJRUowRlowVQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBNzQxNkI1WEpEU1kwSERGOTNSTwACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABVk00RTZKOURQWVlEN0UwQkhOQgACS0daTEFXSVBDUjRXOThGNUxENgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU04tVlRSIENBTEIxIERvcGEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKF%2FlmIhY7XHwOGCqZOhfScqgRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWEFMQWg4zFUoRiab%2BEtOdLBgAHAAAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACDlBVVRFOVMxMEtBRUMyVVpPMzEACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAVkzUDFKTTFFTkNHV0VXOFVTVFYAAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAATNDUElQMjgwNFNCRFgxRFgxUlcAAlM1S1FURkhDUktIVlpWUlI1SFIAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAVNOLVZUUiBDQUxCMSBEb3BhAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTTi1WVFIgQ0FMQjEgRG9wYQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEBAoEi0luBCLU%2BA4Re3WaD6nvJAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIRlRMQVVPVjZTTEIwNzFTVk5VOQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACCAA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0000.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310109"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_12251"/>
-        <obo:CLM_0010002>0.7</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310109"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -2326,8 +2158,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0030"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_12251"/>
         <obo:IAO_0000028>SN EBF2 GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A GABAergic interneuron of the Primates brain. These cells are located in the striatum, substantia nigra . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:SN EBF2 GABA.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>SN EBF2 GABA</oboInOwl:hasExactSynonym>
@@ -2336,22 +2166,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU04gRUJGMiBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChMpFmYR%2BVoYDhQxy%2FoU8XEUEV01QOE5NSjVEOFhPMUFPSTFMOQAFg2xvMYI24kGDwAnEgzgCUgAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACElBNlk2U043UVpTSUVKMEZaMFUACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALATc0MTZCNVhKRFNZMEhERjkzUk8AAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAVZNNEU2SjlEUFlZRDdFMEJITkIAAktHWkxBV0lQQ1I0Vzk4RjVMRDYAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAVNOIEVCRjIgR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoX%2BWYiFjtcfA4YKpk6F9JyqBFdNUDhOTUo1RDhYTzFBT0kxTDkABYQUxBaDjMVShGJpv4S050sGAAcAAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIOUFVVEU5UzEwS0FFQzJVWk8zMQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBWTNQMUpNMUVOQ0dXRVc4VVNUVgACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABM0NQSVAyODA0U0JEWDFEWDFSVwACUzVLUVRGSENSS0hWWlZSUjVIUgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU04gRUJGMiBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTTiBFQkYyIEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAQKBItJbgQi1PgOEXt1mg%2Bp7yQAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACEZUTEFVT1Y2U0xCMDcxU1ZOVTkACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAggA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310110"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.2</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310110"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_12251"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310110"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -2394,8 +2208,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0031"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_12251"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050511"/>
         <obo:IAO_0000028>SN-VTR GAD2 Dopa (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A dopaminergic neuron of the Primates brain. These cells are located in the striatum, substantia nigra . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:SN-VTR GAD2 Dopa.</obo:IAO_0000115>
@@ -2405,22 +2217,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU04tVlRSIEdBRDIgRG9wYQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoTKRZmEflaGA4UMcv6FPFxFBFdNUDhOTUo1RDhYTzFBT0kxTDkABYNsbzGCNuJBg8AJxIM4AlIABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhJQTZZNlNON1FaU0lFSjBGWjBVAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE3NDE2QjVYSkRTWTBIREY5M1JPAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFWTTRFNko5RFBZWUQ3RTBCSE5CAAJLR1pMQVdJUENSNFc5OEY1TEQ2AAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTTi1WVFIgR0FEMiBEb3BhAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChf5ZiIWO1x8DhgqmToX0nKoEV01QOE5NSjVEOFhPMUFPSTFMOQAFhBTEFoOMxVKEYmm%2FhLTnSwYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAg5QVVURTlTMTBLQUVDMlVaTzMxAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwFZM1AxSk0xRU5DR1dFVzhVU1RWAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAEzQ1BJUDI4MDRTQkRYMURYMVJXAAJTNUtRVEZIQ1JLSFZaVlJSNUhSAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTTi1WVFIgR0FEMiBEb3BhAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTTi1WVFIgR0FEMiBEb3BhAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQECgSLSW4EItT4DhF7dZoPqe8kABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhGVExBVU9WNlNMQjA3MVNWTlU5AAlQT1oySENQQlQ2MERTREo4VUE3AAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAIIAA%3D%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0000.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310111"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310111"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_12251"/>
-        <obo:CLM_0010002>0.3</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310111"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -2471,7 +2267,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0032"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_12251"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050512"/>
         <obo:IAO_0000028>SN GATA3-PAX8 GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A GABAergic interneuron of the Primates brain. These cells are located in the substantia nigra . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:SN GATA3-PAX8 GABA.</obo:IAO_0000115>
@@ -2482,14 +2277,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU04gR0FUQTMtUEFYOCBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChMpFmYR%2BVoYDhQxy%2FoU8XEUEV01QOE5NSjVEOFhPMUFPSTFMOQAFg2xvMYI24kGDwAnEgzgCUgAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACElBNlk2U043UVpTSUVKMEZaMFUACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALATc0MTZCNVhKRFNZMEhERjkzUk8AAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAVZNNEU2SjlEUFlZRDdFMEJITkIAAktHWkxBV0lQQ1I0Vzk4RjVMRDYAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAVNOIEdBVEEzLVBBWDggR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoX%2BWYiFjtcfA4YKpk6F9JyqBFdNUDhOTUo1RDhYTzFBT0kxTDkABYQUxBaDjMVShGJpv4S050sGAAcAAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIOUFVVEU5UzEwS0FFQzJVWk8zMQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBWTNQMUpNMUVOQ0dXRVc4VVNUVgACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABM0NQSVAyODA0U0JEWDFEWDFSVwACUzVLUVRGSENSS0hWWlZSUjVIUgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU04gR0FUQTMtUEFYOCBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTTiBHQVRBMy1QQVg4IEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAQKBItJbgQi1PgOEXt1mg%2Bp7yQAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACEZUTEFVT1Y2U0xCMDcxU1ZOVTkACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAggA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310112"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_12251"/>
-        <obo:CLM_0010002>0.9</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310112"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -2539,7 +2326,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0033"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_12251"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050513"/>
         <obo:IAO_0000028>SN GATA3-PVALB GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A GABAergic neuron of the Primates brain. These cells are located in the substantia nigra . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:SN GATA3-PVALB GABA.</obo:IAO_0000115>
@@ -2550,14 +2336,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU04gR0FUQTMtUFZBTEIgR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoTKRZmEflaGA4UMcv6FPFxFBFdNUDhOTUo1RDhYTzFBT0kxTDkABYNsbzGCNuJBg8AJxIM4AlIABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhJQTZZNlNON1FaU0lFSjBGWjBVAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE3NDE2QjVYSkRTWTBIREY5M1JPAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFWTTRFNko5RFBZWUQ3RTBCSE5CAAJLR1pMQVdJUENSNFc5OEY1TEQ2AAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTTiBHQVRBMy1QVkFMQiBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChf5ZiIWO1x8DhgqmToX0nKoEV01QOE5NSjVEOFhPMUFPSTFMOQAFhBTEFoOMxVKEYmm%2FhLTnSwYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAg5QVVURTlTMTBLQUVDMlVaTzMxAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwFZM1AxSk0xRU5DR1dFVzhVU1RWAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAEzQ1BJUDI4MDRTQkRYMURYMVJXAAJTNUtRVEZIQ1JLSFZaVlJSNUhSAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTTiBHQVRBMy1QVkFMQiBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTTiBHQVRBMy1QVkFMQiBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQECgSLSW4EItT4DhF7dZoPqe8kABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhGVExBVU9WNlNMQjA3MVNWTlU5AAlQT1oySENQQlQ2MERTREo4VUE3AAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAIIAA%3D%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310113"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_12251"/>
-        <obo:CLM_0010002>0.8</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310113"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -2608,9 +2386,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0034"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10466"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_12251"/>
         <obo:IAO_0000028>SN SEMA5A GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A GABAergic interneuron of the Primates brain. These cells are located in the striatum, subthalamic nucleus, substantia nigra . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:SN SEMA5A GABA.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>SN SEMA5A GABA</oboInOwl:hasExactSynonym>
@@ -2619,30 +2394,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU04gU0VNQTVBIEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKEykWZhH5WhgOFDHL%2BhTxcRQRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWDbG8xgjbiQYPACcSDOAJSAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAISUE2WTZTTjdRWlNJRUowRlowVQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBNzQxNkI1WEpEU1kwSERGOTNSTwACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABVk00RTZKOURQWVlEN0UwQkhOQgACS0daTEFXSVBDUjRXOThGNUxENgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU04gU0VNQTVBIEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKF%2FlmIhY7XHwOGCqZOhfScqgRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWEFMQWg4zFUoRiab%2BEtOdLBgAHAAAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACDlBVVRFOVMxMEtBRUMyVVpPMzEACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAVkzUDFKTTFFTkNHV0VXOFVTVFYAAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAATNDUElQMjgwNFNCRFgxRFgxUlcAAlM1S1FURkhDUktIVlpWUlI1SFIAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAVNOIFNFTUE1QSBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTTiBTRU1BNUEgR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEBAoEi0luBCLU%2BA4Re3WaD6nvJAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIRlRMQVVPVjZTTEIwNzFTVk5VOQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACCAA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310114"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.3</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310114"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10466"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310114"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_12251"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310114"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -2685,7 +2436,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0035"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_12251"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050515"/>
         <obo:IAO_0000028>SN SOX6 Dopa (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A substantia nigra dopaminergic neuron of the Primates brain. These cells are located in the substantia nigra . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:SN SOX6 Dopa.</obo:IAO_0000115>
@@ -2695,14 +2445,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU04gU09YNiBEb3BhAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChMpFmYR%2BVoYDhQxy%2FoU8XEUEV01QOE5NSjVEOFhPMUFPSTFMOQAFg2xvMYI24kGDwAnEgzgCUgAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACElBNlk2U043UVpTSUVKMEZaMFUACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALATc0MTZCNVhKRFNZMEhERjkzUk8AAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAVZNNEU2SjlEUFlZRDdFMEJITkIAAktHWkxBV0lQQ1I0Vzk4RjVMRDYAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAVNOIFNPWDYgRG9wYQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoX%2BWYiFjtcfA4YKpk6F9JyqBFdNUDhOTUo1RDhYTzFBT0kxTDkABYQUxBaDjMVShGJpv4S050sGAAcAAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIOUFVVEU5UzEwS0FFQzJVWk8zMQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBWTNQMUpNMUVOQ0dXRVc4VVNUVgACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABM0NQSVAyODA0U0JEWDFEWDFSVwACUzVLUVRGSENSS0hWWlZSUjVIUgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU04gU09YNiBEb3BhAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTTiBTT1g2IERvcGEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAQKBItJbgQi1PgOEXt1mg%2Bp7yQAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACEZUTEFVT1Y2U0xCMDcxU1ZOVTkACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAggA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0000.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310115"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_12251"/>
-        <obo:CLM_0010002>0.9</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310115"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -2753,7 +2495,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0037"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_12251"/>
         <obo:IAO_0000028>SN-VTR-HTH GATA3-TCF7L2 GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A GABAergic interneuron of the Primates brain. These cells are located in the substantia nigra . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:SN-VTR-HTH GATA3-TCF7L2 GABA.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>SN-VTR-HTH GATA3-TCF7L2 GABA</oboInOwl:hasExactSynonym>
@@ -2762,14 +2503,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU04tVlRSLUhUSCBHQVRBMy1UQ0Y3TDIgR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoTKRZmEflaGA4UMcv6FPFxFBFdNUDhOTUo1RDhYTzFBT0kxTDkABYNsbzGCNuJBg8AJxIM4AlIABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhJQTZZNlNON1FaU0lFSjBGWjBVAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE3NDE2QjVYSkRTWTBIREY5M1JPAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFWTTRFNko5RFBZWUQ3RTBCSE5CAAJLR1pMQVdJUENSNFc5OEY1TEQ2AAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTTi1WVFItSFRIIEdBVEEzLVRDRjdMMiBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChf5ZiIWO1x8DhgqmToX0nKoEV01QOE5NSjVEOFhPMUFPSTFMOQAFhBTEFoOMxVKEYmm%2FhLTnSwYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAg5QVVURTlTMTBLQUVDMlVaTzMxAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwFZM1AxSk0xRU5DR1dFVzhVU1RWAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAEzQ1BJUDI4MDRTQkRYMURYMVJXAAJTNUtRVEZIQ1JLSFZaVlJSNUhSAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTTi1WVFItSFRIIEdBVEEzLVRDRjdMMiBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTTi1WVFItSFRIIEdBVEEzLVRDRjdMMiBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQECgSLSW4EItT4DhF7dZoPqe8kABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhGVExBVU9WNlNMQjA3MVNWTlU5AAlQT1oySENQQlQ2MERTREo4VUE3AAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAIIAA%3D%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310117"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_12251"/>
-        <obo:CLM_0010002>0.5</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310117"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -2813,7 +2546,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0038"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10466"/>
         <obo:IAO_0000028>STH PVALB-PITX2 Glut (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A glutamatergic neuron of the basal ganglia of the Primates brain. These cells are located in the subthalamic nucleus . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:STH PVALB-PITX2 Glut.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>STH PVALB-PITX2 Glut</oboInOwl:hasExactSynonym>
@@ -2822,14 +2554,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RIIFBWQUxCLVBJVFgyIEdsdXQAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKEykWZhH5WhgOFDHL%2BhTxcRQRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWDbG8xgjbiQYPACcSDOAJSAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAISUE2WTZTTjdRWlNJRUowRlowVQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBNzQxNkI1WEpEU1kwSERGOTNSTwACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABVk00RTZKOURQWVlEN0UwQkhOQgACS0daTEFXSVBDUjRXOThGNUxENgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RIIFBWQUxCLVBJVFgyIEdsdXQAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKF%2FlmIhY7XHwOGCqZOhfScqgRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWEFMQWg4zFUoRiab%2BEtOdLBgAHAAAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACDlBVVRFOVMxMEtBRUMyVVpPMzEACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAVkzUDFKTTFFTkNHV0VXOFVTVFYAAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAATNDUElQMjgwNFNCRFgxRFgxUlcAAlM1S1FURkhDUktIVlpWUlI1SFIAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAVNUSCBQVkFMQi1QSVRYMiBHbHV0AAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVEggUFZBTEItUElUWDIgR2x1dAAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEBAoEi0luBCLU%2BA4Re3WaD6nvJAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIRlRMQVVPVjZTTEIwNzFTVk5VOQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACCAA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0000.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310118"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10466"/>
-        <obo:CLM_0010002>0.9</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310118"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -2880,7 +2604,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0040"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050520"/>
         <obo:IAO_0000028>STR FS PTHLH-PVALB GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A striatal pthlh-expressing interneuron of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:STR FS PTHLH-PVALB GABA.</obo:IAO_0000115>
@@ -2892,14 +2615,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSIEZTIFBUSExILVBWQUxCIEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKEykWZhH5WhgOFDHL%2BhTxcRQRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWDbG8xgjbiQYPACcSDOAJSAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAISUE2WTZTTjdRWlNJRUowRlowVQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBNzQxNkI1WEpEU1kwSERGOTNSTwACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABVk00RTZKOURQWVlEN0UwQkhOQgACS0daTEFXSVBDUjRXOThGNUxENgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSIEZTIFBUSExILVBWQUxCIEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKF%2FlmIhY7XHwOGCqZOhfScqgRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWEFMQWg4zFUoRiab%2BEtOdLBgAHAAAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACDlBVVRFOVMxMEtBRUMyVVpPMzEACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAVkzUDFKTTFFTkNHV0VXOFVTVFYAAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAATNDUElQMjgwNFNCRFgxRFgxUlcAAlM1S1FURkhDUktIVlpWUlI1SFIAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAVNUUiBGUyBQVEhMSC1QVkFMQiBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVFIgRlMgUFRITEgtUFZBTEIgR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEBAoEi0luBCLU%2BA4Re3WaD6nvJAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIRlRMQVVPVjZTTEIwNzFTVk5VOQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACCAA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310120"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.9</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310120"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -2950,7 +2665,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0041"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:IAO_0000028>STR LYPD6-RSPO2 GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A GABAergic interneuron of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:STR LYPD6-RSPO2 GABA.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>STR LYPD6-RSPO2 GABA</oboInOwl:hasExactSynonym>
@@ -2959,14 +2673,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSIExZUEQ2LVJTUE8yIEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKEykWZhH5WhgOFDHL%2BhTxcRQRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWDbG8xgjbiQYPACcSDOAJSAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAISUE2WTZTTjdRWlNJRUowRlowVQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBNzQxNkI1WEpEU1kwSERGOTNSTwACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABVk00RTZKOURQWVlEN0UwQkhOQgACS0daTEFXSVBDUjRXOThGNUxENgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSIExZUEQ2LVJTUE8yIEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKF%2FlmIhY7XHwOGCqZOhfScqgRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWEFMQWg4zFUoRiab%2BEtOdLBgAHAAAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACDlBVVRFOVMxMEtBRUMyVVpPMzEACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAVkzUDFKTTFFTkNHV0VXOFVTVFYAAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAATNDUElQMjgwNFNCRFgxRFgxUlcAAlM1S1FURkhDUktIVlpWUlI1SFIAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAVNUUiBMWVBENi1SU1BPMiBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVFIgTFlQRDYtUlNQTzIgR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEBAoEi0luBCLU%2BA4Re3WaD6nvJAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIRlRMQVVPVjZTTEIwNzFTVk5VOQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACCAA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310121"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.3</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310121"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -3010,7 +2716,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0042"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:IAO_0000028>STR SST-ADARB2 GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A sst GABAergic interneuron of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:STR SST-ADARB2 GABA.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>STR SST GABA</oboInOwl:hasExactSynonym>
@@ -3020,14 +2725,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSIFNTVC1BREFSQjIgR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoTKRZmEflaGA4UMcv6FPFxFBFdNUDhOTUo1RDhYTzFBT0kxTDkABYNsbzGCNuJBg8AJxIM4AlIABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhJQTZZNlNON1FaU0lFSjBGWjBVAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE3NDE2QjVYSkRTWTBIREY5M1JPAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFWTTRFNko5RFBZWUQ3RTBCSE5CAAJLR1pMQVdJUENSNFc5OEY1TEQ2AAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVFIgU1NULUFEQVJCMiBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChf5ZiIWO1x8DhgqmToX0nKoEV01QOE5NSjVEOFhPMUFPSTFMOQAFhBTEFoOMxVKEYmm%2FhLTnSwYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAg5QVVURTlTMTBLQUVDMlVaTzMxAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwFZM1AxSk0xRU5DR1dFVzhVU1RWAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAEzQ1BJUDI4MDRTQkRYMURYMVJXAAJTNUtRVEZIQ1JLSFZaVlJSNUhSAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVFIgU1NULUFEQVJCMiBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVFIgU1NULUFEQVJCMiBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQECgSLSW4EItT4DhF7dZoPqe8kABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhGVExBVU9WNlNMQjA3MVNWTlU5AAlQT1oySENQQlQ2MERTREo4VUE3AAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAIIAA%3D%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310122"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310122"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -3071,7 +2768,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0043"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050523"/>
         <obo:IAO_0000028>STR SST-CHODL GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A sst chodl GABAergic interneuron of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:STR SST-CHODL GABA.</obo:IAO_0000115>
@@ -3083,14 +2779,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSIFNTVC1DSE9ETCBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChMpFmYR%2BVoYDhQxy%2FoU8XEUEV01QOE5NSjVEOFhPMUFPSTFMOQAFg2xvMYI24kGDwAnEgzgCUgAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACElBNlk2U043UVpTSUVKMEZaMFUACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALATc0MTZCNVhKRFNZMEhERjkzUk8AAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAVZNNEU2SjlEUFlZRDdFMEJITkIAAktHWkxBV0lQQ1I0Vzk4RjVMRDYAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAVNUUiBTU1QtQ0hPREwgR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoX%2BWYiFjtcfA4YKpk6F9JyqBFdNUDhOTUo1RDhYTzFBT0kxTDkABYQUxBaDjMVShGJpv4S050sGAAcAAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIOUFVVEU5UzEwS0FFQzJVWk8zMQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBWTNQMUpNMUVOQ0dXRVc4VVNUVgACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABM0NQSVAyODA0U0JEWDFEWDFSVwACUzVLUVRGSENSS0hWWlZSUjVIUgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSIFNTVC1DSE9ETCBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVFIgU1NULUNIT0RMIEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAQKBItJbgQi1PgOEXt1mg%2Bp7yQAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACEZUTEFVT1Y2U0xCMDcxU1ZOVTkACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAggA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310123"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.8</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310123"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -3141,7 +2829,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0044"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:IAO_0000028>STR SST-RSPO2 GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A sst GABAergic interneuron of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:STR SST-RSPO2 GABA.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>STR SST-RSPO2 GABA</oboInOwl:hasExactSynonym>
@@ -3150,14 +2837,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSIFNTVC1SU1BPMiBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChMpFmYR%2BVoYDhQxy%2FoU8XEUEV01QOE5NSjVEOFhPMUFPSTFMOQAFg2xvMYI24kGDwAnEgzgCUgAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACElBNlk2U043UVpTSUVKMEZaMFUACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALATc0MTZCNVhKRFNZMEhERjkzUk8AAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAVZNNEU2SjlEUFlZRDdFMEJITkIAAktHWkxBV0lQQ1I0Vzk4RjVMRDYAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAVNUUiBTU1QtUlNQTzIgR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoX%2BWYiFjtcfA4YKpk6F9JyqBFdNUDhOTUo1RDhYTzFBT0kxTDkABYQUxBaDjMVShGJpv4S050sGAAcAAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIOUFVVEU5UzEwS0FFQzJVWk8zMQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBWTNQMUpNMUVOQ0dXRVc4VVNUVgACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABM0NQSVAyODA0U0JEWDFEWDFSVwACUzVLUVRGSENSS0hWWlZSUjVIUgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSIFNTVC1SU1BPMiBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVFIgU1NULVJTUE8yIEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAQKBItJbgQi1PgOEXt1mg%2Bp7yQAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACEZUTEFVT1Y2U0xCMDcxU1ZOVTkACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAggA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310124"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.4</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310124"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -3201,7 +2880,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0045"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050525"/>
         <obo:IAO_0000028>STR TAC3-PLPP4 GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A TAC3-positive striatal interneuron of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:STR TAC3-PLPP4 GABA.</obo:IAO_0000115>
@@ -3212,14 +2890,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSIFRBQzMtUExQUDQgR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoTKRZmEflaGA4UMcv6FPFxFBFdNUDhOTUo1RDhYTzFBT0kxTDkABYNsbzGCNuJBg8AJxIM4AlIABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhJQTZZNlNON1FaU0lFSjBGWjBVAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE3NDE2QjVYSkRTWTBIREY5M1JPAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFWTTRFNko5RFBZWUQ3RTBCSE5CAAJLR1pMQVdJUENSNFc5OEY1TEQ2AAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVFIgVEFDMy1QTFBQNCBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChf5ZiIWO1x8DhgqmToX0nKoEV01QOE5NSjVEOFhPMUFPSTFMOQAFhBTEFoOMxVKEYmm%2FhLTnSwYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAg5QVVURTlTMTBLQUVDMlVaTzMxAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwFZM1AxSk0xRU5DR1dFVzhVU1RWAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAEzQ1BJUDI4MDRTQkRYMURYMVJXAAJTNUtRVEZIQ1JLSFZaVlJSNUhSAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVFIgVEFDMy1QTFBQNCBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVFIgVEFDMy1QTFBQNCBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQECgSLSW4EItT4DhF7dZoPqe8kABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhGVExBVU9WNlNMQjA3MVNWTlU5AAlQT1oySENQQlQ2MERTREo4VUE3AAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAIIAA%3D%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310125"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.9</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310125"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -3270,7 +2940,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0046"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:IAO_0000028>STR-BF TAC3-PLPP4-LHX8 GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A TAC3-positive striatal interneuron of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:STR-BF TAC3-PLPP4-LHX8 GABA.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>STR-BF TAC3-PLPP4-LHX8 GABA</oboInOwl:hasExactSynonym>
@@ -3279,14 +2948,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSLUJGIFRBQzMtUExQUDQtTEhYOCBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChMpFmYR%2BVoYDhQxy%2FoU8XEUEV01QOE5NSjVEOFhPMUFPSTFMOQAFg2xvMYI24kGDwAnEgzgCUgAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACElBNlk2U043UVpTSUVKMEZaMFUACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALATc0MTZCNVhKRFNZMEhERjkzUk8AAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAVZNNEU2SjlEUFlZRDdFMEJITkIAAktHWkxBV0lQQ1I0Vzk4RjVMRDYAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAVNUUi1CRiBUQUMzLVBMUFA0LUxIWDggR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoX%2BWYiFjtcfA4YKpk6F9JyqBFdNUDhOTUo1RDhYTzFBT0kxTDkABYQUxBaDjMVShGJpv4S050sGAAcAAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIOUFVVEU5UzEwS0FFQzJVWk8zMQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBWTNQMUpNMUVOQ0dXRVc4VVNUVgACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABM0NQSVAyODA0U0JEWDFEWDFSVwACUzVLUVRGSENSS0hWWlZSUjVIUgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSLUJGIFRBQzMtUExQUDQtTEhYOCBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVFItQkYgVEFDMy1QTFBQNC1MSFg4IEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAQKBItJbgQi1PgOEXt1mg%2Bp7yQAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACEZUTEFVT1Y2U0xCMDcxU1ZOVTkACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAggA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310126"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.7</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310126"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -3330,7 +2991,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0047"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050527"/>
         <obo:IAO_0000028>VIP GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A VIP GABAergic interneuron of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:VIP GABA.</obo:IAO_0000115>
@@ -3342,14 +3002,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBVklQIEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKEykWZhH5WhgOFDHL%2BhTxcRQRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWDbG8xgjbiQYPACcSDOAJSAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAISUE2WTZTTjdRWlNJRUowRlowVQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBNzQxNkI1WEpEU1kwSERGOTNSTwACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABVk00RTZKOURQWVlEN0UwQkhOQgACS0daTEFXSVBDUjRXOThGNUxENgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBVklQIEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKF%2FlmIhY7XHwOGCqZOhfScqgRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWEFMQWg4zFUoRiab%2BEtOdLBgAHAAAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACDlBVVRFOVMxMEtBRUMyVVpPMzEACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAVkzUDFKTTFFTkNHV0VXOFVTVFYAAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAATNDUElQMjgwNFNCRFgxRFgxUlcAAlM1S1FURkhDUktIVlpWUlI1SFIAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAVZJUCBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFWSVAgR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEBAoEi0luBCLU%2BA4Re3WaD6nvJAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIRlRMQVVPVjZTTEIwNzFTVk5VOQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACCAA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310127"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.5</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310127"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -3400,7 +3052,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0048"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:IAO_0000028>STRd Cholinergic GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A dorso-striatal cholinergic-GABAergic neuron of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:STRd Cholinergic GABA.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>STRd Cholinergic GABA</oboInOwl:hasExactSynonym>
@@ -3409,14 +3060,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSZCBDaG9saW5lcmdpYyBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChMpFmYR%2BVoYDhQxy%2FoU8XEUEV01QOE5NSjVEOFhPMUFPSTFMOQAFg2xvMYI24kGDwAnEgzgCUgAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACElBNlk2U043UVpTSUVKMEZaMFUACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALATc0MTZCNVhKRFNZMEhERjkzUk8AAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAVZNNEU2SjlEUFlZRDdFMEJITkIAAktHWkxBV0lQQ1I0Vzk4RjVMRDYAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAVNUUmQgQ2hvbGluZXJnaWMgR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoX%2BWYiFjtcfA4YKpk6F9JyqBFdNUDhOTUo1RDhYTzFBT0kxTDkABYQUxBaDjMVShGJpv4S050sGAAcAAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIOUFVVEU5UzEwS0FFQzJVWk8zMQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBWTNQMUpNMUVOQ0dXRVc4VVNUVgACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABM0NQSVAyODA0U0JEWDFEWDFSVwACUzVLUVRGSENSS0hWWlZSUjVIUgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSZCBDaG9saW5lcmdpYyBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVFJkIENob2xpbmVyZ2ljIEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAQKBItJbgQi1PgOEXt1mg%2Bp7yQAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACEZUTEFVT1Y2U0xCMDcxU1ZOVTkACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAggA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310128"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>1.0</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310128"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -3460,7 +3103,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0049"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050529"/>
         <obo:IAO_0000028>STRd D1 Matrix MSN (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A matrix D1 medium spiny neuron of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:STRd D1 Matrix MSN.</obo:IAO_0000115>
@@ -3471,14 +3113,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSZCBEMSBNYXRyaXggTVNOAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChMpFmYR%2BVoYDhQxy%2FoU8XEUEV01QOE5NSjVEOFhPMUFPSTFMOQAFg2xvMYI24kGDwAnEgzgCUgAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACElBNlk2U043UVpTSUVKMEZaMFUACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALATc0MTZCNVhKRFNZMEhERjkzUk8AAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAVZNNEU2SjlEUFlZRDdFMEJITkIAAktHWkxBV0lQQ1I0Vzk4RjVMRDYAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAVNUUmQgRDEgTWF0cml4IE1TTgAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoX%2BWYiFjtcfA4YKpk6F9JyqBFdNUDhOTUo1RDhYTzFBT0kxTDkABYQUxBaDjMVShGJpv4S050sGAAcAAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIOUFVVEU5UzEwS0FFQzJVWk8zMQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBWTNQMUpNMUVOQ0dXRVc4VVNUVgACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABM0NQSVAyODA0U0JEWDFEWDFSVwACUzVLUVRGSENSS0hWWlZSUjVIUgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSZCBEMSBNYXRyaXggTVNOAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVFJkIEQxIE1hdHJpeCBNU04AAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAQKBItJbgQi1PgOEXt1mg%2Bp7yQAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACEZUTEFVT1Y2U0xCMDcxU1ZOVTkACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAggA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310129"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>1.0</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310129"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -3529,7 +3163,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0050"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050530"/>
         <obo:IAO_0000028>STRd D1 Striosome MSN (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A striosomal D1 medium spiny neuron of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:STRd D1 Striosome MSN.</obo:IAO_0000115>
@@ -3540,14 +3173,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSZCBEMSBTdHJpb3NvbWUgTVNOAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChMpFmYR%2BVoYDhQxy%2FoU8XEUEV01QOE5NSjVEOFhPMUFPSTFMOQAFg2xvMYI24kGDwAnEgzgCUgAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACElBNlk2U043UVpTSUVKMEZaMFUACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALATc0MTZCNVhKRFNZMEhERjkzUk8AAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAVZNNEU2SjlEUFlZRDdFMEJITkIAAktHWkxBV0lQQ1I0Vzk4RjVMRDYAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAVNUUmQgRDEgU3RyaW9zb21lIE1TTgAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoX%2BWYiFjtcfA4YKpk6F9JyqBFdNUDhOTUo1RDhYTzFBT0kxTDkABYQUxBaDjMVShGJpv4S050sGAAcAAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIOUFVVEU5UzEwS0FFQzJVWk8zMQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBWTNQMUpNMUVOQ0dXRVc4VVNUVgACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABM0NQSVAyODA0U0JEWDFEWDFSVwACUzVLUVRGSENSS0hWWlZSUjVIUgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSZCBEMSBTdHJpb3NvbWUgTVNOAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVFJkIEQxIFN0cmlvc29tZSBNU04AAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAQKBItJbgQi1PgOEXt1mg%2Bp7yQAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACEZUTEFVT1Y2U0xCMDcxU1ZOVTkACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAggA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310130"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>1.0</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310130"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -3597,7 +3222,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0051"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050531"/>
         <obo:IAO_0000028>STR D1D2 Hybrid MSN (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A D1/D2-hybrid medium spiny neuron of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:STR D1D2 Hybrid MSN.</obo:IAO_0000115>
@@ -3608,14 +3232,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSIEQxRDIgSHlicmlkIE1TTgAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoTKRZmEflaGA4UMcv6FPFxFBFdNUDhOTUo1RDhYTzFBT0kxTDkABYNsbzGCNuJBg8AJxIM4AlIABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhJQTZZNlNON1FaU0lFSjBGWjBVAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE3NDE2QjVYSkRTWTBIREY5M1JPAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFWTTRFNko5RFBZWUQ3RTBCSE5CAAJLR1pMQVdJUENSNFc5OEY1TEQ2AAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVFIgRDFEMiBIeWJyaWQgTVNOAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChf5ZiIWO1x8DhgqmToX0nKoEV01QOE5NSjVEOFhPMUFPSTFMOQAFhBTEFoOMxVKEYmm%2FhLTnSwYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAg5QVVURTlTMTBLQUVDMlVaTzMxAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwFZM1AxSk0xRU5DR1dFVzhVU1RWAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAEzQ1BJUDI4MDRTQkRYMURYMVJXAAJTNUtRVEZIQ1JLSFZaVlJSNUhSAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVFIgRDFEMiBIeWJyaWQgTVNOAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVFIgRDFEMiBIeWJyaWQgTVNOAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQECgSLSW4EItT4DhF7dZoPqe8kABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhGVExBVU9WNlNMQjA3MVNWTlU5AAlQT1oySENQQlQ2MERTREo4VUE3AAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAIIAA%3D%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310131"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>1.0</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310131"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -3666,7 +3282,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0052"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050532"/>
         <obo:IAO_0000028>STRd D2 Matrix MSN (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A matrix D2 medium spiny neuron of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:STRd D2 Matrix MSN.</obo:IAO_0000115>
@@ -3677,14 +3292,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSZCBEMiBNYXRyaXggTVNOAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChMpFmYR%2BVoYDhQxy%2FoU8XEUEV01QOE5NSjVEOFhPMUFPSTFMOQAFg2xvMYI24kGDwAnEgzgCUgAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACElBNlk2U043UVpTSUVKMEZaMFUACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALATc0MTZCNVhKRFNZMEhERjkzUk8AAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAVZNNEU2SjlEUFlZRDdFMEJITkIAAktHWkxBV0lQQ1I0Vzk4RjVMRDYAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAVNUUmQgRDIgTWF0cml4IE1TTgAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoX%2BWYiFjtcfA4YKpk6F9JyqBFdNUDhOTUo1RDhYTzFBT0kxTDkABYQUxBaDjMVShGJpv4S050sGAAcAAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIOUFVVEU5UzEwS0FFQzJVWk8zMQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBWTNQMUpNMUVOQ0dXRVc4VVNUVgACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABM0NQSVAyODA0U0JEWDFEWDFSVwACUzVLUVRGSENSS0hWWlZSUjVIUgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSZCBEMiBNYXRyaXggTVNOAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVFJkIEQyIE1hdHJpeCBNU04AAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAQKBItJbgQi1PgOEXt1mg%2Bp7yQAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACEZUTEFVT1Y2U0xCMDcxU1ZOVTkACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAggA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310132"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>1.0</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310132"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -3734,7 +3341,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0053"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:IAO_0000028>STRd D2 StrioMat Hybrid MSN (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A indirect pathway medium spiny neuron of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:STRd D2 StrioMat Hybrid MSN.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>STRd D2 StrioMat Hybrid MSN</oboInOwl:hasExactSynonym>
@@ -3743,14 +3349,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSZCBEMiBTdHJpb01hdCBIeWJyaWQgTVNOAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChMpFmYR%2BVoYDhQxy%2FoU8XEUEV01QOE5NSjVEOFhPMUFPSTFMOQAFg2xvMYI24kGDwAnEgzgCUgAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACElBNlk2U043UVpTSUVKMEZaMFUACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALATc0MTZCNVhKRFNZMEhERjkzUk8AAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAVZNNEU2SjlEUFlZRDdFMEJITkIAAktHWkxBV0lQQ1I0Vzk4RjVMRDYAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAVNUUmQgRDIgU3RyaW9NYXQgSHlicmlkIE1TTgAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoX%2BWYiFjtcfA4YKpk6F9JyqBFdNUDhOTUo1RDhYTzFBT0kxTDkABYQUxBaDjMVShGJpv4S050sGAAcAAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIOUFVVEU5UzEwS0FFQzJVWk8zMQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBWTNQMUpNMUVOQ0dXRVc4VVNUVgACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABM0NQSVAyODA0U0JEWDFEWDFSVwACUzVLUVRGSENSS0hWWlZSUjVIUgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSZCBEMiBTdHJpb01hdCBIeWJyaWQgTVNOAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVFJkIEQyIFN0cmlvTWF0IEh5YnJpZCBNU04AAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAQKBItJbgQi1PgOEXt1mg%2Bp7yQAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACEZUTEFVT1Y2U0xCMDcxU1ZOVTkACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAggA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310133"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.9</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310133"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -3794,7 +3392,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0054"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050534"/>
         <obo:IAO_0000028>STRd D2 Striosome MSN (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A striosomal D2 medium spiny neuron of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:STRd D2 Striosome MSN.</obo:IAO_0000115>
@@ -3805,14 +3402,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSZCBEMiBTdHJpb3NvbWUgTVNOAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChMpFmYR%2BVoYDhQxy%2FoU8XEUEV01QOE5NSjVEOFhPMUFPSTFMOQAFg2xvMYI24kGDwAnEgzgCUgAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACElBNlk2U043UVpTSUVKMEZaMFUACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALATc0MTZCNVhKRFNZMEhERjkzUk8AAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAVZNNEU2SjlEUFlZRDdFMEJITkIAAktHWkxBV0lQQ1I0Vzk4RjVMRDYAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAVNUUmQgRDIgU3RyaW9zb21lIE1TTgAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoX%2BWYiFjtcfA4YKpk6F9JyqBFdNUDhOTUo1RDhYTzFBT0kxTDkABYQUxBaDjMVShGJpv4S050sGAAcAAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIOUFVVEU5UzEwS0FFQzJVWk8zMQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBWTNQMUpNMUVOQ0dXRVc4VVNUVgACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABM0NQSVAyODA0U0JEWDFEWDFSVwACUzVLUVRGSENSS0hWWlZSUjVIUgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSZCBEMiBTdHJpb3NvbWUgTVNOAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVFJkIEQyIFN0cmlvc29tZSBNU04AAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAQKBItJbgQi1PgOEXt1mg%2Bp7yQAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACEZUTEFVT1Y2U0xCMDcxU1ZOVTkACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAggA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310134"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>1.0</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310134"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -3863,7 +3452,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0055"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:IAO_0000028>STR Cholinergic GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A striatal cholinergic-GABAergic neuron of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:STR Cholinergic GABA.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>STR Cholinergic GABA</oboInOwl:hasExactSynonym>
@@ -3872,14 +3460,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSIENob2xpbmVyZ2ljIEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKEykWZhH5WhgOFDHL%2BhTxcRQRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWDbG8xgjbiQYPACcSDOAJSAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAISUE2WTZTTjdRWlNJRUowRlowVQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBNzQxNkI1WEpEU1kwSERGOTNSTwACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABVk00RTZKOURQWVlEN0UwQkhOQgACS0daTEFXSVBDUjRXOThGNUxENgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSIENob2xpbmVyZ2ljIEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKF%2FlmIhY7XHwOGCqZOhfScqgRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWEFMQWg4zFUoRiab%2BEtOdLBgAHAAAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACDlBVVRFOVMxMEtBRUMyVVpPMzEACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAVkzUDFKTTFFTkNHV0VXOFVTVFYAAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAATNDUElQMjgwNFNCRFgxRFgxUlcAAlM1S1FURkhDUktIVlpWUlI1SFIAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAVNUUiBDaG9saW5lcmdpYyBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVFIgQ2hvbGluZXJnaWMgR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEBAoEi0luBCLU%2BA4Re3WaD6nvJAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIRlRMQVVPVjZTTEIwNzFTVk5VOQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACCAA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310135"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.6</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310135"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -3923,7 +3503,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0056"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050536"/>
         <obo:IAO_0000028>STRv D1 MSN (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A nucleus accumbens shell and olfactory tubercle D1 medium spiny neuron of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:STRv D1 MSN.</obo:IAO_0000115>
@@ -3934,14 +3513,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSdiBEMSBNU04AAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKEykWZhH5WhgOFDHL%2BhTxcRQRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWDbG8xgjbiQYPACcSDOAJSAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAISUE2WTZTTjdRWlNJRUowRlowVQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBNzQxNkI1WEpEU1kwSERGOTNSTwACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABVk00RTZKOURQWVlEN0UwQkhOQgACS0daTEFXSVBDUjRXOThGNUxENgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSdiBEMSBNU04AAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKF%2FlmIhY7XHwOGCqZOhfScqgRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWEFMQWg4zFUoRiab%2BEtOdLBgAHAAAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACDlBVVRFOVMxMEtBRUMyVVpPMzEACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAVkzUDFKTTFFTkNHV0VXOFVTVFYAAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAATNDUElQMjgwNFNCRFgxRFgxUlcAAlM1S1FURkhDUktIVlpWUlI1SFIAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAVNUUnYgRDEgTVNOAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVFJ2IEQxIE1TTgAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEBAoEi0luBCLU%2BA4Re3WaD6nvJAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIRlRMQVVPVjZTTEIwNzFTVk5VOQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACCAA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310136"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.9</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310136"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -3992,7 +3563,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0057"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050537"/>
         <obo:IAO_0000028>STRv D1 NUDAP MSN (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A D1-NUDAP medium spiny neuron of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:STRv D1 NUDAP MSN.</obo:IAO_0000115>
@@ -4003,14 +3573,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSdiBEMSBOVURBUCBNU04AAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKEykWZhH5WhgOFDHL%2BhTxcRQRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWDbG8xgjbiQYPACcSDOAJSAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAISUE2WTZTTjdRWlNJRUowRlowVQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBNzQxNkI1WEpEU1kwSERGOTNSTwACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABVk00RTZKOURQWVlEN0UwQkhOQgACS0daTEFXSVBDUjRXOThGNUxENgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSdiBEMSBOVURBUCBNU04AAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKF%2FlmIhY7XHwOGCqZOhfScqgRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWEFMQWg4zFUoRiab%2BEtOdLBgAHAAAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACDlBVVRFOVMxMEtBRUMyVVpPMzEACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAVkzUDFKTTFFTkNHV0VXOFVTVFYAAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAATNDUElQMjgwNFNCRFgxRFgxUlcAAlM1S1FURkhDUktIVlpWUlI1SFIAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAVNUUnYgRDEgTlVEQVAgTVNOAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVFJ2IEQxIE5VREFQIE1TTgAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEBAoEi0luBCLU%2BA4Re3WaD6nvJAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIRlRMQVVPVjZTTEIwNzFTVk5VOQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACCAA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310137"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.6</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310137"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -4061,7 +3623,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0058"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050538"/>
         <obo:IAO_0000028>STRv D2 MSN (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A nucleus accumbens shell and olfactory tubercle D2 medium spiny neuron of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:STRv D2 MSN.</obo:IAO_0000115>
@@ -4072,14 +3633,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSdiBEMiBNU04AAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKEykWZhH5WhgOFDHL%2BhTxcRQRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWDbG8xgjbiQYPACcSDOAJSAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAISUE2WTZTTjdRWlNJRUowRlowVQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBNzQxNkI1WEpEU1kwSERGOTNSTwACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABVk00RTZKOURQWVlEN0UwQkhOQgACS0daTEFXSVBDUjRXOThGNUxENgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBU1RSdiBEMiBNU04AAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKF%2FlmIhY7XHwOGCqZOhfScqgRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWEFMQWg4zFUoRiab%2BEtOdLBgAHAAAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACDlBVVRFOVMxMEtBRUMyVVpPMzEACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAVkzUDFKTTFFTkNHV0VXOFVTVFYAAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAATNDUElQMjgwNFNCRFgxRFgxUlcAAlM1S1FURkhDUktIVlpWUlI1SFIAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAVNUUnYgRDIgTVNOAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFTVFJ2IEQyIE1TTgAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEBAoEi0luBCLU%2BA4Re3WaD6nvJAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIRlRMQVVPVjZTTEIwNzFTVk5VOQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACCAA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310138"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.8</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310138"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -4130,7 +3683,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0063"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_12251"/>
         <obo:IAO_0000028>ZI-HTH GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A GABAergic interneuron of the Primates brain. These cells are located in the substantia nigra . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:ZI-HTH GABA.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>ZI-HTH GABA</oboInOwl:hasExactSynonym>
@@ -4139,14 +3691,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBWkktSFRIIEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKEykWZhH5WhgOFDHL%2BhTxcRQRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWDbG8xgjbiQYPACcSDOAJSAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAISUE2WTZTTjdRWlNJRUowRlowVQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBNzQxNkI1WEpEU1kwSERGOTNSTwACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABVk00RTZKOURQWVlEN0UwQkhOQgACS0daTEFXSVBDUjRXOThGNUxENgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBWkktSFRIIEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAAKF%2FlmIhY7XHwOGCqZOhfScqgRXTVA4Tk1KNUQ4WE8xQU9JMUw5AAWEFMQWg4zFUoRiab%2BEtOdLBgAHAAAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACDlBVVRFOVMxMEtBRUMyVVpPMzEACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAVkzUDFKTTFFTkNHV0VXOFVTVFYAAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAATNDUElQMjgwNFNCRFgxRFgxUlcAAlM1S1FURkhDUktIVlpWUlI1SFIAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAVpJLUhUSCBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFaSS1IVEggR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEBAoEi0luBCLU%2BA4Re3WaD6nvJAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIRlRMQVVPVjZTTEIwNzFTVk5VOQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACCAA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310143"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_12251"/>
-        <obo:CLM_0010002>0.5</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310143"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -4190,9 +3734,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0064"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10466"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_12251"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5050544"/>
         <obo:IAO_0000028>VTR-HTH Glut (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A glutamatergic neuron of the basal ganglia of the Primates brain. These cells are located in the striatum, subthalamic nucleus, substantia nigra . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:VTR-HTH Glut.</obo:IAO_0000115>
@@ -4203,30 +3744,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBVlRSLUhUSCBHbHV0AAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChMpFmYR%2BVoYDhQxy%2FoU8XEUEV01QOE5NSjVEOFhPMUFPSTFMOQAFg2xvMYI24kGDwAnEgzgCUgAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACElBNlk2U043UVpTSUVKMEZaMFUACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALATc0MTZCNVhKRFNZMEhERjkzUk8AAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAVZNNEU2SjlEUFlZRDdFMEJITkIAAktHWkxBV0lQQ1I0Vzk4RjVMRDYAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAVZUUi1IVEggR2x1dAAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoX%2BWYiFjtcfA4YKpk6F9JyqBFdNUDhOTUo1RDhYTzFBT0kxTDkABYQUxBaDjMVShGJpv4S050sGAAcAAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIOUFVVEU5UzEwS0FFQzJVWk8zMQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBWTNQMUpNMUVOQ0dXRVc4VVNUVgACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABM0NQSVAyODA0U0JEWDFEWDFSVwACUzVLUVRGSENSS0hWWlZSUjVIUgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBVlRSLUhUSCBHbHV0AAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFWVFItSFRIIEdsdXQAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAQKBItJbgQi1PgOEXt1mg%2Bp7yQAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACEZUTEFVT1Y2U0xCMDcxU1ZOVTkACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAggA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0000.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310144"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310144"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10466"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310144"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_12251"/>
-        <obo:CLM_0010002>0.2</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310144"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -4270,7 +3787,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0065"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:IAO_0000028>AMY-SLEA-BNST D1 GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A GABAergic interneuron of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:AMY-SLEA-BNST D1 GABA.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>AMY-SLEA-BNST D1 GABA</oboInOwl:hasExactSynonym>
@@ -4279,14 +3795,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBQU1ZLVNMRUEtQk5TVCBEMSBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChMpFmYR%2BVoYDhQxy%2FoU8XEUEV01QOE5NSjVEOFhPMUFPSTFMOQAFg2xvMYI24kGDwAnEgzgCUgAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACElBNlk2U043UVpTSUVKMEZaMFUACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALATc0MTZCNVhKRFNZMEhERjkzUk8AAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAVZNNEU2SjlEUFlZRDdFMEJITkIAAktHWkxBV0lQQ1I0Vzk4RjVMRDYAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAUFNWS1TTEVBLUJOU1QgRDEgR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoX%2BWYiFjtcfA4YKpk6F9JyqBFdNUDhOTUo1RDhYTzFBT0kxTDkABYQUxBaDjMVShGJpv4S050sGAAcAAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIOUFVVEU5UzEwS0FFQzJVWk8zMQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBWTNQMUpNMUVOQ0dXRVc4VVNUVgACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABM0NQSVAyODA0U0JEWDFEWDFSVwACUzVLUVRGSENSS0hWWlZSUjVIUgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBQU1ZLVNMRUEtQk5TVCBEMSBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFBTVktU0xFQS1CTlNUIEQxIEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAQKBItJbgQi1PgOEXt1mg%2Bp7yQAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACEZUTEFVT1Y2U0xCMDcxU1ZOVTkACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAggA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310145"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.4</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310145"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -4330,7 +3838,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0066"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:IAO_0000028>AMY-SLEA-BNST GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A GABAergic interneuron of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:AMY-SLEA-BNST GABA.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>AMY-SLEA-BNST GABA</oboInOwl:hasExactSynonym>
@@ -4339,14 +3846,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBQU1ZLVNMRUEtQk5TVCBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChMpFmYR%2BVoYDhQxy%2FoU8XEUEV01QOE5NSjVEOFhPMUFPSTFMOQAFg2xvMYI24kGDwAnEgzgCUgAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACElBNlk2U043UVpTSUVKMEZaMFUACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALATc0MTZCNVhKRFNZMEhERjkzUk8AAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAVZNNEU2SjlEUFlZRDdFMEJITkIAAktHWkxBV0lQQ1I0Vzk4RjVMRDYAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAUFNWS1TTEVBLUJOU1QgR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoX%2BWYiFjtcfA4YKpk6F9JyqBFdNUDhOTUo1RDhYTzFBT0kxTDkABYQUxBaDjMVShGJpv4S050sGAAcAAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIOUFVVEU5UzEwS0FFQzJVWk8zMQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBWTNQMUpNMUVOQ0dXRVc4VVNUVgACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABM0NQSVAyODA0U0JEWDFEWDFSVwACUzVLUVRGSENSS0hWWlZSUjVIUgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBQU1ZLVNMRUEtQk5TVCBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFBTVktU0xFQS1CTlNUIEdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAQKBItJbgQi1PgOEXt1mg%2Bp7yQAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACEZUTEFVT1Y2U0xCMDcxU1ZOVTkACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAggA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310146"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310146"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -4390,7 +3889,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0067"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:IAO_0000028>OB Dopa-GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A OB-Dopa-GABA of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:OB Dopa-GABA.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>OB Dopa-GABA</oboInOwl:hasExactSynonym>
@@ -4399,14 +3897,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBT0IgRG9wYS1HQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChMpFmYR%2BVoYDhQxy%2FoU8XEUEV01QOE5NSjVEOFhPMUFPSTFMOQAFg2xvMYI24kGDwAnEgzgCUgAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACElBNlk2U043UVpTSUVKMEZaMFUACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALATc0MTZCNVhKRFNZMEhERjkzUk8AAkNSRUhSQ0syWVhSV0pLMkowQUwAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAVZNNEU2SjlEUFlZRDdFMEJITkIAAktHWkxBV0lQQ1I0Vzk4RjVMRDYAAwUBRTNIR0JZSFJDOThHQTZGVzlGNgACAAABM1hCT0ZCUjMwMkVZQzBVUUQ1MQACAAABU1E2V0pPMEdOVUpHRlU4TEhWVgACAAABSEsxNE8xQVNBTlBZSE9ORkxMUQACAU9CIERvcGEtR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoX%2BWYiFjtcfA4YKpk6F9JyqBFdNUDhOTUo1RDhYTzFBT0kxTDkABYQUxBaDjMVShGJpv4S050sGAAcAAAUABgEBAkhLMTRPMUFTQU5QWUhPTkZMTFEAA34AAAAEAAAIOUFVVEU5UzEwS0FFQzJVWk8zMQAJUE9aMkhDUEJUNjBEU0RKOFVBNwAKAAsBWTNQMUpNMUVOQ0dXRVc4VVNUVgACQ1JFSFJDSzJZWFJXSksySjBBTAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABM0NQSVAyODA0U0JEWDFEWDFSVwACUzVLUVRGSENSS0hWWlZSUjVIUgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBT0IgRG9wYS1HQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFPQiBEb3BhLUdBQkEAAAE2RVdCU0VKNFlGVkdLSTJBUEJMAAIAAAQBAQKBItJbgQi1PgOEXt1mg%2Bp7yQAFAAYBAQJISzE0TzFBU0FOUFlIT05GTExRAAN%2BAAAABAAACEZUTEFVT1Y2U0xCMDcxU1ZOVTkACVBPWjJIQ1BCVDYwRFNESjhVQTcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAggA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310147"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.5</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310147"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
@@ -4449,7 +3939,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20250428/CS20250428_GROUP_0068"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
         <obo:IAO_0000028>OB FRMD7 GABA (Primate)</obo:IAO_0000028>
         <obo:IAO_0000115>A GABAergic neuron of the Primates brain. These cells are located in the striatum . Reference transcriptomic data for this type can be found in the dataset/taxonomy - HMBA Basal Ganglia Consensus Taxonomy in cell set Group:OB FRMD7 GABA.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym>OB FRMD7 GABA</oboInOwl:hasExactSynonym>
@@ -4458,14 +3947,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQQBTlhKOU5aQVFBNU1FSFFOT1dKUQACVEdCUTJGRVYyN04wQ1BMS1ZBWgADBQFFM0hHQllIUkM5OEdBNkZXOUY2AAIAAAEzWEJPRkJSMzAyRVlDMFVRRDUxAAIAAAFTUTZXSk8wR05VSkdGVThMSFZWAAIAAAFISzE0TzFBU0FOUFlIT05GTExRAAIBT0IgRlJNRDcgR0FCQQAAATZFV0JTRUo0WUZWR0tJMkFQQkwAAgAABAEAAoTKRZmEflaGA4UMcv6FPFxFBFdNUDhOTUo1RDhYTzFBT0kxTDkABYNsbzGCNuJBg8AJxIM4AlIABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhJQTZZNlNON1FaU0lFSjBGWjBVAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE3NDE2QjVYSkRTWTBIREY5M1JPAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFWTTRFNko5RFBZWUQ3RTBCSE5CAAJLR1pMQVdJUENSNFc5OEY1TEQ2AAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFPQiBGUk1ENyBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChf5ZiIWO1x8DhgqmToX0nKoEV01QOE5NSjVEOFhPMUFPSTFMOQAFhBTEFoOMxVKEYmm%2FhLTnSwYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAg5QVVURTlTMTBLQUVDMlVaTzMxAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwFZM1AxSk0xRU5DR1dFVzhVU1RWAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAEzQ1BJUDI4MDRTQkRYMURYMVJXAAJTNUtRVEZIQ1JLSFZaVlJSNUhSAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFPQiBGUk1ENyBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQAChebihoaWQSADh2hhMoagk4YEV01QOE5NSjVEOFhPMUFPSTFMOQAFgdih64S2EZmE2pRdhQKGhgYABwAABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhIWkVZWFNRT0VETkQyUTZNOTdNAAlQT1oySENQQlQ2MERTREo4VUE3AAoACwE2VDk2MjYwMTI2VFY0S0xHRFhHAAJDUkVIUkNLMllYUldKSzJKMEFMAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFFSVVBTFBZTkdaNVZVN1kyWTAyAAJRWlEyUUJNVTRUNUk0N0QxSzRGAAMFAUUzSEdCWUhSQzk4R0E2Rlc5RjYAAgAAATNYQk9GQlIzMDJFWUMwVVFENTEAAgAAAVNRNldKTzBHTlVKR0ZVOExIVlYAAgAAAUhLMTRPMUFTQU5QWUhPTkZMTFEAAgFPQiBGUk1ENyBHQUJBAAABNkVXQlNFSjRZRlZHS0kyQVBCTAACAAAEAQECgSLSW4EItT4DhF7dZoPqe8kABQAGAQECSEsxNE8xQVNBTlBZSE9ORkxMUQADfgAAAAQAAAhGVExBVU9WNlNMQjA3MVNWTlU5AAlQT1oySENQQlQ2MERTREo4VUE3AAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAIIAA%3D%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20250428_NEIGH_0002.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310148"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/dhbao/DHBA_10333"/>
-        <obo:CLM_0010002>0.6</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4310148"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>

--- a/src/ontology/components/wmbo-cl-comp.owl
+++ b/src/ontology/components/wmbo-cl-comp.owl
@@ -11,8 +11,8 @@
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#"
      xmlns:CCN20230722="https://purl.brain-bican.org/taxonomy/CCN20230722#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/cl/components/wmbo-cl-comp.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/cl/releases/2026-02-19/components/wmbo-cl-comp.owl"/>
-        <owl:versionInfo>2026-02-19</owl:versionInfo>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/cl/releases/2026-02-28/components/wmbo-cl-comp.owl"/>
+        <owl:versionInfo>2026-02-28</owl:versionInfo>
     </owl:Ontology>
     
 
@@ -89,12 +89,6 @@
     <!-- http://purl.obolibrary.org/obo/IAO_0100001 -->
 
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0100001"/>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/OBI_0000070 -->
-
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0000070"/>
     
 
 
@@ -16464,13 +16458,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_2564"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1097"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_258"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_564"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_596"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_803"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5004314"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007635"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007802"/>
@@ -16503,62 +16490,6 @@
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
         <owl:annotatedTarget rdf:nodeID="genid2232"/>
         <rdfs:comment>Inferred to be glutamate secretion, neurotransmission based on expression of Gad1, Slc17a6, Gad2</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4304384"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1097"/>
-        <obo:CLM_0010002>0.22</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4304384"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_258"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4304384"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_564"/>
-        <obo:CLM_0010002>0.25</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4304384"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_596"/>
-        <obo:CLM_0010002>0.15</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4304384"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010002>0.11</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4304384"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_803"/>
-        <obo:CLM_0010002>0.42</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4304384"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.14</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4304384"/>
@@ -16615,15 +16546,13 @@
                 <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/NCBITaxon_10090"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <rdfs:subClassOf rdf:nodeID="genid2253"/>
+        <rdfs:subClassOf rdf:nodeID="genid2246"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0015001"/>
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_4606"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_129"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006356"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007645"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007922"/>
@@ -16640,7 +16569,7 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIBMjUgUGluZWFsIEdsdXQAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIAAAQBAQKBrMaOgZYVIAOEak39hFgYTQAFAAYBAQJGUzAwRFhWMFQ5UjFYOUZKNFFFAAN%2BAAAABAAACEc0STRHRkpYSkI5QVRaM1BUWDEACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAUs5Sk4yM1AyNEtRQ0dLOVU3NUEAAkhTWVpQWlcxNjY5VTgyMUJXWVAAAwQBRlMwMERYVjBUOVIxWDlGSjRRRQACATI1IFBpbmVhbCBHbHV0AAABUVk1UzhLTU81SExKVUYwUDAwSwACAAABMTVCSzQ3RENJT0YxU0xMVVc5UAACAAABQ0JHQzBVMzBWVjlKUFI2MFRKVQACAAAEAQAChFC%2FH4OCCX8DhKAah4TEPdkEMk5RVElFN1RBTVA4UFFBSE80UAAFga%2BmSoHprA6BoIFHgJLV6AYABwAABQAGAQECRlMwMERYVjBUOVIxWDlGSjRRRQADfgAAAAQAAAhWRk9GWVBGUUdSS1VEUVVaM0ZGAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFUTE9LV0NMOTVSVTAzRDlQRVRHAAI3M0dWVERYREVHRTI3TTJYSk1UAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAIDAA%3D%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_25.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid2253">
+    <owl:Restriction rdf:nodeID="genid2246">
         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002215"/>
         <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0061535"/>
     </owl:Restriction>
@@ -16655,24 +16584,8 @@
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4306426"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid2253"/>
+        <owl:annotatedTarget rdf:nodeID="genid2246"/>
         <rdfs:comment>Inferred to be glutamate secretion, neurotransmission based on expression of Ddc, Slc17a6, Slc17a7</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4306426"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_129"/>
-        <obo:CLM_0010002>0.38</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4306426"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>1.0</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4306426"/>
@@ -16732,19 +16645,13 @@
             </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_4300348"/>
-        <rdfs:subClassOf rdf:nodeID="genid2268"/>
+        <rdfs:subClassOf rdf:nodeID="genid2259"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0015001"/>
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5172"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1041"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_354"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_728"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_96"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006922"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022142"/>
         <obo:IAO_0000028>DCO Il22 Gly-Gaba_2 (Mmus)</obo:IAO_0000028>
@@ -16756,7 +16663,7 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTE3MiBEQ08gSWwyMiBHbHktR2FiYV8yAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MTcyIERDTyBJbDIyIEdseS1HYWJhXzIAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_28.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Class rdf:nodeID="genid2268">
+    <owl:Class rdf:nodeID="genid2259">
         <owl:intersectionOf rdf:parseType="Collection">
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002215"/>
@@ -16771,56 +16678,8 @@
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4306992"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid2268"/>
+        <owl:annotatedTarget rdf:nodeID="genid2259"/>
         <rdfs:comment>Inferred to be gamma-aminobutyric acid secretion, neurotransmission, glycine secretion, neurotransmission based on expression of Slc32a1, Hdc, Slc6a5, Gad2, Gad1</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4306992"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1041"/>
-        <obo:CLM_0010002>0.2</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4306992"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_354"/>
-        <obo:CLM_0010002>0.44</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4306992"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010002>0.25</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4306992"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_728"/>
-        <obo:CLM_0010002>0.16</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4306992"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_96"/>
-        <obo:CLM_0010002>0.44</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4306992"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.31</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4306992"/>
@@ -16871,18 +16730,13 @@
             </owl:Class>
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_4300349"/>
-        <rdfs:subClassOf rdf:nodeID="genid2290"/>
+        <rdfs:subClassOf rdf:nodeID="genid2275"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0015001"/>
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5185"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_728"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_91"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_968"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006935"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022155"/>
         <obo:IAO_0000028>CB PLI Gly-Gaba_4 (Mmus)</obo:IAO_0000028>
@@ -16894,55 +16748,15 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTE4NSBDQiBQTEkgR2x5LUdhYmFfNAAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTE4NSBDQiBQTEkgR2x5LUdhYmFfNAAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_28.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid2290">
+    <owl:Restriction rdf:nodeID="genid2275">
         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002215"/>
         <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0061534"/>
     </owl:Restriction>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307005"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid2290"/>
+        <owl:annotatedTarget rdf:nodeID="genid2275"/>
         <rdfs:comment>Inferred to be gamma-aminobutyric acid secretion, neurotransmission based on expression of Gad1, Gad2, Slc32a1</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307005"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010002>0.76</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307005"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_728"/>
-        <obo:CLM_0010002>0.14</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307005"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_91"/>
-        <obo:CLM_0010002>0.11</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307005"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_968"/>
-        <obo:CLM_0010002>0.17</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307005"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.2</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307005"/>
@@ -16994,15 +16808,13 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_4042035"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_4300028"/>
-        <rdfs:subClassOf rdf:nodeID="genid2308"/>
+        <rdfs:subClassOf rdf:nodeID="genid2288"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0015001"/>
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5192"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006942"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007972"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022162"/>
@@ -17016,7 +16828,7 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIBMzEyIENCWCBNTEkgQ2RoMjIgR2FiYQAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAlFZNVM4S01PNUhMSlVGMFAwMEsAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIBMzEyIENCWCBNTEkgQ2RoMjIgR2FiYQAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAlFZNVM4S01PNUhMSlVGMFAwMEsAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_28.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid2308">
+    <owl:Restriction rdf:nodeID="genid2288">
         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002215"/>
         <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0061534"/>
     </owl:Restriction>
@@ -17031,24 +16843,8 @@
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307012"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid2308"/>
+        <owl:annotatedTarget rdf:nodeID="genid2288"/>
         <rdfs:comment>Inferred to be gamma-aminobutyric acid secretion, neurotransmission based on expression of Gad1, Gad2, Slc32a1</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307012"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010002>0.69</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307012"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.31</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307012"/>
@@ -17105,8 +16901,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5206"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006956"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007976"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022176"/>
@@ -17125,22 +16919,6 @@
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/CL_0000644"/>
         <oboInOwl:evidence rdf:resource="http://identifiers.org/ncbigene/11668"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307026"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010002>0.73</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307026"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.27</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307026"/>
@@ -17197,9 +16975,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5207"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_728"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006957"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007977"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022177"/>
@@ -17218,30 +16993,6 @@
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/CL_0002603"/>
         <oboInOwl:evidence rdf:resource="http://identifiers.org/ncbigene/11668"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307027"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010002>0.65</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307027"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_728"/>
-        <obo:CLM_0010002>0.14</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307027"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.34</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307027"/>
@@ -17298,9 +17049,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5208"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_728"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006958"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022178"/>
         <obo:IAO_0000028>Astro-NT NN_1 Galnt15 (Mmus)</obo:IAO_0000028>
@@ -17311,30 +17059,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIwOCBBc3Ryby1OVCBOTl8xAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjA4IEFzdHJvLU5UIE5OXzEAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307028"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010002>0.32</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307028"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_728"/>
-        <obo:CLM_0010002>0.15</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307028"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.57</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307028"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -17390,9 +17114,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5209"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_313"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006959"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022179"/>
         <obo:IAO_0000028>Astro-NT NN_1 Slc36a2 (Mmus)</obo:IAO_0000028>
@@ -17403,30 +17124,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIwOSBBc3Ryby1OVCBOTl8xAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjA5IEFzdHJvLU5UIE5OXzEAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307029"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_313"/>
-        <obo:CLM_0010002>0.12</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307029"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307029"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.56</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307029"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -17482,9 +17179,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5210"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_728"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006960"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022180"/>
         <obo:IAO_0000028>Astro-NT NN_1 Nuf2 (Mmus)</obo:IAO_0000028>
@@ -17495,30 +17189,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIxMCBBc3Ryby1OVCBOTl8xAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjEwIEFzdHJvLU5UIE5OXzEAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307030"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010002>0.26</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307030"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_728"/>
-        <obo:CLM_0010002>0.16</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307030"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.51</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307030"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -17574,10 +17244,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5211"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_278"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_403"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006961"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022181"/>
         <obo:IAO_0000028>Astro-NT NN_1 Six3os1 (Mmus)</obo:IAO_0000028>
@@ -17588,38 +17254,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIxMSBBc3Ryby1OVCBOTl8xAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjExIEFzdHJvLU5UIE5OXzEAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307031"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_278"/>
-        <obo:CLM_0010002>0.12</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307031"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_403"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307031"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010002>0.14</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307031"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.48</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307031"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -17675,10 +17309,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5212"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_354"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_728"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006962"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022182"/>
         <obo:IAO_0000028>Astro-NT NN_1 Kcnk10 (Mmus)</obo:IAO_0000028>
@@ -17689,38 +17319,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIxMiBBc3Ryby1OVCBOTl8xAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjEyIEFzdHJvLU5UIE5OXzEAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307032"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_354"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307032"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010002>0.21</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307032"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_728"/>
-        <obo:CLM_0010002>0.2</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307032"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.58</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307032"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -17776,13 +17374,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5213"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_101"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1041"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1049"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_354"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_96"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006963"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022183"/>
         <obo:IAO_0000028>Astro-NT NN_1 Mecom (Mmus)</obo:IAO_0000028>
@@ -17793,62 +17384,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIxMyBBc3Ryby1OVCBOTl8xAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjEzIEFzdHJvLU5UIE5OXzEAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307033"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_101"/>
-        <obo:CLM_0010002>0.35</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307033"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1041"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307033"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1049"/>
-        <obo:CLM_0010002>0.18</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307033"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_354"/>
-        <obo:CLM_0010002>0.5</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307033"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010002>0.3</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307033"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_96"/>
-        <obo:CLM_0010002>0.14</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307033"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.2</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307033"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -17904,10 +17439,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5214"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_128"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_313"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_549"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_771"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006964"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022184"/>
         <obo:IAO_0000028>Astro-NT NN_2 Fzd2 (Mmus)</obo:IAO_0000028>
@@ -17918,38 +17449,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIxNCBBc3Ryby1OVCBOTl8yAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjE0IEFzdHJvLU5UIE5OXzIAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307034"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_128"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307034"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_313"/>
-        <obo:CLM_0010002>0.56</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307034"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_549"/>
-        <obo:CLM_0010002>0.11</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307034"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_771"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307034"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -18005,9 +17504,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5215"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1020"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_549"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_733"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006965"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022185"/>
         <obo:IAO_0000028>Astro-NT NN_2 Sez6l (Mmus)</obo:IAO_0000028>
@@ -18018,30 +17514,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIxNSBBc3Ryby1OVCBOTl8yAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjE1IEFzdHJvLU5UIE5OXzIAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307035"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1020"/>
-        <obo:CLM_0010002>0.14</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307035"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_549"/>
-        <obo:CLM_0010002>0.91</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307035"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_733"/>
-        <obo:CLM_0010002>0.17</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307035"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -18097,9 +17569,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5216"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_313"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_354"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_771"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006966"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022186"/>
         <obo:IAO_0000028>Astro-NT NN_2 Fam227b (Mmus)</obo:IAO_0000028>
@@ -18110,30 +17579,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIxNiBBc3Ryby1OVCBOTl8yAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjE2IEFzdHJvLU5UIE5OXzIAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307036"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_313"/>
-        <obo:CLM_0010002>0.19</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307036"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_354"/>
-        <obo:CLM_0010002>0.35</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307036"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_771"/>
-        <obo:CLM_0010002>0.27</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307036"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -18189,11 +17634,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5217"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_101"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_354"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_728"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006967"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022187"/>
         <obo:IAO_0000028>Astro-NT NN_2 Gm30524 (Mmus)</obo:IAO_0000028>
@@ -18204,46 +17644,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIxNyBBc3Ryby1OVCBOTl8yAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjE3IEFzdHJvLU5UIE5OXzIAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307037"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_101"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307037"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_354"/>
-        <obo:CLM_0010002>0.33</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307037"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010002>0.26</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307037"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_728"/>
-        <obo:CLM_0010002>0.11</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307037"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.22</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307037"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -18299,9 +17699,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5218"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006968"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022188"/>
         <obo:IAO_0000028>Astro-TE NN_1 Myoc (Mmus)</obo:IAO_0000028>
@@ -18312,30 +17709,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIxOCBBc3Ryby1URSBOTl8xAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjE4IEFzdHJvLVRFIE5OXzEAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307038"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010002>0.23</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307038"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010002>0.15</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307038"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.55</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307038"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -18391,9 +17764,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5219"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1080"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006969"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022189"/>
         <obo:IAO_0000028>Astro-TE NN_1 Rasl10b (Mmus)</obo:IAO_0000028>
@@ -18404,30 +17774,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIxOSBBc3Ryby1URSBOTl8xAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjE5IEFzdHJvLVRFIE5OXzEAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307039"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1080"/>
-        <obo:CLM_0010002>0.15</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307039"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010002>0.2</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307039"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.42</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307039"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -18483,7 +17829,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5220"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006970"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022190"/>
         <obo:IAO_0000028>Astro-TE NN_1 Lncpint (Mmus)</obo:IAO_0000028>
@@ -18494,14 +17839,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIyMCBBc3Ryby1URSBOTl8xAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjIwIEFzdHJvLVRFIE5OXzEAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307040"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.67</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307040"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -18552,15 +17889,13 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_0000151"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_4301591"/>
-        <rdfs:subClassOf rdf:nodeID="genid2525"/>
+        <rdfs:subClassOf rdf:nodeID="genid2452"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0015001"/>
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5221"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006971"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022191"/>
         <obo:IAO_0000028>Astro-TE NN_1 Jph4 (Mmus)</obo:IAO_0000028>
@@ -18571,31 +17906,15 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIyMSBBc3Ryby1URSBOTl8xAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjIxIEFzdHJvLVRFIE5OXzEAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid2525">
+    <owl:Restriction rdf:nodeID="genid2452">
         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002215"/>
         <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0061535"/>
     </owl:Restriction>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307041"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid2525"/>
+        <owl:annotatedTarget rdf:nodeID="genid2452"/>
         <rdfs:comment>Inferred to be glutamate secretion, neurotransmission based on expression of Aldh1a1, Slc17a7</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307041"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010002>0.19</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307041"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.76</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307041"/>
@@ -18652,11 +17971,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5222"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_10703"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_10704"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1080"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_486"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_632"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006972"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022192"/>
         <obo:IAO_0000028>Astro-TE NN_2 Clstn2 (Mmus)</obo:IAO_0000028>
@@ -18667,46 +17981,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIyMiBBc3Ryby1URSBOTl8yAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjIyIEFzdHJvLVRFIE5OXzIAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307042"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_10703"/>
-        <obo:CLM_0010002>0.19</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307042"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_10704"/>
-        <obo:CLM_0010002>0.19</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307042"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1080"/>
-        <obo:CLM_0010002>0.97</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307042"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_486"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307042"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_632"/>
-        <obo:CLM_0010002>0.27</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307042"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -18762,10 +18036,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5223"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_10703"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_10704"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1080"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_632"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006973"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022193"/>
         <obo:IAO_0000028>Astro-TE NN_2 Mcm6 (Mmus)</obo:IAO_0000028>
@@ -18776,38 +18046,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIyMyBBc3Ryby1URSBOTl8yAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjIzIEFzdHJvLVRFIE5OXzIAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307043"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_10703"/>
-        <obo:CLM_0010002>0.26</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307043"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_10704"/>
-        <obo:CLM_0010002>0.14</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307043"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1080"/>
-        <obo:CLM_0010002>0.9</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307043"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_632"/>
-        <obo:CLM_0010002>0.27</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307043"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -18863,10 +18101,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5224"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1080"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006974"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022194"/>
         <obo:IAO_0000028>Astro-TE NN_3 Cxcl5 (Mmus)</obo:IAO_0000028>
@@ -18877,38 +18111,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIyNCBBc3Ryby1URSBOTl8zAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjI0IEFzdHJvLVRFIE5OXzMAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307044"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1080"/>
-        <obo:CLM_0010002>0.17</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307044"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010002>0.32</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307044"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010002>0.13</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307044"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.15</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307044"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -18964,8 +18166,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5225"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006975"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022195"/>
         <obo:IAO_0000028>Astro-TE NN_3 Fam163a (Mmus)</obo:IAO_0000028>
@@ -18976,22 +18176,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIyNSBBc3Ryby1URSBOTl8zAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjI1IEFzdHJvLVRFIE5OXzMAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307045"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010002>0.71</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307045"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307045"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -19047,10 +18231,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5226"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_258"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_275"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006976"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022196"/>
         <obo:IAO_0000028>Astro-TE NN_3 Zic4 (Mmus)</obo:IAO_0000028>
@@ -19061,38 +18241,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIyNiBBc3Ryby1URSBOTl8zAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjI2IEFzdHJvLVRFIE5OXzMAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307046"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_258"/>
-        <obo:CLM_0010002>0.29</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307046"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_275"/>
-        <obo:CLM_0010002>0.39</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307046"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010002>0.3</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307046"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010002>0.19</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307046"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -19148,10 +18296,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5227"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_485"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_493"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_56"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_672"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006977"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022197"/>
         <obo:IAO_0000028>Astro-TE NN_3 Crym (Mmus)</obo:IAO_0000028>
@@ -19162,38 +18306,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIyNyBBc3Ryby1URSBOTl8zAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjI3IEFzdHJvLVRFIE5OXzMAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307047"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_485"/>
-        <obo:CLM_0010002>0.7</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307047"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_493"/>
-        <obo:CLM_0010002>0.2</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307047"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_56"/>
-        <obo:CLM_0010002>0.15</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307047"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_672"/>
-        <obo:CLM_0010002>0.7</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307047"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -19249,10 +18361,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5228"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_131"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_579"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_703"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006978"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022198"/>
         <obo:IAO_0000028>Astro-TE NN_4 (Mmus)</obo:IAO_0000028>
@@ -19264,38 +18372,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIyOCBBc3Ryby1URSBOTl80AAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjI4IEFzdHJvLVRFIE5OXzQAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307048"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_131"/>
-        <obo:CLM_0010002>0.13</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307048"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_579"/>
-        <obo:CLM_0010002>0.14</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307048"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_703"/>
-        <obo:CLM_0010002>0.25</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307048"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.55</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307048"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -19351,12 +18427,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5229"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_159"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_484682516"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_81"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_956"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006979"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022199"/>
         <obo:IAO_0000028>Astro-TE NN_5 Hs3st3a1 (Mmus)</obo:IAO_0000028>
@@ -19367,54 +18437,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIyOSBBc3Ryby1URSBOTl81AAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjI5IEFzdHJvLVRFIE5OXzUAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307049"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_159"/>
-        <obo:CLM_0010002>0.15</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307049"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_484682516"/>
-        <obo:CLM_0010002>0.19</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307049"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010002>0.39</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307049"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_81"/>
-        <obo:CLM_0010002>0.13</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307049"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_956"/>
-        <obo:CLM_0010002>0.11</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307049"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.58</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307049"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -19470,12 +18492,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5230"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_275"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_485"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_56"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_672"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_81"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006980"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022200"/>
         <obo:IAO_0000028>Astro-TE NN_5 Adamts18 (Mmus)</obo:IAO_0000028>
@@ -19486,54 +18502,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIzMCBBc3Ryby1URSBOTl81AAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjMwIEFzdHJvLVRFIE5OXzUAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307050"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_275"/>
-        <obo:CLM_0010002>0.12</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307050"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_485"/>
-        <obo:CLM_0010002>0.3</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307050"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_56"/>
-        <obo:CLM_0010002>0.11</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307050"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_672"/>
-        <obo:CLM_0010002>0.3</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307050"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_81"/>
-        <obo:CLM_0010002>0.39</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307050"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.43</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307050"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -19589,9 +18557,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5231"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_507"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006981"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022201"/>
         <obo:IAO_0000028>Astro-OLF NN_1 Greb1 (Mmus)</obo:IAO_0000028>
@@ -19602,30 +18567,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIzMSBBc3Ryby1PTEYgTk5fMQAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIzMSBBc3Ryby1PTEYgTk5fMQAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307051"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_507"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307051"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010002>0.32</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307051"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.64</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307051"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -19681,10 +18622,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5232"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1016"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_507"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006982"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022202"/>
         <obo:IAO_0000028>Astro-OLF NN_1 Stk32a (Mmus)</obo:IAO_0000028>
@@ -19695,38 +18632,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIzMiBBc3Ryby1PTEYgTk5fMQAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIzMiBBc3Ryby1PTEYgTk5fMQAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307052"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1016"/>
-        <obo:CLM_0010002>0.31</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307052"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_507"/>
-        <obo:CLM_0010002>0.26</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307052"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010002>0.44</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307052"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.56</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307052"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -19782,10 +18687,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5233"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_244"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_507"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006983"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022203"/>
         <obo:IAO_0000028>Astro-OLF NN_2 Slc25a34 (Mmus)</obo:IAO_0000028>
@@ -19796,38 +18697,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIzMyBBc3Ryby1PTEYgTk5fMgAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIzMyBBc3Ryby1PTEYgTk5fMgAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307053"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_244"/>
-        <obo:CLM_0010002>0.15</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307053"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_507"/>
-        <obo:CLM_0010002>0.11</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307053"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010002>0.44</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307053"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.51</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307053"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -19883,10 +18752,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5234"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_159"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_220"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_236"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006984"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022204"/>
         <obo:IAO_0000028>Astro-OLF NN_2 Alk (Mmus)</obo:IAO_0000028>
@@ -19897,38 +18762,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIzNCBBc3Ryby1PTEYgTk5fMgAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIzNCBBc3Ryby1PTEYgTk5fMgAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307054"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_159"/>
-        <obo:CLM_0010002>0.29</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307054"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_220"/>
-        <obo:CLM_0010002>0.29</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307054"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_236"/>
-        <obo:CLM_0010002>0.14</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307054"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010002>1.0</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307054"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -19984,8 +18817,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5235"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_220"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006985"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022205"/>
         <obo:IAO_0000028>Astro-OLF NN_3 Ecrg4 (Mmus)</obo:IAO_0000028>
@@ -19996,22 +18827,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIzNSBBc3Ryby1PTEYgTk5fMwAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIzNSBBc3Ryby1PTEYgTk5fMwAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307055"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_220"/>
-        <obo:CLM_0010002>0.63</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307055"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010002>0.9</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307055"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -20067,9 +18882,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5236"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_220"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006986"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022206"/>
         <obo:IAO_0000028>Astro-OLF NN_3 Sfrp1 (Mmus)</obo:IAO_0000028>
@@ -20080,30 +18892,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIzNiBBc3Ryby1PTEYgTk5fMwAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTIzNiBBc3Ryby1PTEYgTk5fMwAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307056"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_220"/>
-        <obo:CLM_0010002>0.52</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307056"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010002>0.84</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307056"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.16</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307056"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -20160,9 +18948,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5243"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_108"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_129"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006993"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022213"/>
         <obo:IAO_0000028>Tanycyte NN_1 Cnmd (Mmus)</obo:IAO_0000028>
@@ -20173,30 +18958,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI0MyBUYW55Y3l0ZSBOTl8xAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjQzIFRhbnljeXRlIE5OXzEAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307063"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_108"/>
-        <obo:CLM_0010002>0.58</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307063"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_129"/>
-        <obo:CLM_0010002>0.24</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307063"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.88</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307063"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -20252,9 +19013,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5244"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1097"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_272"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006994"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022214"/>
         <obo:IAO_0000028>Tanycyte NN_1 Glp1r (Mmus)</obo:IAO_0000028>
@@ -20265,30 +19023,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI0NCBUYW55Y3l0ZSBOTl8xAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjQ0IFRhbnljeXRlIE5OXzEAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307064"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1097"/>
-        <obo:CLM_0010002>0.34</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307064"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_272"/>
-        <obo:CLM_0010002>0.34</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307064"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.61</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307064"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -20340,15 +19074,13 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_1100001"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_4042017"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_4301603"/>
-        <rdfs:subClassOf rdf:nodeID="genid2775"/>
+        <rdfs:subClassOf rdf:nodeID="genid2635"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0015001"/>
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5245"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1097"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_118"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006995"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022215"/>
         <obo:IAO_0000028>Tanycyte NN_2 Mylk3 (Mmus)</obo:IAO_0000028>
@@ -20359,7 +19091,7 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI0NSBUYW55Y3l0ZSBOTl8yAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjQ1IFRhbnljeXRlIE5OXzIAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid2775">
+    <owl:Restriction rdf:nodeID="genid2635">
         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002215"/>
         <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0061535"/>
     </owl:Restriction>
@@ -20372,24 +19104,8 @@
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307065"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid2775"/>
+        <owl:annotatedTarget rdf:nodeID="genid2635"/>
         <rdfs:comment>Inferred to be glutamate secretion, neurotransmission based on expression of Slc17a8</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307065"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1097"/>
-        <obo:CLM_0010002>0.92</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307065"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_118"/>
-        <obo:CLM_0010002>0.88</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307065"/>
@@ -20447,11 +19163,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5246"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1097"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_118"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_129"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_223"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006996"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022216"/>
         <obo:IAO_0000028>Tanycyte NN_2 Mroh5 (Mmus)</obo:IAO_0000028>
@@ -20462,46 +19173,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI0NiBUYW55Y3l0ZSBOTl8yAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjQ2IFRhbnljeXRlIE5OXzIAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307066"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1097"/>
-        <obo:CLM_0010002>0.73</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307066"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_118"/>
-        <obo:CLM_0010002>0.47</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307066"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_129"/>
-        <obo:CLM_0010002>0.24</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307066"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_223"/>
-        <obo:CLM_0010002>0.11</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307066"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.27</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307066"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -20558,9 +19229,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5247"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1097"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_126"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_223"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022217"/>
         <obo:IAO_0000028>Tanycyte NN_2 Dscaml1 (Mmus)</obo:IAO_0000028>
@@ -20571,30 +19239,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI0NyBUYW55Y3l0ZSBOTl8yAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjQ3IFRhbnljeXRlIE5OXzIAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307067"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1097"/>
-        <obo:CLM_0010002>0.94</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307067"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_126"/>
-        <obo:CLM_0010002>0.29</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307067"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_223"/>
-        <obo:CLM_0010002>0.6</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307067"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -20650,10 +19294,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5248"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1097"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_126"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_129"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006998"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022218"/>
         <obo:IAO_0000028>Tanycyte NN_2 Otx2 (Mmus)</obo:IAO_0000028>
@@ -20664,38 +19304,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI0OCBUYW55Y3l0ZSBOTl8yAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjQ4IFRhbnljeXRlIE5OXzIAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307068"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1097"/>
-        <obo:CLM_0010002>0.69</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307068"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_126"/>
-        <obo:CLM_0010002>0.69</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307068"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_129"/>
-        <obo:CLM_0010002>0.31</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307068"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.31</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307068"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -20752,10 +19360,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5249"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1097"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_129"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_223"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5006999"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022219"/>
         <obo:IAO_0000028>Tanycyte NN_2 Col25a1 (Mmus)</obo:IAO_0000028>
@@ -20766,38 +19370,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI0OSBUYW55Y3l0ZSBOTl8yAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjQ5IFRhbnljeXRlIE5OXzIAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307069"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1097"/>
-        <obo:CLM_0010002>0.78</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307069"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_129"/>
-        <obo:CLM_0010002>0.22</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307069"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_223"/>
-        <obo:CLM_0010002>0.76</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307069"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.22</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307069"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -20854,11 +19426,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5250"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_10671"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1097"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_129"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_223"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007000"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022220"/>
         <obo:IAO_0000028>Tanycyte NN_3 (Mmus)</obo:IAO_0000028>
@@ -20870,46 +19437,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI1MCBUYW55Y3l0ZSBOTl8zAAAEAQECgazGjoGWFSADhGpN%2FYRYGE0ABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhHNEk0R0ZKWEpCOUFUWjNQVFgxAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFub25lAAJub25lAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAFLOUpOMjNQMjRLUUNHSzlVNzVBAAJIU1laUFpXMTY2OVU4MjFCV1lQAAMEAUZTMDBEWFYwVDlSMVg5Rko0UUUAAgAAAVFZNVM4S01PNUhMSlVGMFAwMEsAAgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgE1MjUwIFRhbnljeXRlIE5OXzMAAAQBAAKEUL8fg4IJfwOEoBqHhMQ92QQyTlFUSUU3VEFNUDhQUUFITzRQAAWBr6ZKgemsDoGggUeAktXoBgAHAAAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACFZGT0ZZUEZRR1JLVURRVVozRkYACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAVRMT0tXQ0w5NVJVMDNEOVBFVEcAAjczR1ZURFhERUdFMjdNMlhKTVQAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAgMA</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307070"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_10671"/>
-        <obo:CLM_0010002>0.46</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307070"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1097"/>
-        <obo:CLM_0010002>0.75</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307070"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_129"/>
-        <obo:CLM_0010002>0.19</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307070"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_223"/>
-        <obo:CLM_0010002>0.29</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307070"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.25</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307070"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -20965,11 +19492,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5263"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_129"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_158"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_313"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_599626923"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007013"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007984"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022233"/>
@@ -20989,46 +19511,6 @@
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
         <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/CL_4023181"/>
         <oboInOwl:evidence rdf:resource="http://identifiers.org/ncbigene/15186"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307083"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_129"/>
-        <obo:CLM_0010002>0.48</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307083"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_158"/>
-        <obo:CLM_0010002>0.11</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307083"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_313"/>
-        <obo:CLM_0010002>0.32</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307083"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_599626923"/>
-        <obo:CLM_0010002>0.23</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307083"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.68</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307083"/>
@@ -21092,10 +19574,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5264"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1041"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_108"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007014"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022234"/>
         <obo:IAO_0000028>CHOR NN_1 Tbc1d1 (Mmus)</obo:IAO_0000028>
@@ -21106,38 +19584,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI2NCBDSE9SIE5OXzEAAAQBAQKBrMaOgZYVIAOEak39hFgYTQAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACEc0STRHRkpYSkI5QVRaM1BUWDEACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAUs5Sk4yM1AyNEtRQ0dLOVU3NUEAAkhTWVpQWlcxNjY5VTgyMUJXWVAAAwQBRlMwMERYVjBUOVIxWDlGSjRRRQACAAABUVk1UzhLTU81SExKVUYwUDAwSwACAAABMTVCSzQ3RENJT0YxU0xMVVc5UAACAAABQ0JHQzBVMzBWVjlKUFI2MFRKVQACATUyNjQgQ0hPUiBOTl8xAAAEAQAChFC%2FH4OCCX8DhKAah4TEPdkEMk5RVElFN1RBTVA4UFFBSE80UAAFga%2BmSoHprA6BoIFHgJLV6AYABwAABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhWRk9GWVBGUUdSS1VEUVVaM0ZGAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFUTE9LV0NMOTVSVTAzRDlQRVRHAAI3M0dWVERYREVHRTI3TTJYSk1UAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAIDAA%3D%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307084"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1041"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307084"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_108"/>
-        <obo:CLM_0010002>0.49</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307084"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010002>0.24</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307084"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.74</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307084"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -21188,16 +19634,13 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_0000686"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_4301608"/>
-        <rdfs:subClassOf rdf:nodeID="genid2891"/>
+        <rdfs:subClassOf rdf:nodeID="genid2719"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0015001"/>
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5265"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_108"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_81"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007015"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022235"/>
         <obo:IAO_0000028>CHOR NN_1 Slc17a8 (Mmus)</obo:IAO_0000028>
@@ -21208,39 +19651,15 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI2NSBDSE9SIE5OXzEAAAQBAQKBrMaOgZYVIAOEak39hFgYTQAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACEc0STRHRkpYSkI5QVRaM1BUWDEACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAUs5Sk4yM1AyNEtRQ0dLOVU3NUEAAkhTWVpQWlcxNjY5VTgyMUJXWVAAAwQBRlMwMERYVjBUOVIxWDlGSjRRRQACAAABUVk1UzhLTU81SExKVUYwUDAwSwACAAABMTVCSzQ3RENJT0YxU0xMVVc5UAACAAABQ0JHQzBVMzBWVjlKUFI2MFRKVQACATUyNjUgQ0hPUiBOTl8xAAAEAQAChFC%2FH4OCCX8DhKAah4TEPdkEMk5RVElFN1RBTVA4UFFBSE80UAAFga%2BmSoHprA6BoIFHgJLV6AYABwAABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhWRk9GWVBGUUdSS1VEUVVaM0ZGAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFUTE9LV0NMOTVSVTAzRDlQRVRHAAI3M0dWVERYREVHRTI3TTJYSk1UAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAIDAA%3D%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_30.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid2891">
+    <owl:Restriction rdf:nodeID="genid2719">
         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002215"/>
         <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0061535"/>
     </owl:Restriction>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307085"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid2891"/>
+        <owl:annotatedTarget rdf:nodeID="genid2719"/>
         <rdfs:comment>Inferred to be glutamate secretion, neurotransmission based on expression of Slc17a8</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307085"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_108"/>
-        <obo:CLM_0010002>0.18</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307085"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_81"/>
-        <obo:CLM_0010002>0.22</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307085"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.81</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307085"/>
@@ -21297,8 +19716,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5266"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007016"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022236"/>
         <obo:IAO_0000028>OPC NN_1 Neil3 (Mmus)</obo:IAO_0000028>
@@ -21309,22 +19726,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI2NiBPUEMgTk5fMQAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI2NiBPUEMgTk5fMQAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_31.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307086"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010002>0.52</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307086"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.14</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307086"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -21380,11 +19781,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5267"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_313"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_354"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_771"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007017"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022237"/>
         <obo:IAO_0000028>OPC NN_1 Irx2 (Mmus)</obo:IAO_0000028>
@@ -21395,46 +19791,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI2NyBPUEMgTk5fMQAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI2NyBPUEMgTk5fMQAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_31.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307087"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_313"/>
-        <obo:CLM_0010002>0.21</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307087"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_354"/>
-        <obo:CLM_0010002>0.13</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307087"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010002>0.14</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307087"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_771"/>
-        <obo:CLM_0010002>0.17</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307087"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.23</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307087"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -21490,9 +19846,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5268"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007018"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022238"/>
         <obo:IAO_0000028>OPC NN_1 Mms22l (Mmus)</obo:IAO_0000028>
@@ -21503,30 +19856,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI2OCBPUEMgTk5fMQAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI2OCBPUEMgTk5fMQAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_31.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307088"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010002>0.53</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307088"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010002>0.12</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307088"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307088"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -21582,9 +19911,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5269"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_313"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_771"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007019"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022239"/>
         <obo:IAO_0000028>OPC NN_1 Col27a1 (Mmus)</obo:IAO_0000028>
@@ -21595,30 +19921,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI2OSBPUEMgTk5fMQAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI2OSBPUEMgTk5fMQAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_31.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307089"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_313"/>
-        <obo:CLM_0010002>0.17</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307089"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_771"/>
-        <obo:CLM_0010002>0.11</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307089"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.16</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307089"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -21674,10 +19976,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5270"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1097"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_313"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_803"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007020"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022240"/>
         <obo:IAO_0000028>OPC NN_1 Rmi2 (Mmus)</obo:IAO_0000028>
@@ -21688,38 +19986,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI3MCBPUEMgTk5fMQAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI3MCBPUEMgTk5fMQAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_31.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307090"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1097"/>
-        <obo:CLM_0010002>0.17</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307090"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_313"/>
-        <obo:CLM_0010002>0.39</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307090"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_803"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307090"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307090"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -21775,8 +20041,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5271"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007021"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022241"/>
         <obo:IAO_0000028>OPC NN_2 (Mmus)</obo:IAO_0000028>
@@ -21788,22 +20052,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI3MSBPUEMgTk5fMgAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI3MSBPUEMgTk5fMgAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_31.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307091"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010002>0.26</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307091"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.17</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307091"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -21859,8 +20107,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5272"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007022"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022242"/>
         <obo:IAO_0000028>COP NN_1 Rgcc (Mmus)</obo:IAO_0000028>
@@ -21871,22 +20117,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI3MiBDT1AgTk5fMQAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI3MiBDT1AgTk5fMQAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_31.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307092"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010002>0.22</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307092"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.2</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307092"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -21942,8 +20172,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5273"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007023"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022243"/>
         <obo:IAO_0000028>COP NN_1 9130019P16Rik (Mmus)</obo:IAO_0000028>
@@ -21954,22 +20182,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI3MyBDT1AgTk5fMQAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI3MyBDT1AgTk5fMQAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_31.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307093"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010002>0.33</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307093"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.2</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307093"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -22025,7 +20237,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5274"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007024"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022244"/>
         <obo:IAO_0000028>COP NN_1 C1ql1 (Mmus)</obo:IAO_0000028>
@@ -22036,14 +20247,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI3NCBDT1AgTk5fMQAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI3NCBDT1AgTk5fMQAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_31.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307094"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.41</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307094"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -22099,7 +20302,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5275"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007025"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022245"/>
         <obo:IAO_0000028>COP NN_1 Bmp4 (Mmus)</obo:IAO_0000028>
@@ -22110,14 +20312,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI3NSBDT1AgTk5fMQAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI3NSBDT1AgTk5fMQAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_31.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307095"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.37</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307095"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -22173,7 +20367,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5276"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007026"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022246"/>
         <obo:IAO_0000028>COP NN_1 Vwc2 (Mmus)</obo:IAO_0000028>
@@ -22184,14 +20377,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI3NiBDT1AgTk5fMQAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI3NiBDT1AgTk5fMQAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_31.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307096"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.51</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307096"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -22247,9 +20432,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5277"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007027"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022247"/>
         <obo:IAO_0000028>COP NN_1 Cck (Mmus)</obo:IAO_0000028>
@@ -22260,30 +20442,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI3NyBDT1AgTk5fMQAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI3NyBDT1AgTk5fMQAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_31.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307097"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010002>0.54</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307097"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010002>0.11</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307097"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307097"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -22339,9 +20497,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5278"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_313"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_549"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007028"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022248"/>
         <obo:IAO_0000028>NFOL NN_2 9630013A20Rik (Mmus)</obo:IAO_0000028>
@@ -22352,30 +20507,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI3OCBORk9MIE5OXzIAAAQBAQKBrMaOgZYVIAOEak39hFgYTQAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACEc0STRHRkpYSkI5QVRaM1BUWDEACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAUs5Sk4yM1AyNEtRQ0dLOVU3NUEAAkhTWVpQWlcxNjY5VTgyMUJXWVAAAwQBRlMwMERYVjBUOVIxWDlGSjRRRQACAAABUVk1UzhLTU81SExKVUYwUDAwSwACAAABMTVCSzQ3RENJT0YxU0xMVVc5UAACAAABQ0JHQzBVMzBWVjlKUFI2MFRKVQACATUyNzggTkZPTCBOTl8yAAAEAQAChFC%2FH4OCCX8DhKAah4TEPdkEMk5RVElFN1RBTVA4UFFBSE80UAAFga%2BmSoHprA6BoIFHgJLV6AYABwAABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhWRk9GWVBGUUdSS1VEUVVaM0ZGAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFUTE9LV0NMOTVSVTAzRDlQRVRHAAI3M0dWVERYREVHRTI3TTJYSk1UAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAIDAA%3D%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_31.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307098"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_313"/>
-        <obo:CLM_0010002>0.31</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307098"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_549"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307098"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.12</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307098"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -22431,8 +20562,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5279"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007029"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022249"/>
         <obo:IAO_0000028>NFOL NN_2 Dbx2 (Mmus)</obo:IAO_0000028>
@@ -22443,22 +20572,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI3OSBORk9MIE5OXzIAAAQBAQKBrMaOgZYVIAOEak39hFgYTQAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACEc0STRHRkpYSkI5QVRaM1BUWDEACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAUs5Sk4yM1AyNEtRQ0dLOVU3NUEAAkhTWVpQWlcxNjY5VTgyMUJXWVAAAwQBRlMwMERYVjBUOVIxWDlGSjRRRQACAAABUVk1UzhLTU81SExKVUYwUDAwSwACAAABMTVCSzQ3RENJT0YxU0xMVVc5UAACAAABQ0JHQzBVMzBWVjlKUFI2MFRKVQACATUyNzkgTkZPTCBOTl8yAAAEAQAChFC%2FH4OCCX8DhKAah4TEPdkEMk5RVElFN1RBTVA4UFFBSE80UAAFga%2BmSoHprA6BoIFHgJLV6AYABwAABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhWRk9GWVBGUUdSS1VEUVVaM0ZGAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFUTE9LV0NMOTVSVTAzRDlQRVRHAAI3M0dWVERYREVHRTI3TTJYSk1UAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAIDAA%3D%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_31.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307099"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010002>0.24</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307099"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.25</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307099"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -22514,8 +20627,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5280"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007030"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022250"/>
         <obo:IAO_0000028>NFOL NN_2 Rgs16 (Mmus)</obo:IAO_0000028>
@@ -22526,22 +20637,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI4MCBORk9MIE5OXzIAAAQBAQKBrMaOgZYVIAOEak39hFgYTQAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACEc0STRHRkpYSkI5QVRaM1BUWDEACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAUs5Sk4yM1AyNEtRQ0dLOVU3NUEAAkhTWVpQWlcxNjY5VTgyMUJXWVAAAwQBRlMwMERYVjBUOVIxWDlGSjRRRQACAAABUVk1UzhLTU81SExKVUYwUDAwSwACAAABMTVCSzQ3RENJT0YxU0xMVVc5UAACAAABQ0JHQzBVMzBWVjlKUFI2MFRKVQACATUyODAgTkZPTCBOTl8yAAAEAQAChFC%2FH4OCCX8DhKAah4TEPdkEMk5RVElFN1RBTVA4UFFBSE80UAAFga%2BmSoHprA6BoIFHgJLV6AYABwAABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhWRk9GWVBGUUdSS1VEUVVaM0ZGAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFUTE9LV0NMOTVSVTAzRDlQRVRHAAI3M0dWVERYREVHRTI3TTJYSk1UAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAIDAA%3D%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_31.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307100"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010002>0.18</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307100"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.28</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307100"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -22597,8 +20692,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5281"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007031"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022251"/>
         <obo:IAO_0000028>NFOL NN_2 Il23a (Mmus)</obo:IAO_0000028>
@@ -22609,22 +20702,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI4MSBORk9MIE5OXzIAAAQBAQKBrMaOgZYVIAOEak39hFgYTQAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACEc0STRHRkpYSkI5QVRaM1BUWDEACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAUs5Sk4yM1AyNEtRQ0dLOVU3NUEAAkhTWVpQWlcxNjY5VTgyMUJXWVAAAwQBRlMwMERYVjBUOVIxWDlGSjRRRQACAAABUVk1UzhLTU81SExKVUYwUDAwSwACAAABMTVCSzQ3RENJT0YxU0xMVVc5UAACAAABQ0JHQzBVMzBWVjlKUFI2MFRKVQACATUyODEgTkZPTCBOTl8yAAAEAQAChFC%2FH4OCCX8DhKAah4TEPdkEMk5RVElFN1RBTVA4UFFBSE80UAAFga%2BmSoHprA6BoIFHgJLV6AYABwAABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhWRk9GWVBGUUdSS1VEUVVaM0ZGAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFUTE9LV0NMOTVSVTAzRDlQRVRHAAI3M0dWVERYREVHRTI3TTJYSk1UAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAIDAA%3D%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_31.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307101"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010002>0.19</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307101"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.3</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307101"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -22680,8 +20757,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5282"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007032"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022252"/>
         <obo:IAO_0000028>MFOL NN_3 Cxcl12 (Mmus)</obo:IAO_0000028>
@@ -22692,22 +20767,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI4MiBNRk9MIE5OXzMAAAQBAQKBrMaOgZYVIAOEak39hFgYTQAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACEc0STRHRkpYSkI5QVRaM1BUWDEACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAUs5Sk4yM1AyNEtRQ0dLOVU3NUEAAkhTWVpQWlcxNjY5VTgyMUJXWVAAAwQBRlMwMERYVjBUOVIxWDlGSjRRRQACAAABUVk1UzhLTU81SExKVUYwUDAwSwACAAABMTVCSzQ3RENJT0YxU0xMVVc5UAACAAABQ0JHQzBVMzBWVjlKUFI2MFRKVQACATUyODIgTUZPTCBOTl8zAAAEAQAChFC%2FH4OCCX8DhKAah4TEPdkEMk5RVElFN1RBTVA4UFFBSE80UAAFga%2BmSoHprA6BoIFHgJLV6AYABwAABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhWRk9GWVBGUUdSS1VEUVVaM0ZGAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFUTE9LV0NMOTVSVTAzRDlQRVRHAAI3M0dWVERYREVHRTI3TTJYSk1UAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAIDAA%3D%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_31.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307102"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010002>0.26</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307102"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.26</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307102"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -22763,9 +20822,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5283"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_313"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007033"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022253"/>
         <obo:IAO_0000028>MFOL NN_3 Il23a (Mmus)</obo:IAO_0000028>
@@ -22776,30 +20832,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI4MyBNRk9MIE5OXzMAAAQBAQKBrMaOgZYVIAOEak39hFgYTQAFAAYBAQJDQkdDMFUzMFZWOUpQUjYwVEpVAAN%2BAAAABAAACEc0STRHRkpYSkI5QVRaM1BUWDEACUxWREJKQVc4Qkk1WVNTMVFVQkcACgALAW5vbmUAAm5vbmUAAwEEAQACIzAwMDAwMAADyAEABQEBAiMwMDAwMDAAA8gBAAAAAUs5Sk4yM1AyNEtRQ0dLOVU3NUEAAkhTWVpQWlcxNjY5VTgyMUJXWVAAAwQBRlMwMERYVjBUOVIxWDlGSjRRRQACAAABUVk1UzhLTU81SExKVUYwUDAwSwACAAABMTVCSzQ3RENJT0YxU0xMVVc5UAACAAABQ0JHQzBVMzBWVjlKUFI2MFRKVQACATUyODMgTUZPTCBOTl8zAAAEAQAChFC%2FH4OCCX8DhKAah4TEPdkEMk5RVElFN1RBTVA4UFFBSE80UAAFga%2BmSoHprA6BoIFHgJLV6AYABwAABQAGAQECQ0JHQzBVMzBWVjlKUFI2MFRKVQADfgAAAAQAAAhWRk9GWVBGUUdSS1VEUVVaM0ZGAAlMVkRCSkFXOEJJNVlTUzFRVUJHAAoACwFUTE9LV0NMOTVSVTAzRDlQRVRHAAI3M0dWVERYREVHRTI3TTJYSk1UAAMBBAEAAiMwMDAwMDAAA8gBAAUBAQIjMDAwMDAwAAPIAQAAAAIDAA%3D%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_31.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307103"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_313"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307103"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010002>0.17</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307103"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.29</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307103"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -22855,8 +20887,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5284"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_354"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007034"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022254"/>
         <obo:IAO_0000028>MOL NN_4 Plin3 (Mmus)</obo:IAO_0000028>
@@ -22867,22 +20897,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI4NCBNT0wgTk5fNAAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI4NCBNT0wgTk5fNAAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_31.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307104"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_354"/>
-        <obo:CLM_0010002>0.11</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307104"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.37</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307104"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -22938,9 +20952,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5285"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_313"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007035"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022255"/>
         <obo:IAO_0000028>MOL NN_4 Spock3 (Mmus)</obo:IAO_0000028>
@@ -22951,30 +20962,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI4NSBNT0wgTk5fNAAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI4NSBNT0wgTk5fNAAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_31.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307105"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_313"/>
-        <obo:CLM_0010002>0.14</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307105"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010002>0.13</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307105"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.27</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307105"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -23030,9 +21017,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5286"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_354"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_771"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007036"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022256"/>
         <obo:IAO_0000028>MOL NN_4 Art3 (Mmus)</obo:IAO_0000028>
@@ -23043,30 +21027,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI4NiBNT0wgTk5fNAAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI4NiBNT0wgTk5fNAAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_31.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307106"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_354"/>
-        <obo:CLM_0010002>0.17</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307106"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_771"/>
-        <obo:CLM_0010002>0.15</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307106"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.44</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307106"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -23122,8 +21082,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5287"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007037"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022257"/>
         <obo:IAO_0000028>MOL NN_4 Il33 (Mmus)</obo:IAO_0000028>
@@ -23134,22 +21092,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI4NyBNT0wgTk5fNAAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI4NyBNT0wgTk5fNAAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_31.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307107"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010002>0.17</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307107"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.41</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307107"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -23205,8 +21147,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5288"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007038"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022258"/>
         <obo:IAO_0000028>MOL NN_4 Sspo (Mmus)</obo:IAO_0000028>
@@ -23217,22 +21157,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI4OCBNT0wgTk5fNAAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI4OCBNT0wgTk5fNAAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_31.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307108"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010002>0.11</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307108"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.41</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307108"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -23288,8 +21212,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5289"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1016"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007039"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022259"/>
         <obo:IAO_0000028>OEC NN_1 Adamts12 (Mmus)</obo:IAO_0000028>
@@ -23300,22 +21222,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI4OSBPRUMgTk5fMQAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI4OSBPRUMgTk5fMQAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_32.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307109"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1016"/>
-        <obo:CLM_0010002>0.15</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307109"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.89</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307109"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -23371,8 +21277,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5290"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1016"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007040"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022260"/>
         <obo:IAO_0000028>OEC NN_1 Gdpd4 (Mmus)</obo:IAO_0000028>
@@ -23383,22 +21287,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI5MCBPRUMgTk5fMQAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI5MCBPRUMgTk5fMQAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_32.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307110"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1016"/>
-        <obo:CLM_0010002>0.39</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307110"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.8</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307110"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -23454,10 +21342,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5291"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1016"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_507"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007041"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022261"/>
         <obo:IAO_0000028>OEC NN_1 A330076C08Rik (Mmus)</obo:IAO_0000028>
@@ -23468,38 +21352,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI5MSBPRUMgTk5fMQAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI5MSBPRUMgTk5fMQAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_32.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307111"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_1016"/>
-        <obo:CLM_0010002>0.14</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307111"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_507"/>
-        <obo:CLM_0010002>0.16</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF acronym region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307111"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_698"/>
-        <obo:CLM_0010002>0.36</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307111"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.64</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307111"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -23550,14 +21402,13 @@
         </owl:equivalentClass>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_0000151"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CL_4301615"/>
-        <rdfs:subClassOf rdf:nodeID="genid3229"/>
+        <rdfs:subClassOf rdf:nodeID="genid2991"/>
         <rdfs:subClassOf>
             <owl:Restriction>
                 <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0015001"/>
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5292"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007042"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022262"/>
         <obo:IAO_0000028>OEC NN_1 Rasgef1c (Mmus)</obo:IAO_0000028>
@@ -23568,23 +21419,15 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI5MiBPRUMgTk5fMQAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI5MiBPRUMgTk5fMQAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_32.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Restriction rdf:nodeID="genid3229">
+    <owl:Restriction rdf:nodeID="genid2991">
         <owl:onProperty rdf:resource="http://purl.obolibrary.org/obo/RO_0002215"/>
         <owl:someValuesFrom rdf:resource="http://purl.obolibrary.org/obo/GO_0061535"/>
     </owl:Restriction>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307112"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:nodeID="genid3229"/>
+        <owl:annotatedTarget rdf:nodeID="genid2991"/>
         <rdfs:comment>Inferred to be glutamate secretion, neurotransmission based on expression of Slc17a7</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307112"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.85</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307112"/>
@@ -23641,7 +21484,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5293"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007043"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022263"/>
         <obo:IAO_0000028>ABC NN_1 Pde11a (Mmus)</obo:IAO_0000028>
@@ -23652,14 +21494,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI5MyBBQkMgTk5fMQAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI5MyBBQkMgTk5fMQAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_33.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307113"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.73</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307113"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -23715,7 +21549,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5294"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007044"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022264"/>
         <obo:IAO_0000028>ABC NN_1 Dapl1 (Mmus)</obo:IAO_0000028>
@@ -23726,14 +21559,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI5NCBBQkMgTk5fMQAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI5NCBBQkMgTk5fMQAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_33.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307114"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.76</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307114"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -23789,7 +21614,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5295"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007045"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022265"/>
         <obo:IAO_0000028>ABC NN_1 Cubn (Mmus)</obo:IAO_0000028>
@@ -23800,14 +21624,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI5NSBBQkMgTk5fMQAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTI5NSBBQkMgTk5fMQAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_33.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307115"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.74</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307115"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -23869,8 +21685,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5312"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007062"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007994"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022282"/>
@@ -23884,22 +21698,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIBMzM0IE1pY3JvZ2xpYSBOTgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAlFZNVM4S01PNUhMSlVGMFAwMEsAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIBMzM0IE1pY3JvZ2xpYSBOTgAAATE1Qks0N0RDSU9GMVNMTFVXOVAAAgAAAUNCR0MwVTMwVlY5SlBSNjBUSlUAAgAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAlFZNVM4S01PNUhMSlVGMFAwMEsAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_34.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307132"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010002>0.29</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307132"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.17</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307132"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -23955,9 +21753,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5313"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_354"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007063"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022283"/>
         <obo:IAO_0000028>BAM NN_1 Mrc1 (Mmus)</obo:IAO_0000028>
@@ -23968,30 +21763,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTMxMyBCQU0gTk5fMQAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTMxMyBCQU0gTk5fMQAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_34.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307133"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_354"/>
-        <obo:CLM_0010002>0.1</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307133"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010002>0.13</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307133"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.34</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307133"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>
@@ -24047,9 +21818,6 @@
                 <owl:hasValue rdf:resource="https://purl.brain-bican.org/ontology/CCN20230722/CS20230722_CLUS_5314"/>
             </owl:Restriction>
         </rdfs:subClassOf>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010001 rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5007064"/>
         <obo:CLM_0010003 rdf:resource="http://purl.obolibrary.org/obo/CLM_5022284"/>
         <obo:IAO_0000028>BAM NN_1 Fos (Mmus)</obo:IAO_0000028>
@@ -24060,30 +21828,6 @@
         <rdfs:seeAlso>https://knowledge.brain-map.org/abcatlas#AQIBQVA4Sk5ONUxZQUJHVk1HS1kxQgACUTFOQ1dXUEc2RlowRE5JWEpCUQADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTMxNCBCQU0gTk5fMQAABAEBAoGsxo6BlhUgA4RqTf2EWBhNAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIRzRJNEdGSlhKQjlBVFozUFRYMQAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBbm9uZQACbm9uZQADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAABSzlKTjIzUDI0S1FDR0s5VTc1QQACSFNZWlBaVzE2NjlVODIxQldZUAADBAFGUzAwRFhWMFQ5UjFYOUZKNFFFAAIAAAFRWTVTOEtNTzVITEpVRjBQMDBLAAIAAAExNUJLNDdEQ0lPRjFTTExVVzlQAAIAAAFDQkdDMFUzMFZWOUpQUjYwVEpVAAIBNTMxNCBCQU0gTk5fMQAABAEAAoRQvx%2BDggl%2FA4SgGoeExD3ZBDJOUVRJRTdUQU1QOFBRQUhPNFAABYGvpkqB6awOgaCBR4CS1egGAAcAAAUABgEBAkNCR0MwVTMwVlY5SlBSNjBUSlUAA34AAAAEAAAIVkZPRllQRlFHUktVRFFVWjNGRgAJTFZEQkpBVzhCSTVZU1MxUVVCRwAKAAsBVExPS1dDTDk1UlUwM0Q5UEVURwACNzNHVlREWERFR0UyN00yWEpNVAADAQQBAAIjMDAwMDAwAAPIAQAFAQECIzAwMDAwMAADyAEAAAACAwA%3D</rdfs:seeAlso>
         <rdfs:seeAlso>https://purl.brain-bican.org/taxonomy/CCN20230722/CS20230722_CLAS_34.h5ad</rdfs:seeAlso>
     </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307134"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_315"/>
-        <obo:CLM_0010002>0.14</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307134"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_512"/>
-        <obo:CLM_0010002>0.16</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307134"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010001"/>
-        <owl:annotatedTarget rdf:resource="https://purl.brain-bican.org/ontology/mbao/MBA_997"/>
-        <obo:CLM_0010002>0.26</obo:CLM_0010002>
-        <obo:OBI_0000070 rdf:resource="http://www.ebi.ac.uk/efo/EFO_0008992"/>
-        <rdfs:comment>Location assignment based on CCF broad region.</rdfs:comment>
-    </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/CL_4307134"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/CLM_0010003"/>


### PR DESCRIPTION
Add Makefile targets to override downloaded component OWL files (wmbo-cl-comp.owl and bgo-cl-comp.owl) by removing the OBI:0000070 (assay) term. This is a temporary hotfix while obophenotype/cell-ontology[#3578](https://github.com/obophenotype/cell-ontology/issues/3578) is being resolved.