### PR TITLE
Taxon constraint update: added SubClass of Ecdysozoa and annotations #3666

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -24886,9 +24886,13 @@ SubClassOf(obo:CL_0011014 obo:CL_0000019)
 # Class: obo:CL_0011015 (amoeboid sperm cell)
 
 AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:17708982") obo:IAO_0000115 obo:CL_0011015 "A motile sperm cell that contain no F-actin, and their motility is powered by a dynamic filament system.")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:20803732") obo:RO_0002161 obo:CL_0011015 "'Hexapoda'")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:20803732") obo:RO_0002161 obo:CL_0011015 "'Vertebrata'")
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:20803732") obo:RO_0002175 obo:CL_0011015 "'Nematoda'")
 AnnotationAssertion(terms:contributor obo:CL_0011015 <https://orcid.org/0000-0001-5208-3432>)
 AnnotationAssertion(rdfs:label obo:CL_0011015 "amoeboid sperm cell")
 SubClassOf(obo:CL_0011015 obo:CL_0011013)
+SubClassOf(obo:CL_0011015 ObjectSomeValuesFrom(obo:RO_0002162 obo:NCBITaxon_1206794))
 
 # Class: obo:CL_0011016 (flagellated sperm cell)
 


### PR DESCRIPTION
Updated taxon constraints for amoeboid sperm cell, including SubClass of 'in taxon' some Ecdysozoa. Added annotations: never in taxon Vertebrata or Hexapoda, present in taxon Nematoda with reference. #3666