### PR TITLE
Buccal mucosa cell edits

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -17755,7 +17755,7 @@ SubClassOf(obo:CL_0002335 obo:CL_0002334)
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "MESH:D009061") obo:IAO_0000115 obo:CL_0002336 "An epithelial cell that lines the oral cavity including the mucosa of the gums, the palate, the lip, and the cheek.")
 AnnotationAssertion(terms:contributor obo:CL_0002336 <https://orcid.org/0000-0003-1980-3228>)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002336 "2010-09-20T02:52:54Z"^^xsd:dateTime)
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "https://www.scielo.org.mx/scielo.php?pid=S1870-199X2013000400001&script=sci_arttext&tlng=en") rdfs:comment obo:CL_0002336 "Buccal mucosa cell is sometimes only used to refer to as the lining of the cheeks, as part of the lining mucosa.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "merriamwebster:buccal") rdfs:comment obo:CL_0002336 "Buccal mucosa cell is sometimes only used to refer to as the lining of the cheeks, as part of the lining mucosa.")
 AnnotationAssertion(rdfs:label obo:CL_0002336 "buccal mucosa cell")
 EquivalentClasses(obo:CL_0002336 ObjectIntersectionOf(obo:CL_0000312 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0003729)))
 

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -6656,7 +6656,7 @@ SubClassOf(obo:CL_0000311 obo:CL_0000325)
 
 # Class: obo:CL_0000312 (keratinocyte)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:15749908") Annotation(oboInOwl:hasDbXref "PMID:19256306") Annotation(oboInOwl:hasDbXref "PMID:19727116") Annotation(oboInOwl:hasDbXref "PMID:29713660") Annotation(oboInOwl:hasDbXref "PMID:37873034") obo:IAO_0000115 obo:CL_0000312 "An epithelial cell of stratified squamous tissues, including skin, oral mucosa (Hiroshima et al., 2011), and esophagus (Whelan et al., 2018), that produces keratin proteins and secretes antimicrobial peptides to form a resilient barrier against environmental damage, dehydration, pathogens, and microbial invasion. It undergoes successive stages of differentiation marked by changes in keratin expression, supporting tissue integrity, wound repair, and contributing to immune defense.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:15749908") Annotation(oboInOwl:hasDbXref "PMID:19256306") Annotation(oboInOwl:hasDbXref "PMID:19727116") Annotation(oboInOwl:hasDbXref "PMID:29713660") Annotation(oboInOwl:hasDbXref "PMID:37873034") Annotation(oboInOwl:hasDbXref "PMID:21316034") obo:IAO_0000115 obo:CL_0000312 "An epithelial cell of stratified squamous tissues, including skin, oral mucosa (Hiroshima et al., 2011), and esophagus (Whelan et al., 2018), that produces keratin proteins and secretes antimicrobial peptides to form a resilient barrier against environmental damage, dehydration, pathogens, and microbial invasion. It undergoes successive stages of differentiation marked by changes in keratin expression, supporting tissue integrity, wound repair, and contributing to immune defense.")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000312 "BTO:0000667")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000312 "CALOHA:TS-0500")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_0000312 "FMA:62879")
@@ -15895,14 +15895,11 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_0002169 obo:CL_0002167
 
 # Class: obo:CL_0002170 (keratinized cell of the oral mucosa)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "PMID:12014572") obo:IAO_0000115 obo:CL_0002170 "A keratinized cell located in the hard palate or gingiva.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "PMID:12014572") obo:IAO_0000115 obo:CL_0002170 "A keratinized buccal mucosa cell. These are mostly located in the hard palate and gingiva.")
 AnnotationAssertion(terms:contributor obo:CL_0002170 <https://orcid.org/0000-0003-1980-3228>)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002170 "2010-08-26T02:51:30Z"^^xsd:dateTime)
 AnnotationAssertion(rdfs:label obo:CL_0002170 "keratinized cell of the oral mucosa")
-EquivalentClasses(obo:CL_0002170 ObjectIntersectionOf(obo:CL_0000237 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0003729)))
-SubClassOf(obo:CL_0002170 obo:CL_0000237)
 SubClassOf(obo:CL_0002170 obo:CL_0002336)
-SubClassOf(obo:CL_0002170 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0003729))
 
 # Class: obo:CL_0002171 (globose cell of olfactory epithelium)
 
@@ -17755,11 +17752,12 @@ SubClassOf(obo:CL_0002335 obo:CL_0002334)
 
 # Class: obo:CL_0002336 (buccal mucosa cell)
 
-AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "MESH:D009061") obo:IAO_0000115 obo:CL_0002336 "An endothelial cell that lines the oral cavity including the mucosa of the gums, the palate, the lip, and the cheek.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") Annotation(oboInOwl:hasDbXref "MESH:D009061") obo:IAO_0000115 obo:CL_0002336 "An epithelial cell that lines the oral cavity including the mucosa of the gums, the palate, the lip, and the cheek.")
 AnnotationAssertion(terms:contributor obo:CL_0002336 <https://orcid.org/0000-0003-1980-3228>)
 AnnotationAssertion(oboInOwl:creation_date obo:CL_0002336 "2010-09-20T02:52:54Z"^^xsd:dateTime)
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "https://www.scielo.org.mx/scielo.php?pid=S1870-199X2013000400001&script=sci_arttext&tlng=en") rdfs:comment obo:CL_0002336 "Buccal mucosa cell is sometimes only used to refer to as the lining of the cheeks, as part of the lining mucosa.")
 AnnotationAssertion(rdfs:label obo:CL_0002336 "buccal mucosa cell")
-SubClassOf(obo:CL_0002336 obo:CL_0002261)
+EquivalentClasses(obo:CL_0002336 ObjectIntersectionOf(obo:CL_0000312 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0003729)))
 
 # Class: obo:CL_0002337 (keratinocyte stem cell)
 


### PR DESCRIPTION
Corrected endothelial to epithelial for buccal mucosa cell definition. Accepted suggested parent class of keratinocyte for buccal mucosa cell, with supporting reference. Added additional comment for buccal mucosa cell. Added missing cross reference for keratinocyte definition.