### PR TITLE
ci: wire routed CLARA review workflow

### DIFF
--- a/.github/workflows/clara-review.yml
+++ b/.github/workflows/clara-review.yml
@@ -1,7 +1,7 @@
 name: CLARA Review
 
 env:
-  CLARA_WORKFLOW_REPO: dosumis/clara_workflow
+  CLARA_WORKFLOW_REPO: ubyndr/clara_workflow
   CLARA_WORKFLOW_REF: main
 
 on:

--- a/.github/workflows/clara-review.yml
+++ b/.github/workflows/clara-review.yml
@@ -174,16 +174,8 @@ jobs:
             Write one `runs/<TERM_ID>/...` bundle per processed term.
 
             Requirements:
-            - Handle `ntr`, `relationship`, and `synonym` routed targets according to the issue routing rules.
-            - Use `textual_changes` as the canonical prose field for `ntr` targets; `definition_changes` may appear only as a compatibility alias.
-            - For new terms, decompose routed text and convert routed structural changes into atomic assertions.
-            - For routed `relationship` targets, check the atomic structural claim against refs with the core workflow.
-            - For routed `synonym` targets with refs, check the synonym claim against refs.
-            - Treat `candidate_refs` and `term_level_candidate_refs` as already filtered to searchable literature ids; do not broaden the ref set.
-            - Write `runs/<TERM_ID>/verdicts.json`, `runs/<TERM_ID>/tool_calls.jsonl`, and `runs/<TERM_ID>/report.md` for each processed term.
             - Follow repository guidance in `CLAUDE.md` when useful, but do not edit ontology source files.
             - Do not modify `changes.json` or `routing.json`.
-            - If a routed target has no searchable refs, still write the required outputs.
 
       - name: Upload CLARA runs artifact
         if: always()

--- a/.github/workflows/clara-review.yml
+++ b/.github/workflows/clara-review.yml
@@ -99,7 +99,19 @@ jobs:
           name: clara-changes-pr-${{ steps.pr.outputs.num }}
           path: changes.json
 
-      - name: Build stage 1 summary comment
+      - name: Select CLARA routing targets
+        run: |
+          python src/scripts/clara_select_targets.py \
+            --input changes.json \
+            --output routing.json
+
+      - name: Upload routing.json artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: clara-routing-pr-${{ steps.pr.outputs.num }}
+          path: routing.json
+
+      - name: Build stage 1 and routing summary comment
         env:
           PR_NUMBER: ${{ steps.pr.outputs.num }}
         run: |
@@ -109,13 +121,16 @@ jobs:
 
           with open("changes.json", encoding="utf-8") as handle:
               data = json.load(handle)
+          with open("routing.json", encoding="utf-8") as handle:
+              routing = json.load(handle)
 
           reviewable = data["reviewable"]
           by_term = data["by_term"]
+          route_counts = routing["summary"]["route_counts"]
           lines = [
               f"### CLARA review for PR #{os.environ['PR_NUMBER']}",
               "",
-              "_Stage 1 only: change extraction and routing preview. Atomic assertion validation is not wired up yet._",
+              "_Phase 1/2 preview only: stage-1 extraction and ticket-specific routing. Atomic assertion validation is not wired up yet._",
               "",
               f"- Base SHA: `{data['left']['ref']}`",
               f"- Head SHA: `{data['right']['ref']}`",
@@ -123,6 +138,10 @@ jobs:
               f"- Total extracted changes: `{len(data['changes'])}`",
               f"- Reviewable changes: `{len(reviewable)}`",
               f"- Decomposable changes: `{len(data['decomposable'])}`",
+              f"- Routed validation targets: `{routing['summary']['selected_targets']}`",
+              f"- Routed NTR bundles: `{route_counts['ntr']}`",
+              f"- Routed relationship targets: `{route_counts['relationship']}`",
+              f"- Routed synonym targets with refs: `{route_counts['synonym']}`",
               "",
               "#### Terms flagged for downstream CLARA routing",
           ]
@@ -145,6 +164,18 @@ jobs:
                       f"- `{term_id}` — {entry['term_label']}{tag_text}: "
                       f"{len(entry['changes'])} extracted change(s)"
                   )
