### PR TITLE
Assert that no cell is part_of an acellular anatomical structure

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -3819,6 +3819,7 @@ AnnotationAssertion(rdfs:comment obo:CL_0000000 "The definition of cell is inten
 AnnotationAssertion(rdfs:label obo:CL_0000000 "cell")
 SubClassOf(obo:CL_0000000 obo:UBERON_0000061)
 SubClassOf(obo:CL_0000000 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_131567))
+DisjointClasses(obo:CL_0000000 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0000476))
 
 # Class: obo:CL_0000001 (primary cultured cell)
 


### PR DESCRIPTION
Addresses the logical half of #3701. **Draft — CI will fail, deliberately. See blockers.**

**Stacked on #3704** (base `issue-3699`), which fixes four of the seven violations.

## The axiom

```
DisjointClasses(obo:CL_0000000 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0000476))
```

`UBERON:0000476 acellular anatomical structure` is by definition made of cell parts and cell substances and does not constitute a cell or tissue. Nothing is both a cell and part of one.

CL already imports `DisjointClasses(CL:0000000, GO:0031012 'extracellular matrix')`, but plain class disjointness only stops a cell from *being* ECM, not from being *part of* it — the existential form is what's needed.

Written as `DisjointClasses` with an existential rather than the more natural

```
SubClassOf(UBERON:0000476, has_part only (not cell))
```

because CL reasons with **WHELK** (`Makefile:30`). `ObjectAllValuesFrom` and `ObjectComplementOf` are outside EL; disjointness reduces to ⊥ and is supported.

## Violation set

Transitive `part_of` closure, inherited over `is_a`, against the 29-member acellular branch — **7 classes**, not the 2 visible from asserted axioms alone:

| class | fixed by |
|---|---|
| `CL:0002169` basal cell of olfactory epithelium | #3704 (this branch's base) |
| `CL:0002171` globose cell of olfactory epithelium | #3704, inherits `CL:0002169` |
| `CL:0002184` basal proper cell of olfactory epithelium | #3704, inherits `CL:0002169` |
| `CL:4033093` limbal epithelial stem cell of cornea | #3704 |
| `CL:0008045` tanycyte of subcommissural organ | ⛔ upstream |
| `CL:4023181` hypendymal cell | ⛔ upstream |
| `CL:2000096` fibroblast of the reticular layer of dermis | ⛔ upstream |

## Blockers — two upstream UBERON axioms

The last three have **correct CL axioms** and inherit a bogus `part_of` from UBERON:

```
SubClassOf(UBERON:0002139 subcommissural organ,      part_of some UBERON:0011357 Reissner's fiber)
SubClassOf(UBERON:0001993 reticular layer of dermis, part_of some UBERON:0008877 epidermal-dermal junction)   [source: FMA]
```

`CL:0008045` and `CL:4023181` are `part_of some 'subcommissural organ'`; `CL:2000096` is `part_of some 'reticular layer of dermis'`. Those are right. The inherited edges are not:

- An organ is not part of the acellular strand it **secretes**. UBERON separately and correctly records `subcommissural organ produces SCO-spondin`; the `part_of Reissner's fiber` axiom looks like a direction error.
- The reticular dermis is not part of the basement membrane zone between dermis and epidermis. This one carries `source: FMA`, so it is likely inherited from FMA's modelling of the junction as including adjacent tissue.

Both also make a *multicellular* anatomical structure part of an *acellular* one, which sits badly against CARO's own `DisjointClasses(UBERON:0000476, UBERON:0010000)` at the sibling level — so these are defects on UBERON's own terms, not artefacts of CL's stricter constraint. There is no correct local fix: CL would have to delete accurate axioms to work around them.

## Sequencing

1. #3705 / #3706 — unrelated, parallel.
2. **#3704** — merge first; clears 4 of 7.
3. **Two UBERON tickets** — clears the remaining 3. Not yet filed; that repo is not in this session's scope.
4. This PR — undraft and merge once CI is green.

I could not run `robot reason` locally (`robot` is unavailable in this environment); the violation set above comes from computing the closure over `cl-edit.owl` + `imports/merged_import.owl` directly. CI on this draft should confirm it independently — three unsatisfiable classes is the expected result until the upstream fixes land.

Part of #3703.

---
@cmungall drove the agent, checked its reasoning, and is accountable for its output.

_Generated by [Claude Code](https://claude.ai/code)_