### PR TITLE
Fix interplexiform cell hidden GCI

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -10245,6 +10245,7 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1038/s41598-020-66092-
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1038/s41598-020-66092-9") Annotation(oboInOwl:hasSynonymType obo:OMO_0003000) Annotation(oboInOwl:hasSynonymType obo:OMO_0003004) oboInOwl:hasRelatedSynonym obo:CL_0000740 "RGCs")
 AnnotationAssertion(rdfs:label obo:CL_0000740 "retinal ganglion cell")
 SubClassOf(obo:CL_0000740 obo:CL_0000540)
+SubClassOf(obo:CL_0000740 obo:CL_0000748)
 SubClassOf(obo:CL_0000740 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000966))
 
 # Class: obo:CL_0000741 (spinal accessory motor neuron)
@@ -10320,8 +10321,10 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1038/s41598-020-66092-
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "geo:GSE137537") Annotation(oboInOwl:hasSynonymType obo:OMO_0003000) Annotation(oboInOwl:hasSynonymType obo:OMO_0003004) oboInOwl:hasRelatedSynonym obo:CL_0000748 "BPs")
 AnnotationAssertion(rdfs:label obo:CL_0000748 "retinal bipolar neuron")
 AnnotationAssertion(Annotation(rdfs:label "reference transcriptomic data on Cell Annotation Platform") rdfs:seeAlso obo:CL_0000748 <https://celltype.info/project/544/dataset/1157>)
+EquivalentClasses(obo:CL_0000748 ObjectIntersectionOf(obo:CL_0000540 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001791)))
 SubClassOf(obo:CL_0000748 obo:CL_0009004)
-SubClassOf(obo:CL_0000748 ObjectSomeValuesFrom(obo:RO_0002215 ObjectIntersectionOf(obo:GO_0061535 ObjectSomeValuesFrom(obo:BFO_0000050 obo:GO_0098976))))
+SubClassOf(obo:CL_0000748 ObjectSomeValuesFrom(obo:BFO_0000050 obo:GO_0098976))
+SubClassOf(obo:CL_0000748 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061535))
 SubClassOf(obo:CL_0000748 ObjectSomeValuesFrom(obo:RO_0002216 obo:GO_0007601))
 
 # Class: obo:CL_0000749 (ON-bipolar cell)
@@ -15870,6 +15873,7 @@ AnnotationAssertion(rdfs:label obo:CL_0002167 "olfactory epithelial cell")
 EquivalentClasses(obo:CL_0002167 ObjectIntersectionOf(obo:CL_0000066 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0001997)))
 SubClassOf(obo:CL_0002167 obo:CL_0000098)
 SubClassOf(obo:CL_0002167 obo:CL_0000710)
+SubClassOf(obo:CL_0002167 ObjectSomeValuesFrom(obo:BFO_0000050 obo:GO_0098976))
 SubClassOf(obo:CL_0002167 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0050911))
 
 # Class: obo:CL_0002168 (border cell of cochlea)

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -10320,7 +10320,6 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1038/s41598-020-66092-
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "geo:GSE137537") Annotation(oboInOwl:hasSynonymType obo:OMO_0003000) Annotation(oboInOwl:hasSynonymType obo:OMO_0003004) oboInOwl:hasRelatedSynonym obo:CL_0000748 "BPs")
 AnnotationAssertion(rdfs:label obo:CL_0000748 "retinal bipolar neuron")
 AnnotationAssertion(Annotation(rdfs:label "reference transcriptomic data on Cell Annotation Platform") rdfs:seeAlso obo:CL_0000748 <https://celltype.info/project/544/dataset/1157>)
-EquivalentClasses(obo:CL_0000748 ObjectIntersectionOf(obo:CL_0000540 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001791)))
 SubClassOf(obo:CL_0000748 obo:CL_0009004)
 SubClassOf(obo:CL_0000748 ObjectSomeValuesFrom(obo:RO_0002215 ObjectIntersectionOf(obo:GO_0061535 ObjectSomeValuesFrom(obo:BFO_0000050 obo:GO_0098976))))
 SubClassOf(obo:CL_0000748 ObjectSomeValuesFrom(obo:RO_0002216 obo:GO_0007601))

--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -10246,7 +10246,6 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1038/s41598-020-66092-
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1038/s41598-020-66092-9") Annotation(oboInOwl:hasSynonymType obo:OMO_0003000) Annotation(oboInOwl:hasSynonymType obo:OMO_0003004) oboInOwl:hasRelatedSynonym obo:CL_0000740 "RGCs")
 AnnotationAssertion(rdfs:label obo:CL_0000740 "retinal ganglion cell")
 SubClassOf(obo:CL_0000740 obo:CL_0000540)
-SubClassOf(obo:CL_0000740 obo:CL_0000748)
 SubClassOf(obo:CL_0000740 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0000966))
 
 # Class: obo:CL_0000741 (spinal accessory motor neuron)
@@ -10322,10 +10321,10 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "doi:10.1038/s41598-020-66092-
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "geo:GSE137537") Annotation(oboInOwl:hasSynonymType obo:OMO_0003000) Annotation(oboInOwl:hasSynonymType obo:OMO_0003004) oboInOwl:hasRelatedSynonym obo:CL_0000748 "BPs")
 AnnotationAssertion(rdfs:label obo:CL_0000748 "retinal bipolar neuron")
 AnnotationAssertion(Annotation(rdfs:label "reference transcriptomic data on Cell Annotation Platform") rdfs:seeAlso obo:CL_0000748 <https://celltype.info/project/544/dataset/1157>)
-EquivalentClasses(obo:CL_0000748 ObjectIntersectionOf(obo:CL_0000540 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001791)))
+SubClassOf(obo:CL_0000748 obo:CL_0000540)
 SubClassOf(obo:CL_0000748 obo:CL_0009004)
-SubClassOf(obo:CL_0000748 ObjectSomeValuesFrom(obo:BFO_0000050 obo:GO_0098976))
-SubClassOf(obo:CL_0000748 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0061535))
+SubClassOf(obo:CL_0000748 ObjectSomeValuesFrom(obo:RO_0002100 obo:UBERON_0001791))
+SubClassOf(obo:CL_0000748 ObjectSomeValuesFrom(obo:RO_0002215 ObjectIntersectionOf(obo:GO_0061535 ObjectSomeValuesFrom(obo:BFO_0000050 obo:GO_0098976))))
 SubClassOf(obo:CL_0000748 ObjectSomeValuesFrom(obo:RO_0002216 obo:GO_0007601))
 
 # Class: obo:CL_0000749 (ON-bipolar cell)


### PR DESCRIPTION
Removal of the equivalent to definition for retinal bipolar neuron to fix GCI of interplexiform cell. #3724 #3732