+
+          if routing["summary"]["ignored_changes"]:
+              ignored_counts = routing["summary"]["ignored_reason_counts"]
+              lines.extend(
+                  [
+                      "",
+                      "#### Currently ignored by routing",
+                      "",
+                      f"- Existing-term text changes not yet routed: `{ignored_counts.get('existing_term_text_not_yet_routed', 0)}`",
+                      f"- Synonym changes without refs: `{ignored_counts.get('synonym_without_refs', 0)}`",
+                  ]
+              )
 
           print("\n".join(lines))
           PY

--- a/.github/workflows/clara-review.yml
+++ b/.github/workflows/clara-review.yml
@@ -1,5 +1,9 @@
 name: CLARA Review
 
+env:
+  CLARA_WORKFLOW_REPO: dosumis/clara_workflow
+  CLARA_WORKFLOW_REF: main
+
 on:
   issue_comment:
     types: [created]
@@ -13,6 +17,8 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
+  id-token: write
 
 concurrency:
   group: clara-review-${{ github.event.issue.number || github.event.inputs.pr || github.run_id }}
@@ -26,7 +32,6 @@ jobs:
       (github.event.issue.pull_request != null &&
        startsWith(github.event.comment.body, '/clara'))
     runs-on: ubuntu-latest
-
     steps:
       - name: Resolve PR number
         id: pr
@@ -80,9 +85,18 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Check out clara_workflow reference
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.CLARA_WORKFLOW_REPO }}
+          ref: ${{ env.CLARA_WORKFLOW_REF }}
+          path: clara_workflow_ref
+
       - name: Install clara_workflow
-        # Pin this once the workflow contract stabilizes.
-        run: pip install "git+https://github.com/Cellular-Semantics/clara_workflow.git@main"
+        run: pip install -e ./clara_workflow_ref
 
       - name: Run CLARA stage 1 extractor
         run: |
@@ -111,59 +125,165 @@ jobs:
           name: clara-routing-pr-${{ steps.pr.outputs.num }}
           path: routing.json
 
-      - name: Build stage 1 and routing summary comment
+      - name: Extract routed target summary
+        id: routing_meta
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          routing = json.loads(Path("routing.json").read_text(encoding="utf-8"))
+          term_ids = sorted({target["term_id"].replace(":", "_", 1) for target in routing["targets"]})
+
+          Path("/tmp/routing_outputs.txt").write_text(
+              f"target_count={len(routing['targets'])}\nterm_count={len(term_ids)}\nterms={' '.join(term_ids)}\n",
+              encoding="utf-8",
+          )
+          PY
+          cat /tmp/routing_outputs.txt >> "$GITHUB_OUTPUT"
+
+      - name: Write MCP config for CLARA verification
+        if: steps.routing_meta.outputs.target_count != '0'
+        run: |
+          cp clara_workflow_ref/.mcp.json .mcp.json
+
+      - name: Run CLARA stage 2/3 verification for routed targets
+        id: claude
+        if: steps.routing_meta.outputs.target_count != '0'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        env:
+          ASTA_API_KEY: ${{ secrets.ASTA_API_KEY }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ github.token }}
+          track_progress: ${{ github.event_name == 'issue_comment' }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ steps.pr.outputs.num }}
+            BASE SHA: ${{ steps.refs.outputs.base }}
+            HEAD SHA: ${{ steps.refs.outputs.head }}
+
+            Work in the checked out ontology repository root.
+
+            Read and follow `clara_workflow_ref/clara_workflow/agent_instructions.md`.
+
+            Use `routing.json` in the repository root as the verification input.
+            Process every routed target in that file according to its route.
+            Group outputs by term, writing one `runs/<TERM_ID>/...` bundle per term.
+
+            Requirements:
+            - Handle `ntr`, `relationship`, and `synonym` routed targets according to the issue routing rules.
+            - For new terms, decompose routed text and convert routed structural changes into atomic assertions.
+            - For routed `relationship` targets, check the atomic structural claim against refs with the core workflow.
+            - For routed `synonym` targets with refs, check the synonym claim against refs.
+            - Write `runs/<TERM_ID>/verdicts.json`, `runs/<TERM_ID>/tool_calls.jsonl`, and `runs/<TERM_ID>/report.md` for each processed term.
+            - Follow repository guidance in `CLAUDE.md` when useful, but do not edit ontology source files.
+            - Do not modify `changes.json` or `routing.json`.
+            - If a routed target has no searchable refs, still write the required outputs.
+
+      - name: Upload CLARA runs artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: clara-runs-pr-${{ steps.pr.outputs.num }}
+          path: runs
+          if-no-files-found: warn
+
+      - name: Build CLARA summary comment
         env:
           PR_NUMBER: ${{ steps.pr.outputs.num }}
