### PR TITLE
Fixing neuroendocrine cell SC #3724

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -26595,7 +26595,6 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:15153415") oboInOwl:hasB
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:15153415") oboInOwl:hasBroadSynonym obo:CL_1000222 "diffuse endocrine system cell")
 AnnotationAssertion(rdfs:label obo:CL_1000222 "stomach neuroendocrine cell")
 EquivalentClasses(obo:CL_1000222 ObjectIntersectionOf(obo:CL_0000165 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0001276)))
-SubClassOf(obo:CL_1000222 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0046717))
 
 # Class: obo:CL_1000223 (pulmonary neuroendocrine cell)
 


### PR DESCRIPTION
Removing capable_of some 'gastric acid secretion' from neuroendocrine cell to ensure type D and type G cell of the stomach did not inherit 'capable of acid secretion'. #3724 #3730 