### PR TITLE
Fixing logical definition #3723

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -26913,9 +26913,8 @@ SubClassOf(Annotation(oboInOwl:is_inferred "true") obo:CL_1000306 obo:CL_0000057
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "GOC:tfm") obo:IAO_0000115 obo:CL_1000307 "A fibroblast that is part of the dense regular elastic tissue.")
 AnnotationAssertion(oboInOwl:hasDbXref obo:CL_1000307 "FMA:261287")
 AnnotationAssertion(rdfs:label obo:CL_1000307 "fibroblast of dense regular elastic tissue")
-EquivalentClasses(obo:CL_1000307 ObjectIntersectionOf(obo:CL_0000057 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0007846)))
+EquivalentClasses(obo:CL_1000307 ObjectIntersectionOf(obo:CL_0000057 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0002521)))
 SubClassOf(obo:CL_1000307 obo:CL_0000057)
-SubClassOf(obo:CL_1000307 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0002521))
 
 # Class: obo:CL_1000308 (fibrocyte of adventitia of ureter)
 


### PR DESCRIPTION
Removed "SubClass Of elastic tissue" for 'fibroblast of dense regular elastic tissue' to prevent tendon cell from inheriting 'part of elastic tissue'. #3723