+          CLAUDE_STEP_OUTCOME: ${{ steps.claude.outcome }}
+          TARGET_COUNT: ${{ steps.routing_meta.outputs.target_count }}
         run: |
           python - <<'PY' > comment.md
           import json
           import os
+          from pathlib import Path
 
-          with open("changes.json", encoding="utf-8") as handle:
-              data = json.load(handle)
-          with open("routing.json", encoding="utf-8") as handle:
-              routing = json.load(handle)
+          def load_json(path):
+              with open(path, encoding="utf-8") as handle:
+                  return json.load(handle)
 
-          reviewable = data["reviewable"]
-          by_term = data["by_term"]
+          def summarize_verdict(path):
+              data = load_json(path)
+              assertions = data.get("assertions", [])
+              core = [a for a in assertions if a.get("category") == "core"]
+              background = [a for a in assertions if a.get("category") == "background"]
+              core_fail = [a for a in core if a.get("final_verdict") == "fail"]
+              core_uncertain = [a for a in core if a.get("final_verdict") == "uncertain"]
+              if core_fail:
+                  status = "FAIL"
+              elif core_uncertain:
+                  status = "UNCERTAIN"
+              else:
+                  status = "PASS"
+              return {
+                  "cell_id": data["cell_id"],
+                  "name": data["name"],
+                  "status": status,
+                  "core_total": len(core),
+                  "core_fail": len(core_fail),
+                  "core_uncertain": len(core_uncertain),
+                  "background_warn": sum(1 for a in background if a.get("warn_background")),
+                  "failed_texts": [a["text"] for a in core_fail[:3]],
+              }
+
+          data = load_json("changes.json")
+          routing = load_json("routing.json")
+
           route_counts = routing["summary"]["route_counts"]
+          target_count = int(os.environ["TARGET_COUNT"])
+          claude_outcome = os.environ.get("CLAUDE_STEP_OUTCOME", "")
+          runs_dir = Path("runs")
+          verdict_files = sorted(runs_dir.glob("*/verdicts.json")) if runs_dir.exists() else []
+          verdict_summaries = [summarize_verdict(path) for path in verdict_files]
+
           lines = [
               f"### CLARA review for PR #{os.environ['PR_NUMBER']}",
               "",
-              "_Phase 1/2 preview only: stage-1 extraction and ticket-specific routing. Atomic assertion validation is not wired up yet._",
-              "",
               f"- Base SHA: `{data['left']['ref']}`",
               f"- Head SHA: `{data['right']['ref']}`",
-              f"- Terms touched: `{len(by_term)}`",
+              f"- Terms touched: `{len(data['by_term'])}`",
               f"- Total extracted changes: `{len(data['changes'])}`",
-              f"- Reviewable changes: `{len(reviewable)}`",
+              f"- Reviewable changes: `{len(data['reviewable'])}`",
               f"- Decomposable changes: `{len(data['decomposable'])}`",
               f"- Routed validation targets: `{routing['summary']['selected_targets']}`",
               f"- Routed NTR bundles: `{route_counts['ntr']}`",
               f"- Routed relationship targets: `{route_counts['relationship']}`",
               f"- Routed synonym targets with refs: `{route_counts['synonym']}`",
-              "",
-              "#### Terms flagged for downstream CLARA routing",
           ]
 
-          if not by_term:
-              lines.append("")
-              lines.append("- No term-level changes were detected in `src/ontology/cl-edit.owl`.")
+          if target_count == 0:
+              lines.extend([
+                  "",
+                  "_No routed CLARA targets were found, so stage 2/3 verification did not run._",
+              ])
+          elif claude_outcome == "failure":
+              lines.extend([
+                  "",
+                  "_Stage 2/3 verification was invoked for routed CLARA targets, but the Claude step did not complete successfully. Check the workflow logs and uploaded artifacts._",
+              ])
           else:
