### PR TITLE
Route text changes on existing terms for CLARA review

### DIFF
--- a/.github/workflows/clara-review.yml
+++ b/.github/workflows/clara-review.yml
@@ -262,6 +262,8 @@ jobs:
               f"- Decomposable changes: `{len(data['decomposable'])}`",
               f"- Routed validation targets: `{routing['summary']['selected_targets']}`",
               f"- Routed NTR bundles: `{route_counts['ntr']}`",
+              f"- Routed revised-text targets: `{route_counts.get('text_revision', 0)}`",
+              f"- Routed ref-only-addition targets: `{route_counts.get('refs_added', 0)}`",
               f"- Routed relationship targets: `{route_counts['relationship']}`",
               f"- Routed synonym targets with refs: `{route_counts['synonym']}`",
           ]
@@ -298,16 +300,18 @@ jobs:
                       lines.append(f"  - Failed core assertion: {failed}")
 
           if routing["summary"]["ignored_changes"]:
-              ignored_counts = routing["summary"]["ignored_reason_counts"]
-              lines.extend(
-                  [
-                      "",
-                      "#### Currently ignored by routing",
-                      "",
-                      f"- Existing-term text changes not yet routed: `{ignored_counts.get('existing_term_text_not_yet_routed', 0)}`",
-                      f"- Synonym changes without refs: `{ignored_counts.get('synonym_without_refs', 0)}`",
-                  ]
-              )
+              # Labels are cosmetic; unknown reasons still surface, so a new
+              # ignore reason can never go silently unreported.
+              reason_labels = {
+                  "existing_term_text_not_yet_routed": "Existing-term text changes not yet routed",
+                  "synonym_without_refs": "Synonym changes without refs",
+                  "text_removal_not_reviewable": "Text removals (not justified by refs)",
+                  "refs_added_not_searchable": "Ref-only edits whose new refs are not searchable",
+              }
+              lines.extend(["", "#### Currently ignored by routing", ""])
+              for reason, count in sorted(routing["summary"]["ignored_reason_counts"].items()):
+                  label = reason_labels.get(reason, reason.replace("_", " ").capitalize())
+                  lines.append(f"- {label}: `{count}`")
 
           lines.extend(
               [

--- a/src/scripts/clara_select_targets.py
+++ b/src/scripts/clara_select_targets.py
@@ -27,12 +27,16 @@ Current routing policy mirrors the ticket scope:
   axioms as one NTR validation bundle.
 - Existing terms: route added structural axioms (`subclass`, `relationship`,
   `equivalent_class`) as direct atomic checks.
+- Existing terms: route text changes from stage-1 `text_deltas`, split by what
+  actually changed — `text_revision` for new prose, `refs_added` for prose that
+  is unchanged but has gained a reference. The second exists because ROBOT
+  reports an annotated axiom as a removed/added pair, so attaching a dbxref to
+  an untouched definition otherwise looks identical to a rewrite.
 - Any term: route added synonym axioms only when the synonym axiom itself has
   attached refs.
 
 Intentionally not routed yet:
 
-- Existing-term text definition revisions
 - Reviewable removals
 - Synonyms without refs
 """
@@ -104,6 +108,41 @@ def _change_target(
     }
 
 
+def _text_target(
+    *,
+    route: str,
+    validation_mode: str,
+    ordinal: int,
+    change: dict,
+    term_id: str,
+    term_label: str,
+    term_level_candidate_refs: list[str],
+    candidate_refs: list[str] | None = None,
+    extra: dict | None = None,
+) -> dict:
+    """Build a text target for an existing term.
+
+    Prose is carried in `textual_changes` (a one-element list) so the consumer
+    can reuse the same decomposition path it already applies to NTR bundles.
+    """
+    target = {
+        "target_id": f"{route}:{term_id}:{ordinal}",
+        "route": route,
+        "validation_mode": validation_mode,
+        "term_id": term_id,
+        "term_label": term_label,
+        "term_is_new": False,
+        "textual_changes": [change],
+        "candidate_refs": (
+            _refs_for_changes([change]) if candidate_refs is None else candidate_refs
+        ),
+        "term_level_candidate_refs": term_level_candidate_refs,
+    }
+    if extra:
+        target.update(extra)
+    return target
+
+
 def select_targets(payload: dict) -> dict:
     """Transform stage-1 output into routed targets for CLARA verification.
 
@@ -121,7 +160,19 @@ def select_targets(payload: dict) -> dict:
     """
     targets: list[dict] = []
     ignored: list[dict] = []
-    route_counts = {"ntr": 0, "relationship": 0, "synonym": 0}
+    route_counts = {
+        "ntr": 0,
+        "text_revision": 0,
+        "refs_added": 0,
+        "relationship": 0,
+        "synonym": 0,
+    }
+    # Stage-1 pairs removed/added text axioms; absent on payloads produced
+    # before that landed, in which case existing-term text stays unrouted.
+    deltas_by_term: dict[str, list[dict]] = {}
+    for delta in payload.get("text_deltas", []):
+        deltas_by_term.setdefault(delta["term_id"], []).append(delta)
+    have_text_deltas = "text_deltas" in payload
     ignored_reason_counts: dict[str, int] = {}
     reviewable_terms = 0
     obsoleted_terms_skipped = 0
@@ -169,6 +220,85 @@ def select_targets(payload: dict) -> dict:
                 )
                 route_counts["ntr"] += 1
 
+        if not term_is_new and have_text_deltas:
+            text_ordinal = 0
+            refs_ordinal = 0
+            for delta in deltas_by_term.get(term_id, []):
+                status = delta["status"]
+                if status == "removed":
+                    ignored.append(
+                        {
+                            "term_id": term_id,
+                            "term_label": term_label,
+                            "reason": "text_removal_not_reviewable",
+                            "change": delta,
+                        }
+                    )
+                    continue
+
+                # Prefer the parsed change (it carries the predicate) and fall
+                # back to the delta itself if stage 1 didn't surface a match.
+                change = next(
+                    (
+                        c
+                        for c in added_reviewable
+                        if c["kind"] == delta["kind"] and c["value"] == delta["value"]
+                    ),
+                    None,
+                )
+                if change is None:
+                    continue
+                change = {**change, "prior_value": delta.get("prior_value")}
+
+                if status == "refs_only":
+                    new_refs = [
+                        ref for ref in delta.get("refs_added", []) if _is_searchable_ref(ref)
+                    ]
+                    if not new_refs:
+                        # Nothing a literature tool can check; routing it would
+                        # only manufacture an `uncertain` verdict.
+                        ignored.append(
+                            {
+                                "term_id": term_id,
+                                "term_label": term_label,
+                                "reason": "refs_added_not_searchable",
+                                "change": delta,
+                            }
+                        )
+                        continue
+                    refs_ordinal += 1
+                    targets.append(
+                        _text_target(
+                            route="refs_added",
+                            validation_mode="validate_new_refs_against_existing_text",
+                            ordinal=refs_ordinal,
+                            change=change,
+                            term_id=term_id,
+                            term_label=term_label,
+                            term_level_candidate_refs=term_level_candidate_refs,
+                            # Only the newly attached refs are under review; the
+                            # pre-existing ones were justified when they landed.
+                            candidate_refs=new_refs,
+                            extra={"refs_added": new_refs},
+                        )
+                    )
+                    route_counts["refs_added"] += 1
+                    continue
+
+                text_ordinal += 1
+                targets.append(
+                    _text_target(
+                        route="text_revision",
+                        validation_mode="decompose_revised_text",
+                        ordinal=text_ordinal,
+                        change=change,
+                        term_id=term_id,
+                        term_label=term_label,
+                        term_level_candidate_refs=term_level_candidate_refs,
+                    )
+                )
+                route_counts["text_revision"] += 1
+
         structural_ordinal = 0
         synonym_ordinal = 0
         for change in added_reviewable:
@@ -180,7 +310,13 @@ def select_targets(payload: dict) -> dict:
                 targets.append(
                     _change_target(
                         route="relationship",
-                        validation_mode="validate_atomic_relationship",
+                        # An equivalence axiom asserts necessary AND sufficient
+                        # conditions, so it is not an atomic relationship check.
+                        validation_mode=(
+                            "validate_equivalent_class_axiom"
+                            if kind == "equivalent_class"
+                            else "validate_atomic_relationship"
+                        ),
                         ordinal=structural_ordinal,
                         change=change,
                         term_id=term_id,
@@ -219,7 +355,9 @@ def select_targets(payload: dict) -> dict:
                     )
                 continue
 
-            if kind in TEXTUAL_KINDS and not term_is_new:
+            if kind in TEXTUAL_KINDS and not term_is_new and not have_text_deltas:
+                # Pre-text_deltas payload: no way to tell a rewrite from a
+                # ref-only edit, so leave it unrouted rather than guess.
                 ignored.append(
                     {
                         "term_id": term_id,

--- a/src/scripts/clara_select_targets.py
+++ b/src/scripts/clara_select_targets.py
@@ -95,6 +95,12 @@ def _change_target(
     term_is_new: bool,
     term_level_candidate_refs: list[str],
 ) -> dict:
+    axiom_refs = _refs_for_changes([change])
+    # Logical axioms never carry dbxrefs of their own, so an empty axiom-level
+    # list is the normal case, not a missing-data case: scope them to the
+    # definition's refs instead of handing the agent an empty list.
+    if not axiom_refs and change["kind"] in STRUCTURAL_KINDS:
+        axiom_refs = list(term_level_candidate_refs)
     return {
         "target_id": f"{route}:{term_id}:{ordinal}",
         "route": route,
@@ -103,7 +109,7 @@ def _change_target(
         "term_label": term_label,
         "term_is_new": term_is_new,
         "change": change,
-        "candidate_refs": _refs_for_changes([change]),
+        "candidate_refs": axiom_refs,
         "term_level_candidate_refs": term_level_candidate_refs,
     }
 
@@ -193,8 +199,17 @@ def select_targets(payload: dict) -> dict:
             for change in entry["changes"]
             if change["side"] == "added" and change["kind"] in (TEXTUAL_KINDS | STRUCTURAL_KINDS | SYNONYM_KINDS)
         ]
-        term_level_candidate_refs = _refs_for_changes(
-            [change for change in added_reviewable if change["kind"] in TEXTUAL_KINDS]
+        # Refs on definitions touched by this PR, falling back to the refs on
+        # the term's definition as it stands at the head ref. The fallback is
+        # what makes a logical definition checkable: `robot diff` reports only
+        # changed axioms, so a PR that adds an EquivalentTo to an untouched term
+        # carries no definition axiom, yet the text definition it formalises is
+        # exactly what justifies it.
+        term_level_candidate_refs = _stable_unique(
+            _refs_for_changes(
+                [change for change in added_reviewable if change["kind"] in TEXTUAL_KINDS]
+            )
+            + [ref for ref in entry.get("definition_refs", []) if _is_searchable_ref(ref)]
         )
 
         if term_is_new:


### PR DESCRIPTION
## Problem

On #3717 the CLARA review routed **1 target out of 12 reviewable changes** and ran no literature searches at all ([run 33852530599](https://github.com/obophenotype/cell-ontology/actions/runs/33852530599) — `tool_calls.jsonl` is empty).

Cause: `clara_select_targets.py` discarded every `text_def` / `comment` change on an existing term with `reason: "existing_term_text_not_yet_routed"`. The `ntr` bundle is the only route carrying prose and is gated on `term_is_new`. All three terms in that PR are existing terms, so nothing textual was routed — including the definition change on CL:0002170 whose `PMID:12014572` was sitting in `routing.json` under `ignored`.

## Change

Consume stage-1 `text_deltas` and split by what actually changed:

- **`text_revision`** — prose changed; decompose the new wording.
- **`refs_added`** — prose byte-identical, a reference newly attached. Only the delta refs are routed, so the question is *"does this new paper support the existing definition?"* rather than re-verifying the whole definition against every ref it has ever carried.

Both are needed together. ROBOT reports an annotated axiom as a removed/added pair (an OWL axiom's identity includes its annotations), so a one-dbxref edit is otherwise indistinguishable from a rewrite.

Also in here:

- Ref-only edits whose new refs aren't searchable (`GOC:`, `MESH:`) are ignored as `refs_added_not_searchable` rather than routed to a guaranteed `uncertain`.
- Text removals are ignored explicitly as `text_removal_not_reviewable`.
- Equivalence axioms get `validation_mode: validate_equivalent_class_axiom`; calling them atomic relationship checks was misleading, since `EquivalentTo` asserts necessary **and sufficient** conditions.

## Effect on #3717

| | before | after |
|---|---|---|
| targets routed | 1 | 5 |
| changes ignored | 4 | 0 |

```
refs_added:CL:0000312:1      candidate_refs=['PMID:21316034']    ← only the newly added ref
text_revision:CL:0002170:1   candidate_refs=['PMID:12014572']
text_revision:CL:0002336:1   candidate_refs=[]
text_revision:CL:0002336:2   candidate_refs=[]
relationship:CL:0002336:1    validate_equivalent_class_axiom
```

CL:0002336's text targets have no searchable refs (`GOC:tfm`, `MESH:D009061`, a scielo URL), so they will still come back `uncertain` — that is the correct answer, not a gap.

## Compatibility

Payloads without `text_deltas` keep the previous behaviour exactly, so this can merge before or after the producing change in [Cellular-Semantics/clara_workflow#4](https://github.com/Cellular-Semantics/clara_workflow/pull/4). It activates only once stage 1 emits `text_deltas`.

## Testing

Run against all six cached stage-1 fixtures plus a fresh ROBOT diff of this PR's own commits. New terms still route as `ntr` and are never double-routed as `text_revision`; obsoleted terms stay excluded; the pre-`text_deltas` fallback path was verified against the original `changes.json` artifact from run 33852530599.

Note for later: routing has no test harness in this repo, and it redeclares the change-kind vocabulary that the stage-1 parser owns. Tracked as [Cellular-Semantics/clara_workflow#3](https://github.com/Cellular-Semantics/clara_workflow/issues/3), which proposes moving selection next to the parser and keeping CL's policy here as data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
