### PR TITLE
Rewrite basal cell (CL:0000646) definition position-first

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -9453,7 +9453,7 @@ SubClassOf(obo:CL_0000645 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_000219
 
 # Class: obo:CL_0000646 (basal cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "ISBN:0517223651") obo:IAO_0000115 obo:CL_0000646 "Undifferentiated; mitotic stem cell for other epithelial cell types; rounded or elliptical with little cytoplasm and few organelles; contain cytokeratin intermediate filament.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "ISBN:0517223651") obo:IAO_0000115 obo:CL_0000646 "An epithelial cell of the basal layer of a stratified or pseudostratified epithelium, resting on the basal lamina and containing cytokeratin intermediate filaments. Basal cells include the stem and transit-amplifying populations that give rise to the overlying layers.")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000646 "BTO:0000939")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000646 "FMA:62516")
 AnnotationAssertion(rdfs:label obo:CL_0000646 "basal cell")


### PR DESCRIPTION
Closes #3697. **Stacked on #3705** — base is `issue-3694`, not `master`, because both edit the same stanza. Review/merge #3705 first; this will retarget to `master` automatically.

## Before

> "Undifferentiated; mitotic stem cell for other epithelial cell types; rounded or elliptical with little cytoplasm and few organelles; contain cytokeratin intermediate filament."

## After

> "An epithelial cell of the basal layer of a stratified or pseudostratified epithelium, resting on the basal lamina and containing cytokeratin intermediate filaments. Basal cells include the stem and transit-amplifying populations that give rise to the overlying layers."

## Why

**The old text is inaccurate on its own terms.** The basal layer of a stratified epithelium contains both stem cells and transit-amplifying cells — not every basal cell is a stem cell. `CL:4033048 respiratory tract suprabasal cell` already acknowledges this landscape ("intermediate progenitor cell has limited proliferative capacity").

**Leading with stemness is what caused the misplacement.** Reading *"mitotic stem cell for other epithelial cell types"* as *"precursor to epithelium, therefore not epithelium"* is what put the term under `epithelial fate stem cell`. Fixing the classification (#3705) without fixing the text papers over the conflation and leaves the door open for a genuinely pre-epithelial progenitor to be filed here later.

**Position is what the class actually does.** All eight descendants are defined by location inside an epithelium — stratum basale of epidermis, respiratory tract epithelium, urothelium, epithelium of esophagus, bronchus, limb, and two duct cases.

## Editorial calls, flagged for pushback

- **Morphology clause dropped.** "Rounded or elliptical with little cytoplasm and few organelles" is not universally true — airway basal cells are pyramidal, epidermal basal cells cuboidal to columnar. Happy to restore it as a hedged clause if you would rather not lose sourced content.
- **Cytokeratin clause kept.** It is the one cytological feature that holds across the class, and it independently supports the epithelial classification.
- **Existing xrefs retained** (GOC:tfm, ISBN:0517223651).
- Wording is a first draft — the substance is "lead with position, demote stemness", not this exact sentence.

Part of #3703.

---
@cmungall drove the agent, checked its reasoning, and is accountable for its output.

_Generated by [Claude Code](https://claude.ai/code)_