-              lines.append("")
-              for term_id, entry in sorted(by_term.items()):
-                  tags = []
-                  if entry["is_new_term"]:
-                      tags.append("new term")
-                  if entry["is_reviewable"]:
-                      tags.append("reviewable")
-                  if entry["is_obsoleted"]:
-                      tags.append("obsoleted")
-                  tag_text = f" ({', '.join(tags)})" if tags else ""
+              lines.extend([
+                  "",
+                  f"_Stage 2/3 verification ran for `{len(verdict_summaries)}` routed term(s)._",
+              ])
+
+          if verdict_summaries:
+              lines.extend([
+                  "",
+                  "#### Routed verification results",
+                  "",
+              ])
+              for item in verdict_summaries:
                   lines.append(
-                      f"- `{term_id}` — {entry['term_label']}{tag_text}: "
-                      f"{len(entry['changes'])} extracted change(s)"
+                      f"- `{item['cell_id']}` — {item['name']}: **{item['status']}** "
+                      f"(core: {item['core_total']}, fail: {item['core_fail']}, "
+                      f"uncertain: {item['core_uncertain']}, background warnings: {item['background_warn']})"
                   )
+                  for failed in item["failed_texts"]:
+                      lines.append(f"  - Failed core assertion: {failed}")
 
           if routing["summary"]["ignored_changes"]:
               ignored_counts = routing["summary"]["ignored_reason_counts"]
@@ -177,10 +297,20 @@ jobs:
                   ]
               )
 
+          lines.extend(
+              [
+                  "",
+                  "Artifacts uploaded:",
+                  "- `changes.json`",
+                  "- `routing.json`",
+                  "- `runs/`",
+              ]
+          )
+
           print("\n".join(lines))
           PY
 
-      - name: Post stage 1 summary to PR
+      - name: Post CLARA summary to PR
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/clara-review.yml
+++ b/.github/workflows/clara-review.yml
@@ -169,14 +169,17 @@ jobs:
             Read and follow `clara_workflow_ref/clara_workflow/agent_instructions.md`.
 
             Use `routing.json` in the repository root as the verification input.
-            Process every routed target in that file according to its route.
-            Group outputs by term, writing one `runs/<TERM_ID>/...` bundle per term.
+            Treat `routing.json` as the stable consumer contract for routed CLARA review.
+            Group targets by `term_id` and process one term-group at a time.
+            Write one `runs/<TERM_ID>/...` bundle per processed term.
 
             Requirements:
             - Handle `ntr`, `relationship`, and `synonym` routed targets according to the issue routing rules.
+            - Use `textual_changes` as the canonical prose field for `ntr` targets; `definition_changes` may appear only as a compatibility alias.
             - For new terms, decompose routed text and convert routed structural changes into atomic assertions.
             - For routed `relationship` targets, check the atomic structural claim against refs with the core workflow.
             - For routed `synonym` targets with refs, check the synonym claim against refs.
+            - Treat `candidate_refs` and `term_level_candidate_refs` as already filtered to searchable literature ids; do not broaden the ref set.
             - Write `runs/<TERM_ID>/verdicts.json`, `runs/<TERM_ID>/tool_calls.jsonl`, and `runs/<TERM_ID>/report.md` for each processed term.
             - Follow repository guidance in `CLAUDE.md` when useful, but do not edit ontology source files.
             - Do not modify `changes.json` or `routing.json`.

--- a/src/scripts/clara_select_targets.py
+++ b/src/scripts/clara_select_targets.py
@@ -46,10 +46,15 @@ def _stable_unique(values: list[str]) -> list[str]:
     return ordered
 
 
+def _is_searchable_ref(value: str) -> bool:
+    upper = value.upper()
+    return upper.startswith("PMID:") or upper.startswith("DOI:")
+
+
 def _refs_for_changes(changes: list[dict]) -> list[str]:
     refs: list[str] = []
     for change in changes:
-        refs.extend(change.get("refs", []))
+        refs.extend(ref for ref in change.get("refs", []) if _is_searchable_ref(ref))
     return _stable_unique(refs)
 
 
@@ -72,7 +77,7 @@ def _change_target(
         "term_label": term_label,
         "term_is_new": term_is_new,
         "change": change,
-        "candidate_refs": list(change.get("refs", [])),
+        "candidate_refs": _refs_for_changes([change]),
         "term_level_candidate_refs": term_level_candidate_refs,
     }
 
