### PR TITLE
Demilune cell subclass of acinar cell #3724

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -26239,8 +26239,7 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:23209333") oboInOwl:hasR
 AnnotationAssertion(oboInOwl:hasRelatedSynonym obo:CL_0020059 "serous crescent cell")
 AnnotationAssertion(rdfs:comment obo:CL_0020059 "The classic crescent-shaped morphology that gives demilune cells their name is a well-established histological feature, but must be caveated with the fixation artifact issue. Amano et al. (2012) describe how rapid-freeze fixation reveals a more tubular arrangement, suggesting the demilune shape is at least partly artifactual.")
 AnnotationAssertion(rdfs:label obo:CL_0020059 "serous demilune cell of salivary gland")
-EquivalentClasses(obo:CL_0020059 ObjectIntersectionOf(obo:CL_0000313 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0001044)))
-SubClassOf(obo:CL_0020059 obo:CL_0000313)
+SubClassOf(obo:CL_0020059 obo:CL_4052065)
 SubClassOf(obo:CL_0020059 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0046541))
 
 # Class: obo:CL_0020060 (basal duct cell of salivary gland)


### PR DESCRIPTION
Fixing the inference that acinar cell are part of demilune cell. Demilune cell should be part of acinar cell of salivary gland. #3724 #3728