### PR TITLE
NTR perivascular renal mesenchymal progenitor cell

### DIFF
--- a/src/ontology/cl-edit.owl
+++ b/src/ontology/cl-edit.owl
@@ -3357,6 +3357,7 @@ Declaration(Class(obo:CL_4072102))
 Declaration(Class(obo:CL_4072103))
 Declaration(Class(obo:CL_4072104))
 Declaration(Class(obo:CL_4082001))
+Declaration(Class(obo:CL_4082002))
 Declaration(Class(obo:CL_7770002))
 Declaration(Class(obo:CL_7770003))
 Declaration(Class(obo:CL_7770004))
@@ -36399,6 +36400,15 @@ AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:31836875") Annotation(ob
 AnnotationAssertion(terms:contributor obo:CL_4082001 "https://orcid.org/0000-0003-2473-2313")
 AnnotationAssertion(rdfs:label obo:CL_4082001 "pancreatic islet macrophage")
 EquivalentClasses(obo:CL_4082001 ObjectIntersectionOf(obo:CL_0000864 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0000006)))
+
+# Class: obo:CL_4082002 (perivascular renal mesenchymal progenitor cell)
+
+AnnotationAssertion(Annotation(oboInOwl:hasDbXref "PMID:25465115") Annotation(oboInOwl:hasDbXref "PMID:38060571") obo:IAO_0000115 obo:CL_4082002 "A mesenchymal progenitor cell found adjacent to kidney blood vessels, which arises in response to tissue injury. These cells express CD44, CD73, CD105, Sca-1, and GLI1.")
+AnnotationAssertion(terms:contributor obo:CL_4082002 <https://orcid.org/0009-0003-5092-2089>)
+AnnotationAssertion(rdfs:label obo:CL_4082002 "perivascular renal mesenchymal progenitor cell"@en)
+SubClassOf(obo:CL_4082002 obo:CL_0000134)
+SubClassOf(obo:CL_4082002 ObjectSomeValuesFrom(obo:BFO_0000050 obo:UBERON_0002113))
+SubClassOf(obo:CL_4082002 ObjectSomeValuesFrom(obo:RO_0002220 obo:UBERON_0002049))
 
 # Class: obo:CL_7770002 (juxtacanalicular tissue cell)
 


### PR DESCRIPTION
NTR perivascular renal mesenchymal progenitor cell. Parent cell type mesenchymal stem cell . 'Part of some kidney' selected instead of 'kidney blood vessel' because inferred to be the same as a kidney blood vessel cell which is not accurate. #3131