@@ -117,6 +122,7 @@ def select_targets(payload: dict) -> dict:
                         "term_id": term_id,
                         "term_label": term_label,
                         "term_is_new": True,
+                        "textual_changes": ntr_textual,
                         "definition_changes": ntr_textual,
                         "relationship_changes": ntr_structural,
                         "candidate_refs": _refs_for_changes(ntr_textual + ntr_structural),

--- a/src/scripts/clara_select_targets.py
+++ b/src/scripts/clara_select_targets.py
@@ -6,6 +6,21 @@ Phase 2 is still a routing preview. This script reads `changes.json` from
 `clara_workflow.stage1.extract` and emits a normalized `routing.json` payload
 that identifies which downstream CLARA checks should run for the current PR.
 
+This file is the producer-side contract for routed CLARA review. The consumer
+is `clara_workflow/clara_workflow/agent_instructions.md`, which expects:
+
+- processing grouped by `term_id`
+- `ntr` targets with canonical prose in `textual_changes`
+- `relationship` / `synonym` targets with a single `change`
+- `candidate_refs` and `term_level_candidate_refs` already filtered to
+  searchable literature ids (`PMID:...` / `DOI:...`)
+
+Notes on compatibility:
+
+- `textual_changes` is the canonical field for decomposable prose
+- `definition_changes` is still emitted as a temporary alias so the current
+  consumer can tolerate older payload samples during cleanup
+
 Current routing policy mirrors the ticket scope:
 
 - New terms (NTRs): route added definitions/comments plus added structural
@@ -47,11 +62,18 @@ def _stable_unique(values: list[str]) -> list[str]:
 
 
 def _is_searchable_ref(value: str) -> bool:
+    """Return whether a ref is usable by the downstream literature tools."""
     upper = value.upper()
     return upper.startswith("PMID:") or upper.startswith("DOI:")
 
 
 def _refs_for_changes(changes: list[dict]) -> list[str]:
+    """Collect unique searchable refs from staged ontology changes.
+
+    This is the upstream filtering point for the routed-target contract.
+    Downstream agentic stages should treat these lists as already curated and
+    should not broaden them beyond formatting normalization for tool calls.
+    """
     refs: list[str] = []
     for change in changes:
         refs.extend(ref for ref in change.get("refs", []) if _is_searchable_ref(ref))
