### PR TITLE
Fixing olfactory epithelial cell hidden GCI #3724

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -15872,7 +15872,6 @@ AnnotationAssertion(rdfs:label obo:CL_0002167 "olfactory epithelial cell")
 EquivalentClasses(obo:CL_0002167 ObjectIntersectionOf(obo:CL_0000066 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0001997)))
 SubClassOf(obo:CL_0002167 obo:CL_0000098)
 SubClassOf(obo:CL_0002167 obo:CL_0000710)
-SubClassOf(obo:CL_0002167 ObjectSomeValuesFrom(obo:RO_0002215 obo:GO_0050911))
 
 # Class: obo:CL_0002168 (border cell of cochlea)
 


### PR DESCRIPTION
Removed the axiom subclass of 'capable_of detection of chemical stimulus involved in sensory perception of smell' to prevent this being inherited by tuft cell of olfactory epithelium. #3724