### PR TITLE
Classify basal cell (CL:0000646) as an epithelial cell

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -9458,6 +9458,7 @@ AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000646 "BTO:0000939")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000646 "FMA:62516")
 AnnotationAssertion(rdfs:label obo:CL_0000646 "basal cell")
 SubClassOf(obo:CL_0000646 obo:CL_0000036)
+SubClassOf(obo:CL_0000646 obo:CL_0000066)
 
 # Class: obo:CL_0000647 (multinucleated giant cell)
 


### PR DESCRIPTION
Closes #3694.

One line:

```diff
 SubClassOf(obo:CL_0000646 obo:CL_0000036)
+SubClassOf(obo:CL_0000646 obo:CL_0000066)
```

## Why

Basal cells were classified only under `CL:0000036 epithelial fate stem cell` ≡ `somatic stem cell and capable_of some 'epithelial cell differentiation'` — a "not yet epithelial" reading, arrived at by treating the definition's *"mitotic stem cell for other epithelial cell types"* as *"precursor to epithelium, therefore not epithelium."*

That inference is right for a genuinely pre-epithelial progenitor (a nephron progenitor becoming epithelial via MET). It is wrong for basal cells, which are already inside the epithelium — anchored to the basal lamina by hemidesmosomes, junctionally coupled to their neighbours, and containing cytokeratin intermediate filaments, which the current definition already states.

Two pieces of evidence from inside CL:

**The layer directly above is already epithelial.** `CL:7770004 suprabasal cell` — *"An epithelial cell that resides in the layer(s) immediately above the basal layer in stratified or pseudostratified epithelia"* — is asserted `SubClassOf epithelial cell`. And `CL:4033048 respiratory tract suprabasal cell` `develops_from` `CL:0002633 respiratory basal cell`, so CL currently has an epithelial cell developing from a non-epithelial cell within the same epithelium.

**The classification is already half-done.** Four descendants are both, via hand-asserted lineage parents:

```
cl info [ .sub CL:0000036 .and .sub "epithelial cell" ]
CL:1000486 ! basal cell of urothelium        (via urothelial cell)
CL:2000033 ! limb basal cell of epidermis    (via CL:0002187)
CL:1000349 ! basal cell of epithelium of bronchus (via basal epithelial cell of tracheobronchial tree)
CL:0002187 ! basal cell of epidermis         (via keratinocyte)
```

Four of eight. `CL:0002633 respiratory basal cell` is absent while its own child `CL:1000349` is present; `CL:1000447` is absent despite being labelled *"epithelial cell of stratum germinativum of esophagus"*. Nothing decided that split — it is whichever subtypes happened to get a second lineage parent typed in.

## Expected effect

`CL:0000646` and the four descendants that do not already have it acquire `epithelial cell` as an ancestor: `CL:0002633`, `CL:1000447`, `CL:0020060`, `CL:4033024`.

Since `CL:0000066` is `SubClassOf part_of some UBERON:0000483 'epithelium'`, all basal cells inherit that. Six of eight already assert a `part_of` into an epithelium directly. The two that do not — `CL:0020060 basal duct cell of salivary gland` and `CL:4033024 airway submucosal gland duct basal cell` — are duct cells, and those ducts are epithelium-lined, so the entailment holds; flagging them as the only places it is not already locally witnessed.

I could not run `robot reason` locally (`robot` is not available in this environment), so the above is derived from the asserted axioms rather than from a reasoner run. Relying on CI to confirm, and calling that out rather than implying I verified it.

## Scope

Deliberately just the `SubClassOf` edit, so this can merge on its own:

- The definition still leads with stemness and needs rewriting position-first — #3697 / PR #3706, stacked on this branch.
- Whether `CL:0000036` should be renamed to `epithelial stem cell` and its `capable_of` differentia replaced — #3698, blocked on this.
- QC invariant for the completeness of this classification — #3701, blocked on this.

Index: #3703.

---
@cmungall drove the agent, checked its reasoning, and is accountable for its output.

_Generated by [Claude Code](https://claude.ai/code)_