@@ -83,6 +105,20 @@ def _change_target(
 
 
 def select_targets(payload: dict) -> dict:
+    """Transform stage-1 output into routed targets for CLARA verification.
+
+    Output contract:
+
+    - one `ntr` target per new term containing:
+      - `textual_changes` (canonical prose field)
+      - `definition_changes` (compatibility alias only)
+      - `relationship_changes`
+    - one `relationship` target per existing-term structural assertion
+    - one `synonym` target per synonym assertion that carries attached refs
+
+    The resulting `routing.json` is consumed term-grouped: every target with the
+    same `term_id` is expected to be processed together downstream.
+    """
     targets: list[dict] = []
     ignored: list[dict] = []
     route_counts = {"ntr": 0, "relationship": 0, "synonym": 0}
@@ -122,7 +158,9 @@ def select_targets(payload: dict) -> dict:
                         "term_id": term_id,
                         "term_label": term_label,
                         "term_is_new": True,
+                        # Canonical field consumed by clara_workflow.
                         "textual_changes": ntr_textual,
+                        # Temporary alias kept during producer/consumer cleanup.
                         "definition_changes": ntr_textual,
                         "relationship_changes": ntr_structural,
                         "candidate_refs": _refs_for_changes(ntr_textual + ntr_structural),

--- a/src/scripts/clara_select_targets.py
+++ b/src/scripts/clara_select_targets.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+
+"""Select ticket-relevant CLARA validation targets from stage-1 output.
+
+Phase 2 is still a routing preview. This script reads `changes.json` from
+`clara_workflow.stage1.extract` and emits a normalized `routing.json` payload
+that identifies which downstream CLARA checks should run for the current PR.
+
+Current routing policy mirrors the ticket scope:
+
+- New terms (NTRs): route added definitions/comments plus added structural
+  axioms as one NTR validation bundle.
+- Existing terms: route added structural axioms (`subclass`, `relationship`,
+  `equivalent_class`) as direct atomic checks.
+- Any term: route added synonym axioms only when the synonym axiom itself has
+  attached refs.
+
+Intentionally not routed yet:
+
+- Existing-term text definition revisions
+- Reviewable removals
+- Synonyms without refs
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+TEXTUAL_KINDS = frozenset({"text_def", "comment"})
+STRUCTURAL_KINDS = frozenset({"subclass", "relationship", "equivalent_class"})
+SYNONYM_KINDS = frozenset(
+    {"synonym_exact", "synonym_broad", "synonym_narrow", "synonym_related"}
+)
+
+
+def _stable_unique(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            ordered.append(value)
+    return ordered
+
+
+def _refs_for_changes(changes: list[dict]) -> list[str]:
+    refs: list[str] = []
+    for change in changes:
+        refs.extend(change.get("refs", []))
+    return _stable_unique(refs)
+
+
+def _change_target(
+    *,
+    route: str,
+    validation_mode: str,
+    ordinal: int,
+    change: dict,
+    term_id: str,
+    term_label: str,
+    term_is_new: bool,
+    term_level_candidate_refs: list[str],
+) -> dict:
+    return {
+        "target_id": f"{route}:{term_id}:{ordinal}",
+        "route": route,
+        "validation_mode": validation_mode,
+        "term_id": term_id,
+        "term_label": term_label,
+        "term_is_new": term_is_new,
+        "change": change,
+        "candidate_refs": list(change.get("refs", [])),
+        "term_level_candidate_refs": term_level_candidate_refs,
+    }
+
+
+def select_targets(payload: dict) -> dict:
+    targets: list[dict] = []
+    ignored: list[dict] = []
+    route_counts = {"ntr": 0, "relationship": 0, "synonym": 0}
+    ignored_reason_counts: dict[str, int] = {}
+    reviewable_terms = 0
+    obsoleted_terms_skipped = 0
+
+    for term_id, entry in sorted(payload["by_term"].items()):
+        term_label = entry["term_label"]
+        term_is_new = bool(entry["is_new_term"])
+        term_is_obsoleted = bool(entry["is_obsoleted"])
+        term_is_reviewable = bool(entry["is_reviewable"])
+        if term_is_reviewable:
+            reviewable_terms += 1
+        if term_is_obsoleted:
+            obsoleted_terms_skipped += 1
+            continue
+
+        added_reviewable = [
+            change
+            for change in entry["changes"]
+            if change["side"] == "added" and change["kind"] in (TEXTUAL_KINDS | STRUCTURAL_KINDS | SYNONYM_KINDS)
+        ]
+        term_level_candidate_refs = _refs_for_changes(
+            [change for change in added_reviewable if change["kind"] in TEXTUAL_KINDS]
+        )
+
+        if term_is_new:
+            ntr_textual = [change for change in added_reviewable if change["kind"] in TEXTUAL_KINDS]
+            ntr_structural = [change for change in added_reviewable if change["kind"] in STRUCTURAL_KINDS]
+            if ntr_textual or ntr_structural:
+                targets.append(
+                    {
+                        "target_id": f"ntr:{term_id}",
+                        "route": "ntr",
+                        "validation_mode": "decompose_definition_and_relationships",
+                        "term_id": term_id,
+                        "term_label": term_label,
+                        "term_is_new": True,
+                        "definition_changes": ntr_textual,
+                        "relationship_changes": ntr_structural,
+                        "candidate_refs": _refs_for_changes(ntr_textual + ntr_structural),
+                        "term_level_candidate_refs": term_level_candidate_refs,
+                    }
+                )
+                route_counts["ntr"] += 1
+
+        structural_ordinal = 0
+        synonym_ordinal = 0
+        for change in added_reviewable:
+            kind = change["kind"]
+            if kind in STRUCTURAL_KINDS:
+                if term_is_new:
+                    continue
+                structural_ordinal += 1
+                targets.append(
+                    _change_target(
+                        route="relationship",
+                        validation_mode="validate_atomic_relationship",
+                        ordinal=structural_ordinal,
+                        change=change,
+                        term_id=term_id,
+                        term_label=term_label,
+                        term_is_new=term_is_new,
+                        term_level_candidate_refs=term_level_candidate_refs,
+                    )
+                )
+                route_counts["relationship"] += 1
+                continue
+
+            if kind in SYNONYM_KINDS:
+                if change.get("refs"):
+                    synonym_ordinal += 1
+                    targets.append(
+                        _change_target(
+                            route="synonym",
+                            validation_mode="validate_synonym_against_attached_refs",
+                            ordinal=synonym_ordinal,
+                            change=change,
+                            term_id=term_id,
+                            term_label=term_label,
+                            term_is_new=term_is_new,
+                            term_level_candidate_refs=term_level_candidate_refs,
+                        )
+                    )
+                    route_counts["synonym"] += 1
+                else:
+                    ignored.append(
+                        {
+                            "term_id": term_id,
+                            "term_label": term_label,
+                            "reason": "synonym_without_refs",
+                            "change": change,
+                        }
+                    )
+                continue
+
+            if kind in TEXTUAL_KINDS and not term_is_new:
+                ignored.append(
+                    {
+                        "term_id": term_id,
+                        "term_label": term_label,
+                        "reason": "existing_term_text_not_yet_routed",
+                        "change": change,
+                    }
+                )
+
+    for item in ignored:
+        reason = item["reason"]
+        ignored_reason_counts[reason] = ignored_reason_counts.get(reason, 0) + 1
+
+    return {
+        "source": {
+            "left": payload["left"],
+            "right": payload["right"],
+        },
+        "summary": {
+            "terms_touched": len(payload["by_term"]),
+            "reviewable_terms": reviewable_terms,
+            "obsoleted_terms_skipped": obsoleted_terms_skipped,
+            "reviewable_changes": len(payload["reviewable"]),
+            "decomposable_changes": len(payload["decomposable"]),
+            "selected_targets": len(targets),
+            "route_counts": route_counts,
+            "ignored_changes": len(ignored),
+            "ignored_reason_counts": ignored_reason_counts,
+        },
+        "targets": targets,
+        "ignored": ignored,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, required=True, help="Path to stage-1 changes.json")
+    parser.add_argument("--output", type=Path, required=True, help="Path to write routing.json")
+    args = parser.parse_args(argv)
+
+    payload = json.loads(args.input.read_text(encoding="utf-8"))
+    selected = select_targets(payload)
+    args.output.write_text(json.dumps(selected, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR wires `cell-ontology` into the routed CLARA review workflow for PR-triggered validation.

It extends the earlier CLARA workflow scaffold so the workflow now goes beyond stage-1 extraction and routing preview. The workflow still begins from PR-triggered ROBOT diff output, but it now also invokes the agentic Stage 2/3 review flow from `clara_workflow` and summarizes the routed verification results back on the PR.

## What changed

- updates `.github/workflows/clara-review.yml`
- keeps and aligns `src/scripts/clara_select_targets.py` as the producer-side routed-target contract

## Workflow behavior in this PR

The `CLARA Review` workflow now:

- triggers from:
  - `/clara` comments on PRs
  - `workflow_dispatch`
- resolves PR base/head refs
- checks out the PR head
- installs ROBOT, Python, and `uv`
- checks out the configured `clara_workflow` reference
- runs CLARA Stage 1 via `clara_workflow.stage1.extract`
- writes and uploads `changes.json`
- routes reviewable targets via `src/scripts/clara_select_targets.py`
- writes and uploads `routing.json`
- invokes `anthropics/claude-code-action@v1` for routed Stage 2/3 verification
- uploads `runs/` artifacts
- posts a PR summary comment with:
  - stage-1/routing counts
  - routed verification status per processed term
  - ignored-routing counts

## Routed-target contract alignment

This PR also tightens the producer-side contract in `src/scripts/clara_select_targets.py` so it matches the consumer contract now documented in `clara_workflow`.

In particular, it makes explicit that:

- routed verification is consumed term-grouped by `term_id`
- `textual_changes` is the canonical prose field for `ntr` targets
- `definition_changes` is kept only as a temporary compatibility alias
- `candidate_refs` and `term_level_candidate_refs` are filtered upstream to searchable literature ids

## Current routed review scope

The routing behavior remains:

- `ntr`
  - bundle new-term textual changes plus structural changes
- `relationship`
  - route added structural assertions on existing terms
- `synonym`
  - route synonym assertions only when the synonym axiom has attached refs

Still intentionally not routed:

- existing-term text definition revisions
- removals
- synonyms without refs