### PR TITLE
ci: add PR-triggered CLARA review workflow

### DIFF
--- a/.github/workflows/clara-review.yml
+++ b/.github/workflows/clara-review.yml
@@ -1,0 +1,158 @@
+name: CLARA Review
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number to review
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: clara-review-${{ github.event.issue.number || github.event.inputs.pr || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # issue_comment also fires for plain issues; only honor /clara on PRs.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.issue.pull_request != null &&
+       startsWith(github.event.comment.body, '/clara'))
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve PR number
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "num=${{ inputs.pr }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "num=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Acknowledge trigger comment
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api --method POST \
+            /repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            -f content=eyes
+
+      - name: Look up PR refs
+        id: refs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          data=$(gh pr view "${{ steps.pr.outputs.num }}" \
+            --repo "${{ github.repository }}" \
+            --json baseRefOid,headRefOid,headRefName,baseRefName)
+          echo "base=$(echo "$data" | jq -r .baseRefOid)" >> "$GITHUB_OUTPUT"
+          echo "base_name=$(echo "$data" | jq -r .baseRefName)" >> "$GITHUB_OUTPUT"
+          echo "head=$(echo "$data" | jq -r .headRefOid)" >> "$GITHUB_OUTPUT"
+          echo "head_name=$(echo "$data" | jq -r .headRefName)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout PR head with full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ steps.refs.outputs.head }}
+
+      - name: Install ROBOT
+        run: |
+          mkdir -p "$HOME/.robot"
+          curl -fsSL -o "$HOME/.robot/robot.jar" \
+            https://github.com/ontodev/robot/releases/latest/download/robot.jar
+          printf '#!/bin/bash\nexec java -jar "%s/.robot/robot.jar" "$@"\n' "$HOME" \
+            > "$HOME/.robot/robot"
+          chmod +x "$HOME/.robot/robot"
+          echo "$HOME/.robot" >> "$GITHUB_PATH"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install clara_workflow
+        # Pin this once the workflow contract stabilizes.
+        run: pip install "git+https://github.com/Cellular-Semantics/clara_workflow.git@main"
+
+      - name: Run CLARA stage 1 extractor
+        run: |
+          python -m clara_workflow.stage1.extract \
+            --repo . \
+            --left "${{ steps.refs.outputs.base }}" \
+            --right "${{ steps.refs.outputs.head }}" \
+            --edit-file src/ontology/cl-edit.owl \
+            --output changes.json
+
+      - name: Upload changes.json artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: clara-changes-pr-${{ steps.pr.outputs.num }}
+          path: changes.json
+
+      - name: Build stage 1 summary comment
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.num }}
+        run: |
+          python - <<'PY' > comment.md
+          import json
+          import os
+
+          with open("changes.json", encoding="utf-8") as handle:
+              data = json.load(handle)
+
+          reviewable = data["reviewable"]
+          by_term = data["by_term"]
+          lines = [
+              f"### CLARA review for PR #{os.environ['PR_NUMBER']}",
+              "",
+              "_Stage 1 only: change extraction and routing preview. Atomic assertion validation is not wired up yet._",
+              "",
+              f"- Base SHA: `{data['left']['ref']}`",
+              f"- Head SHA: `{data['right']['ref']}`",
+              f"- Terms touched: `{len(by_term)}`",
+              f"- Total extracted changes: `{len(data['changes'])}`",
+              f"- Reviewable changes: `{len(reviewable)}`",
+              f"- Decomposable changes: `{len(data['decomposable'])}`",
+              "",
+              "#### Terms flagged for downstream CLARA routing",
+          ]
+
+          if not by_term:
+              lines.append("")
+              lines.append("- No term-level changes were detected in `src/ontology/cl-edit.owl`.")
+          else:
+              lines.append("")
+              for term_id, entry in sorted(by_term.items()):
+                  tags = []
+                  if entry["is_new_term"]:
+                      tags.append("new term")
+                  if entry["is_reviewable"]:
+                      tags.append("reviewable")
+                  if entry["is_obsoleted"]:
+                      tags.append("obsoleted")
+                  tag_text = f" ({', '.join(tags)})" if tags else ""
+                  lines.append(
+                      f"- `{term_id}` — {entry['term_label']}{tag_text}: "
+                      f"{len(entry['changes'])} extracted change(s)"
+                  )
+
+          print("\n".join(lines))
+          PY
+
+      - name: Post stage 1 summary to PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment "${{ steps.pr.outputs.num }}" \
+            --repo "${{ github.repository }}" \
+            --body-file comment.md


### PR DESCRIPTION
  ## Summary

  This PR introduces Phase 1 of a PR-triggered CLARA review workflow for #3616 in `cell-ontology`.

  This is an incremental foundation for the CLARA workflow described in the ticket. At this stage, the workflow is limited to stage-1 change extraction and PR feedback; later phases will add ticket-specific
  routing and literature validation.

  ## What this PR adds

  Phase 1 wires up the initial workflow scaffold and stage-1 extraction flow:

  - adds a new `clara-review.yml` workflow
  - allows on-demand triggering from a PR comment starting with `/clara`
  - also supports manual triggering via `workflow_dispatch`
  - resolves the target PR number from either trigger path
  - acknowledges the trigger comment with an `eyes` reaction
  - looks up the PR base/head refs
  - checks out the PR head commit
  - installs ROBOT and Python
  - installs `clara_workflow`
  - runs the CLARA stage-1 extractor against `src/ontology/cl-edit.owl`
  - writes `changes.json`
  - uploads `changes.json` as a workflow artifact
  - posts a stage-1 summary comment back to the PR

  ## Current scope

  This PR implements only stage-1 change extraction and a routing preview.

  It does not yet implement the full CLARA review flow described in the ticket. In particular, this PR does not yet add:

  - decomposition of NTR definitions and relationships into atomic assertions
  - validation of atomic assertions against cited literature
  - ASTA-first checking with full-text fallback
  - ticket-specific routing for:
    - NTR review
    - changed relationships
    - synonyms that carry refs
  - final pass/fail reporting in the requested ticket format

  ## Why merge this now

  This phase provides a working GitHub Actions entry point that lets us validate:

  - workflow wiring
  - permissions
  - PR ref resolution
  - stage-1 extraction output
  - artifact generation
  - PR comment feedback loop

  That gives us a stable base for implementing the later CLARA phases incrementally instead of landing the entire pipeline at once.

  ## Testing

  - Workflow YAML validated locally.
  - GitHub-side execution testing will begin once this workflow exists on the default branch.
  - After merge to `master`, the intended Phase 1 checks are:
    - manual `workflow_dispatch`
    - `/clara` comment-triggered execution on a PR
  - Functional CLARA review beyond stage 1 is not yet implemented in this PR.