### PR TITLE
clara-mcp-runtime-fix

### DIFF
--- a/.github/workflows/clara-review.yml
+++ b/.github/workflows/clara-review.yml
@@ -147,6 +147,14 @@ jobs:
         run: |
           cp clara_workflow_ref/.mcp.json .mcp.json
 
+      - name: Install local MCP server dependencies
+        if: steps.routing_meta.outputs.target_count != '0'
+        # The Asta MCP server is remote HTTP, but artl-mcp is configured as a
+        # local stdio server in clara_workflow's .mcp.json and must be runnable
+        # on the GitHub runner.
+        run: |
+          uv tool install artl-mcp
+
       - name: Run CLARA stage 2/3 verification for routed targets
         id: claude
         if: steps.routing_meta.outputs.target_count != '0'
@@ -158,6 +166,10 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ github.token }}
           track_progress: ${{ github.event_name == 'issue_comment' }}
+          claude_args: >-
+            --mcp-config .mcp.json
+            --disallowedTools
+            "Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(gh pr create:*),Bash(gh pr comment:*),Bash(gh issue comment:*)"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ steps.pr.outputs.num }}
@@ -174,7 +186,10 @@ jobs:
             Write one `runs/<TERM_ID>/...` bundle per processed term.
 
             Requirements:
-            - Follow repository guidance in `CLAUDE.md` when useful, but do not edit ontology source files.
+            - Only produce the required `runs/<TERM_ID>/verdicts.json`, `runs/<TERM_ID>/tool_calls.jsonl`, and `runs/<TERM_ID>/report.md` outputs.
+            - Do not create commits, push branches, open PRs, or post GitHub comments. The workflow itself will publish the final PR comment from the generated files.
+            - Ignore any `CLAUDE.md` guidance about committing, pushing, or opening PRs for this run.
+            - Follow other repository guidance in `CLAUDE.md` when useful, but do not edit ontology source files.
             - Do not modify `changes.json` or `routing.json`.
 
       - name: Upload CLARA runs artifact


### PR DESCRIPTION
This PR fixes the CLARA GitHub Actions runtime so the routed verification step can actually use its configured MCP tools.

### Changes

- explicitly loads `.mcp.json` via `claude_args`
- installs the local `artl-mcp` stdio MCP dependency on the runner
- restricts Claude to artifact-only behavior for this workflow
- prevents commit/push/PR/comment actions from the Claude step

### Why

The previous workflow could run the agent step, but MCP tools were not available in practice, causing assertions to fall back to `uncertain`. This PR focuses on making the MCP/runtime path usable while keeping the final PR comment owned by the workflow itself.