### PR TITLE
Replace use of obsoleted NCBITaxon:6657.

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -3389,7 +3389,6 @@ Declaration(Class(obo:NCBITaxon_10090))
 Declaration(Class(obo:NCBITaxon_4896))
 Declaration(Class(obo:NCBITaxon_6157))
 Declaration(Class(obo:NCBITaxon_6237))
-Declaration(Class(obo:NCBITaxon_6657))
 Declaration(Class(obo:NCBITaxon_9606))
 Declaration(Class(obo:NCBITaxon_9789))
 Declaration(Class(obo:NCBITaxon_9986))
@@ -35384,7 +35383,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4070010 "GM")
 AnnotationAssertion(rdfs:label obo:CL_4070010 "gastric mill neuron")
 SubClassOf(obo:CL_4070010 obo:CL_0000100)
 SubClassOf(obo:CL_4070010 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_8910001))
-SubClassOf(obo:CL_4070010 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_6657))
+SubClassOf(obo:CL_4070010 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_197562))
 
 # Class: obo:CL_4070011 (lateral gastric neuron)
 
@@ -35396,7 +35395,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4070011 "LG")
 AnnotationAssertion(rdfs:label obo:CL_4070011 "lateral gastric neuron")
 SubClassOf(obo:CL_4070011 obo:CL_0000100)
 SubClassOf(obo:CL_4070011 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_8910001))
-SubClassOf(obo:CL_4070011 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_6657))
+SubClassOf(obo:CL_4070011 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_197562))
 
 # Class: obo:CL_4070012 (inferior cardiac neuron)
 
@@ -35408,7 +35407,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4070012 "IC")
 AnnotationAssertion(rdfs:label obo:CL_4070012 "inferior cardiac neuron")
 SubClassOf(obo:CL_4070012 obo:CL_0000100)
 SubClassOf(obo:CL_4070012 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_8910001))
-SubClassOf(obo:CL_4070012 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_6657))
+SubClassOf(obo:CL_4070012 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_197562))
 
 # Class: obo:CL_4070013 (ventricular dilator motor neuron)
 
@@ -35420,7 +35419,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4070013 "VD")
 AnnotationAssertion(rdfs:label obo:CL_4070013 "ventricular dilator motor neuron")
 SubClassOf(obo:CL_4070013 obo:CL_0000100)
 SubClassOf(obo:CL_4070013 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_8910001))
-SubClassOf(obo:CL_4070013 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_6657))
+SubClassOf(obo:CL_4070013 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_197562))
 
 # Class: obo:CL_4070014 (pyloric motor neuron)
 
@@ -35432,7 +35431,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4070014 "PY")
 AnnotationAssertion(rdfs:label obo:CL_4070014 "pyloric motor neuron")
 SubClassOf(obo:CL_4070014 obo:CL_0000100)
 SubClassOf(obo:CL_4070014 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_8910001))
-SubClassOf(obo:CL_4070014 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_6657))
+SubClassOf(obo:CL_4070014 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_197562))
 
 # Class: obo:CL_4070015 (pyloric dilator neuron)
 
@@ -35444,7 +35443,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4070015 "PD")
 AnnotationAssertion(rdfs:label obo:CL_4070015 "pyloric dilator neuron")
 SubClassOf(obo:CL_4070015 obo:CL_0000100)
 SubClassOf(obo:CL_4070015 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_8910001))
-SubClassOf(obo:CL_4070015 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_6657))
+SubClassOf(obo:CL_4070015 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_197562))
 
 # Class: obo:CL_4070016 (anterior burster neuron)
 
@@ -35456,7 +35455,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4070016 "AB")
 AnnotationAssertion(rdfs:label obo:CL_4070016 "anterior burster neuron")
 SubClassOf(obo:CL_4070016 obo:CL_0000099)
 SubClassOf(obo:CL_4070016 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_8910001))
-SubClassOf(obo:CL_4070016 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_6657))
+SubClassOf(obo:CL_4070016 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_197562))
 
 # Class: obo:CL_4070017 (lateral pyloric motor neuron)
 
@@ -35468,7 +35467,7 @@ AnnotationAssertion(oboInOwl:hasExactSynonym obo:CL_4070017 "LP")
 AnnotationAssertion(rdfs:label obo:CL_4070017 "lateral pyloric motor neuron")
 SubClassOf(obo:CL_4070017 obo:CL_0000100)
 SubClassOf(obo:CL_4070017 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_8910001))
-SubClassOf(obo:CL_4070017 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_6657))
+SubClassOf(obo:CL_4070017 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_197562))
 
 # Class: obo:CL_4072001 (newly formed oligodendrocyte)
 


### PR DESCRIPTION
NCBITaxon has obsoleted NCBITaxon:6657 (crustacea) and merged it with NCBITaxon:197562 (pancrustacea), so this PR updates all CL references to NCBITaxon:6657 accordingly.